### PR TITLE
fix (#309): readSettingsGradle() now ignores lines that don't contain

### DIFF
--- a/core/src/main/java/io/dekorate/project/GradleInfoReader.java
+++ b/core/src/main/java/io/dekorate/project/GradleInfoReader.java
@@ -119,6 +119,7 @@ public class GradleInfoReader implements BuildInfoReader {
       try {
         Files.lines(path)
           .map(l -> l.replaceAll("[ ]*", ""))
+          .filter(l -> l.contains(EQUALS))
           .forEach(l -> {
             String key = l.substring(0, l.lastIndexOf(EQUALS));
             if (key.startsWith(ROOT_PROJECT_PREFIX)) {

--- a/core/src/test/java/io/dekorate/project/GradleInfoReaderTest.java
+++ b/core/src/test/java/io/dekorate/project/GradleInfoReaderTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class GradleInfoReaderTest {
   String GRADLE_INITIAL = "gradle/gradle-initial/build.gradle";
   String GRADLE_VERSIONED = "gradle/gradle-versioned/build.gradle";
+  String GRADLE_WITH_SETTINGS = "gradle/gradle-with-settings/build.gradle";
 
   @Test
   void shouldParsePlainBuildGradle() {
@@ -51,4 +52,13 @@ class GradleInfoReaderTest {
     assertEquals("jar", info.getPackaging());
   }
 
+  @Test
+  void shouldParseBuildGradleWithSettings() {
+    URL gradleInitial = GradleInfoReaderTest.class.getClassLoader().getResource(GRADLE_WITH_SETTINGS);
+    File file = Urls.toFile(gradleInitial);
+    Path root = file.toPath().getParent();
+    BuildInfo info = new GradleInfoReader().getInfo(root);
+    assertNotNull(info);
+    assertEquals("with-settings", info.getName());
+  }
 }

--- a/core/src/test/resources/gradle/gradle-with-settings/build.gradle
+++ b/core/src/test/resources/gradle/gradle-with-settings/build.gradle
@@ -1,0 +1,1 @@
+apply plugin: 'java'

--- a/core/src/test/resources/gradle/gradle-with-settings/settings.gradle
+++ b/core/src/test/resources/gradle/gradle-with-settings/settings.gradle
@@ -1,0 +1,4 @@
+// comment
+
+rootProject.name = with-settings
+rootProject.version = 0.2.0.Final


### PR DESCRIPTION
the equals sign.