### PR TITLE
Stop defaulting to /actuator/health on liveness probes

### DIFF
--- a/examples/spring-boot-on-kubernetes-example/src/main/java/io/dekorate/example/sbonkubernetes/Main.java
+++ b/examples/spring-boot-on-kubernetes-example/src/main/java/io/dekorate/example/sbonkubernetes/Main.java
@@ -22,7 +22,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @KubernetesApplication(
-  livenessProbe = @Probe(httpActionPath = "/actuator/health"),
+  livenessProbe = @Probe(httpActionPath = "/actuator/info"),
   readinessProbe = @Probe(httpActionPath = "/actuator/health")
 )
 @SpringBootApplication

--- a/examples/spring-boot-with-gradle-on-kubernetes-example/src/main/java/io/dekorate/example/sbonkubernetes/Main.java
+++ b/examples/spring-boot-with-gradle-on-kubernetes-example/src/main/java/io/dekorate/example/sbonkubernetes/Main.java
@@ -23,7 +23,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @KubernetesApplication(envVars = @Env(name = "MESSAGE", value = "Hello world"),
-livenessProbe = @Probe(httpActionPath = "/actuator/health"),
+livenessProbe = @Probe(httpActionPath = "/actuator/info"),
   readinessProbe = @Probe(httpActionPath = "/actuator/health"))
 @SpringBootApplication
 public class Main {

--- a/examples/spring-boot-with-gradle-on-openshift-example/src/main/groovy/io/dekorate/example/sbonopenshift/Main.groovy
+++ b/examples/spring-boot-with-gradle-on-openshift-example/src/main/groovy/io/dekorate/example/sbonopenshift/Main.groovy
@@ -21,7 +21,7 @@ import io.dekorate.openshift.annotation.OpenshiftApplication
 import io.dekorate.kubernetes.annotation.Probe;
 
 @OpenshiftApplication(
-  livenessProbe = @Probe(httpActionPath = "/actuator/health"),
+  livenessProbe = @Probe(httpActionPath = "/actuator/info"),
   readinessProbe = @Probe(httpActionPath = "/actuator/health"))
 @SpringBootApplication
 class Main {

--- a/frameworks/spring-boot/src/main/java/io/dekorate/spring/generator/SpringBootApplicationGenerator.java
+++ b/frameworks/spring-boot/src/main/java/io/dekorate/spring/generator/SpringBootApplicationGenerator.java
@@ -86,7 +86,7 @@ public interface SpringBootApplicationGenerator extends Generator, WithSession {
 
     if (isActuatorAvailable()) {
       //Users configuration should take priority, so add but don't overwrite.
-      session.configurators().add(new AddLivenessProbeConfigurator(new ProbeBuilder().withHttpActionPath("/actuator/health").build(), false));
+      session.configurators().add(new AddLivenessProbeConfigurator(new ProbeBuilder().withHttpActionPath("/actuator/info").build(), false));
       session.configurators().add(new AddReadinessProbeConfigurator(new ProbeBuilder().withHttpActionPath("/actuator/health").build(), false));
     }
 


### PR DESCRIPTION
At the moment, every example using Spring boot defaults to `livenessProbe` == `readinessProbe` == `/actuator/health` and that is typically a bad idea.
Liveness Probes responds to the question of when should I restart a container. Readiness Probes responds to the question of when should I start accepting traffic.

Making Liveness dependent on an external check, like other services or databases can cause a restart of all your containers when just a single external failure occurs.

For that reason, I suggest making the liveness probe defaults to `/actuator/info`
What are your thoughts?

Thanks,
Alberto