### PR TITLE
Combine properties from all YAML and Properties files

### DIFF
--- a/core/src/main/java/io/dekorate/processor/AbstractAnnotationProcessor.java
+++ b/core/src/main/java/io/dekorate/processor/AbstractAnnotationProcessor.java
@@ -115,7 +115,7 @@ public abstract class AbstractAnnotationProcessor extends AbstractProcessor impl
 
   private void mergeProperties(Map<String, Object> result, Map<String, Object> newProps) {
     for(String newKey : newProps.keySet()) {
-      if(result.containsKey(newKey)) {
+      if(result.containsKey(newKey) && Map.class.isInstance(result.get(newKey)) && Map.class.isInstance(newProps.get(newKey))) {
         mergeProperties((Map)result.get(newKey), (Map)newProps.get(newKey));
       } else {
         result.putAll(newProps);

--- a/frameworks/spring-boot/src/it/annotationless-yml/src/main/resources/application-kubernetes.yml
+++ b/frameworks/spring-boot/src/it/annotationless-yml/src/main/resources/application-kubernetes.yml
@@ -1,0 +1,3 @@
+dekorate:
+  kubernetes:
+    replicas: 2

--- a/frameworks/spring-boot/src/it/annotationless-yml/src/test/java/io/dekorate/annotationless/AnnotationLessTest.java
+++ b/frameworks/spring-boot/src/it/annotationless-yml/src/test/java/io/dekorate/annotationless/AnnotationLessTest.java
@@ -36,6 +36,7 @@ public class AnnotationLessTest {
     Deployment d = findFirst(list, Deployment.class).orElseThrow(() -> new IllegalStateException());
     assertNotNull(d);
     final Map<String, String> labels = d.getMetadata().getLabels();
+    assertEquals(2, d.getSpec().getReplicas().intValue());
     assertEquals("bar", labels.get("foo"));
     assertEquals("baz", labels.get("zoo"));
     assertEquals("annotationless", labels.get("group"));


### PR DESCRIPTION
It would be very common to have both an `application` properties file and an `application-kubernetes` properties.  Right now only one can be used.  This would allow us to combine the properties in more than one file.