### PR TITLE
fix (#352): Builds are now triggered both build service and

### DIFF
--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/generator/KnativeApplicationGenerator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/generator/KnativeApplicationGenerator.java
@@ -77,7 +77,7 @@ public interface KnativeApplicationGenerator extends Generator, WithSession, Wit
     default void on(ConfigurationSupplier<KnativeConfig> config) {
       Session session = getSession();
       session.configurators().add(config);
-      session.handlers().add(new KnativeHandler(session.resources()));
+      session.handlers().add(new KnativeHandler(session.resources(), session.configurators()));
       session.addListener(this);
   }
 

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/annotation/KubernetesApplication.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/annotation/KubernetesApplication.java
@@ -16,7 +16,6 @@
 package io.dekorate.kubernetes.annotation;
 
 
-import io.dekorate.kubernetes.config.ApplicationConfiguration;
 import io.dekorate.kubernetes.config.BaseConfig;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/generator/KubernetesApplicationGenerator.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/generator/KubernetesApplicationGenerator.java
@@ -77,7 +77,7 @@ public interface KubernetesApplicationGenerator extends Generator, WithProject {
   default void add(ConfigurationSupplier<KubernetesConfig> config)  {
     Session session = getSession();
     session.configurators().add(config);
-    session.handlers().add(new KubernetesHandler(session.resources()));
+    session.handlers().add(new KubernetesHandler(session.resources(), session.configurators()));
     session.addListener(LISTENER);
   }
 }

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/handler/KubernetesHandler.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/handler/KubernetesHandler.java
@@ -16,6 +16,7 @@
 package io.dekorate.kubernetes.handler;
 
 import io.dekorate.AbstractKubernetesHandler;
+import io.dekorate.BuildServiceFactories;
 import io.dekorate.Configurators;
 import io.dekorate.Handler;
 import io.dekorate.HandlerFactory;
@@ -25,6 +26,7 @@ import io.dekorate.Resources;
 import io.dekorate.WithProject;
 import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.project.Project;
+import io.dekorate.utils.Images;
 import io.dekorate.utils.Strings;
 import io.dekorate.deps.kubernetes.api.model.KubernetesListBuilder;
 import io.dekorate.deps.kubernetes.api.model.LabelSelector;
@@ -40,6 +42,8 @@ import io.dekorate.kubernetes.config.KubernetesConfig;
 import io.dekorate.kubernetes.config.KubernetesConfigBuilder;
 import io.dekorate.kubernetes.configurator.ApplyDeployToImageConfiguration;
 import io.dekorate.kubernetes.config.EditableKubernetesConfig;
+import io.dekorate.kubernetes.config.ImageConfiguration;
+import io.dekorate.kubernetes.config.ImageConfigurationBuilder;
 import io.dekorate.kubernetes.config.Configuration;
 import io.dekorate.kubernetes.decorator.AddIngressDecorator;
 import io.dekorate.kubernetes.decorator.AddInitContainerDecorator;
@@ -61,19 +65,22 @@ public class KubernetesHandler extends AbstractKubernetesHandler<KubernetesConfi
   private static final String IF_NOT_PRESENT = "IfNotPresent";
   private static final String KUBERNETES_NAMESPACE = "KUBERNETES_NAMESPACE";
   private static final String METADATA_NAMESPACE = "metadata.namespace";
-  private final Logger LOGGER = LoggerFactory.getLogger();
 
+  private final Logger LOGGER = LoggerFactory.getLogger();
+  private final Configurators configurators;
+  
   public KubernetesHandler() {
-    this(new Resources());
+    this(new Resources(), new Configurators());
   }
 
-  public KubernetesHandler(Resources resources) {
+  public KubernetesHandler(Resources resources, Configurators configurators) {
     super(resources);
+    this.configurators = configurators;
   }
 
   @Override
   public Handler create(Resources resources, Configurators configurators) {
-    return new KubernetesHandler(resources);
+    return new KubernetesHandler(resources, configurators);
   }
 
   @Override
@@ -84,6 +91,8 @@ public class KubernetesHandler extends AbstractKubernetesHandler<KubernetesConfi
   public void handle(KubernetesConfig config) {
     LOGGER.info("Processing kubernetes configuration.");
     setApplicationInfo(config);
+    ImageConfiguration imageConfig = getImageConfiguration(getProject(), config, configurators);
+
     Optional<Deployment> existingDeployment = resources.groups().getOrDefault(KUBERNETES, new KubernetesListBuilder()).buildItems().stream()
       .filter(i -> i instanceof Deployment)
       .map(i -> (Deployment)i)
@@ -91,10 +100,16 @@ public class KubernetesHandler extends AbstractKubernetesHandler<KubernetesConfi
       .findAny();
 
     if (!existingDeployment.isPresent()) {
-      resources.add(KUBERNETES, createDeployment(config));
+      resources.add(KUBERNETES, createDeployment(config, imageConfig));
     }
     resources.decorate(KUBERNETES, new ApplyReplicasDecorator(config.getName(), config.getReplicas()));
     addDecorators(KUBERNETES, config);
+
+    String image = Images.getImage(imageConfig.isAutoPushEnabled() ?
+                                   (Strings.isNullOrEmpty(imageConfig.getRegistry()) ? DEFAULT_REGISTRY : imageConfig.getRegistry())
+                                   : imageConfig.getRegistry(), imageConfig.getGroup(), imageConfig.getName(), imageConfig.getVersion()); 
+
+    resources.decorate(KUBERNETES, new ApplyImageDecorator(resources.getName(), image));
   }
 
   public boolean canHandle(Class<? extends Configuration> type) {
@@ -112,13 +127,6 @@ public class KubernetesHandler extends AbstractKubernetesHandler<KubernetesConfi
 
     resources.decorate(group, new AddIngressDecorator(config, resources.getLabels()));
     resources.decorate(group, new ApplyLabelSelectorDecorator(createSelector()));
-    if  (Strings.isNotNullOrEmpty(config.getRegistry()))  {
-      resources.decorate(group, new ApplyImageDecorator(config.getName(), config.getRegistry() + "/" + config.getGroup() + "/" + config.getName() + ":" + config.getVersion()));
-    } else if (config.isAutoPushEnabled()) {
-      resources.decorate(group, new ApplyImageDecorator(config.getName(), DEFAULT_REGISTRY + "/" + config.getGroup() + "/" + config.getName() + ":" + config.getVersion()));
-    } else {
-      resources.decorate(group, new ApplyImageDecorator(config.getName(), config.getGroup() + "/" + config.getName() + ":" + config.getVersion()));
-    }
   }
 
   /**
@@ -126,7 +134,7 @@ public class KubernetesHandler extends AbstractKubernetesHandler<KubernetesConfi
    * @param config   The session.
    * @return          The deployment.
    */
-  public Deployment createDeployment(KubernetesConfig config)  {
+  public Deployment createDeployment(KubernetesConfig config, ImageConfiguration imageConfig)  {
     return new DeploymentBuilder()
       .withNewMetadata()
       .withName(config.getName())
@@ -134,7 +142,7 @@ public class KubernetesHandler extends AbstractKubernetesHandler<KubernetesConfi
       .endMetadata()
       .withNewSpec()
       .withReplicas(1)
-      .withTemplate(createPodTemplateSpec(config))
+      .withTemplate(createPodTemplateSpec(config, imageConfig))
       .withSelector(createSelector())
       .endSpec()
       .build();
@@ -157,9 +165,9 @@ public class KubernetesHandler extends AbstractKubernetesHandler<KubernetesConfi
    * @param config   The sesssion.
    * @return          The pod template specification.
    */
-  public static PodTemplateSpec createPodTemplateSpec(KubernetesConfig config) {
+  public static PodTemplateSpec createPodTemplateSpec(KubernetesConfig config, ImageConfiguration imageConfig) {
     return new PodTemplateSpecBuilder()
-      .withSpec(createPodSpec(config))
+      .withSpec(createPodSpec(imageConfig))
       .withNewMetadata()
       .withLabels(createLabels(config))
       .endMetadata()
@@ -168,14 +176,18 @@ public class KubernetesHandler extends AbstractKubernetesHandler<KubernetesConfi
 
   /**
    * Creates a {@link PodSpec} for the {@link KubernetesConfig}.
-   * @param config   The sesssion.
-   * @return          The pod specification.
+   * @param imageConfig   The sesssion.
+   * @return The pod specification.
    */
-  public static PodSpec createPodSpec(KubernetesConfig config) {
+  public static PodSpec createPodSpec(ImageConfiguration imageConfig) {
+   String image = Images.getImage(imageConfig.isAutoPushEnabled() ?
+                                  (Strings.isNullOrEmpty(imageConfig.getRegistry()) ? DEFAULT_REGISTRY : imageConfig.getRegistry())
+                                  : imageConfig.getRegistry(), imageConfig.getGroup(), imageConfig.getName(), imageConfig.getVersion()); 
+
     return new PodSpecBuilder()
       .addNewContainer()
-      .withName(config.getName())
-      .withImage(config.getGroup() + "/" + config.getName() + ":" + config.getVersion())
+      .withName(imageConfig.getName())
+      .withImage(image)
       .withImagePullPolicy(IF_NOT_PRESENT)
       .addNewEnv()
       .withName(KUBERNETES_NAMESPACE)
@@ -192,7 +204,32 @@ public class KubernetesHandler extends AbstractKubernetesHandler<KubernetesConfi
     Project p = getProject();
     return new ConfigurationSupplier<KubernetesConfig>(new KubernetesConfigBuilder().accept(new ApplyDeployToImageConfiguration()).accept(new ApplyProjectInfo(p)));
   }
-
   
+  private static ImageConfiguration getImageConfiguration(Project project, KubernetesConfig config, Configurators configurators) {
+    Optional<ImageConfiguration> origin = configurators.get(ImageConfiguration.class,
+        BuildServiceFactories.matches(project));
+    //    .get();
 
+    return configurators.get(ImageConfiguration.class, BuildServiceFactories.matches(project)).map(i -> merge(config, i)).orElse(ImageConfiguration.from(config));
+  }
+
+  private static ImageConfiguration merge(KubernetesConfig config, ImageConfiguration imageConfig) {
+    if (config == null) {
+      throw new NullPointerException("KubernetesConfig is null.");
+    }
+    if (imageConfig == null) {
+      return ImageConfiguration.from(config);
+    }
+    return new ImageConfigurationBuilder()
+      .withProject(imageConfig.getProject() != null ? imageConfig.getProject() : config.getProject())
+      .withGroup(imageConfig.getGroup() != null ? imageConfig.getGroup() : config.getGroup())
+      .withName(imageConfig.getName() != null ? imageConfig.getName() : config.getName())
+      .withVersion(imageConfig.getVersion() != null ? imageConfig.getVersion() : config.getVersion())
+      .withRegistry(imageConfig.getRegistry() != null ? imageConfig.getRegistry() : config.getRegistry())
+      .withDockerFile(imageConfig.getDockerFile() != null ? imageConfig.getDockerFile() : config.getDockerFile())
+      .withAutoBuildEnabled(imageConfig.isAutoBuildEnabled() ? imageConfig.isAutoBuildEnabled() : config.isAutoBuildEnabled())
+      .withAutoPushEnabled(imageConfig.isAutoPushEnabled() ? imageConfig.isAutoPushEnabled() : config.isAutoPushEnabled())
+      .withAutoDeployEnabled(imageConfig.isAutoDeployEnabled() ? imageConfig.isAutoDeployEnabled() : config.isAutoDeployEnabled())
+      .build();
+  }
 }

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/hook/ScaleDeploymentHook.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/hook/ScaleDeploymentHook.java
@@ -44,7 +44,7 @@ public class ScaleDeploymentHook extends ProjectHook {
 
     @Override
     public void run() {
-      LOGGER.info("Performing docker build.");
+      LOGGER.info("Scaling deployment: "+name +" to: "+replicas+".");
       exec("kubectl", "scale", "deployment/" + name, "--replicas="+replicas);
     }
 }

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/generator/OpenshiftApplicationGenerator.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/generator/OpenshiftApplicationGenerator.java
@@ -70,7 +70,7 @@ public interface OpenshiftApplicationGenerator extends Generator, WithSession, W
       Session session = getSession();
       session.configurators().add(config);
       session.addListener(LISTENER);
-      session.handlers().add(new OpenshiftHandler(session.resources()));
+      session.handlers().add(new OpenshiftHandler(session.resources(), session.configurators()));
   }
 
 }

--- a/core/src/main/java/io/dekorate/hook/ResourceDeleteHook.java
+++ b/core/src/main/java/io/dekorate/hook/ResourceDeleteHook.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate.hook;
+
+import io.dekorate.project.Project;
+import io.dekorate.utils.Exec;
+
+public class ResourceDeleteHook extends ProjectHook {
+
+  private final Exec.ProjectExec exec;
+  private final String group;
+  private final String command;
+  private final String path;
+
+	public ResourceDeleteHook(Project project, String group, String command) {
+		super(project);
+    this.exec = Exec.inProject(project);
+    this.group = group;
+    this.command = command;
+    this.path = project.getBuildInfo().getClassOutputDir().resolve(project.getDekorateOutputDir()).resolve(group + ".yml").toAbsolutePath().toString();
+	}
+
+	@Override
+	public void run() {
+    exec.commands(command, "delete", "-f", path);
+	}
+
+	@Override
+	public void init() {
+		
+	}
+
+	@Override
+	public void warmup() {
+		
+	}
+}

--- a/core/src/main/java/io/dekorate/hook/ResourcesApplyHook.java
+++ b/core/src/main/java/io/dekorate/hook/ResourcesApplyHook.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate.hook;
+
+import io.dekorate.project.Project;
+import io.dekorate.utils.Exec;
+
+public class ResourcesApplyHook extends ProjectHook {
+
+  private final Exec.ProjectExec exec;
+  private final String group;
+  private final String command;
+  private final String path;
+
+	public ResourcesApplyHook(Project project, String group, String command) {
+		super(project);
+    this.exec = Exec.inProject(project);
+    this.group = group;
+    this.command = command;
+    this.path = project.getBuildInfo().getClassOutputDir().resolve(project.getDekorateOutputDir()).resolve(group + ".yml").toAbsolutePath().toString();
+	}
+
+	@Override
+	public void run() {
+    exec.commands(command, "apply", "--force", "-f", path);
+	}
+
+	@Override
+	public void init() {
+		
+	}
+
+	@Override
+	public void warmup() {
+		
+	}
+
+}

--- a/core/src/main/java/io/dekorate/kubernetes/config/ImageConfiguration.java
+++ b/core/src/main/java/io/dekorate/kubernetes/config/ImageConfiguration.java
@@ -31,6 +31,16 @@ public class ImageConfiguration extends ApplicationConfiguration {
   private boolean autoDeployEnabled;
   private boolean autoPushEnabled;
 
+  public static ImageConfiguration from(ApplicationConfiguration applicationConfiguration) {
+    return new ImageConfigurationBuilder()
+      .withProject(applicationConfiguration.getProject())
+      .withGroup(applicationConfiguration.getGroup())
+      .withName(applicationConfiguration.getName())
+      .withVersion(applicationConfiguration.getVersion())
+      .withAttributes(applicationConfiguration.getAttributes())
+      .build();
+  }
+
   public ImageConfiguration() {
   }
 

--- a/frameworks/spring-boot/src/it/annotationless-yml/Dockerfile
+++ b/frameworks/spring-boot/src/it/annotationless-yml/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:8u171-alpine3.7
+RUN apk --no-cache add curl
+COPY target/*.jar example.jar
+CMD java ${JAVA_OPTS} -jar example.jar

--- a/frameworks/spring-boot/src/it/annotationless-yml/src/main/resources/application.yml
+++ b/frameworks/spring-boot/src/it/annotationless-yml/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 dekorate:
+  docker:
+    registry: quay.io
   kubernetes:
     group: annotationless
     labels:


### PR DESCRIPTION
application annotations.

Ever since we split build annotations from application annotations some properties were available to both kind of annotation. However, build annotations were not working correctly.

This pull request fixes build annotations and it makes sure that both kinds work (until we de-duplicate).