### PR TITLE
chore: exclude com.sun.tools from all profiles.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,12 +89,24 @@
         <groupId>io.sundr</groupId>
         <artifactId>builder-annotations</artifactId>
         <version>${version.sundrio}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.sun</groupId>
+            <artifactId>tools</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>io.sundr</groupId>
         <artifactId>transform-annotations</artifactId>
         <version>${version.sundrio}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.sun</groupId>
+            <artifactId>tools</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- Testing -->
@@ -360,17 +372,6 @@
         <java.source>1.8</java.source>
         <java.target>1.8</java.target>
       </properties>
-      <dependencyManagement>
-       <dependencies>
-         <dependency>
-           <groupId>com.sun</groupId>
-           <artifactId>tools</artifactId>
-           <version>${sun.tools.version}</version>
-           <scope>system</scope>
-           <systemPath>${java.home}/../lib/tools.jar</systemPath>
-         </dependency>
-        </dependencies>
-      </dependencyManagement>
     </profile>
     <profile>
       <id>jdk11</id>
@@ -381,32 +382,6 @@
         <java.source>11</java.source>
         <java.target>11</java.target>
       </properties>
-      <dependencyManagement>
-        <dependencies>
-            <dependency>
-              <groupId>io.sundr</groupId>
-              <artifactId>builder-annotations</artifactId>
-              <version>${version.sundrio}</version>
-              <exclusions>
-                <exclusion>
-                  <groupId>com.sun</groupId>
-                  <artifactId>tools</artifactId>
-                </exclusion>
-              </exclusions>
-            </dependency>
-            <dependency>
-              <groupId>io.sundr</groupId>
-              <artifactId>transform-annotations</artifactId>
-              <version>${version.sundrio}</version>
-              <exclusions>
-                <exclusion>
-                  <groupId>com.sun</groupId>
-                  <artifactId>tools</artifactId>
-                </exclusion>
-              </exclusions>
-            </dependency>
-          </dependencies>
-        </dependencyManagement>  
     </profile>
     <profile>
       <id>doclint-java8-disable</id>


### PR DESCRIPTION
Why?

- We don't need it and its a dependency not available in central.
- To avoid issues with donwstream project.
- To make things cleaner.