### PR TITLE
refactor: Tests now use their own dedicated profile.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
           key: v8-dependencies-{{ checksum "pom.xml" }}
 
       # run tests!
-      - run: mvn clean integration-test -Pwith-examples
+      - run: mvn clean integration-test -Pwith-examples -Pwith-tests
   JDK11:
     docker:
       # specify the version you desire here
@@ -77,7 +77,7 @@ jobs:
           key: v11-dependencies-{{ checksum "pom.xml" }}
 
       # run tests!
-      - run: mvn clean integration-test -Pwith-examples
+      - run: mvn clean integration-test -Pwith-examples -Pwith-tests
 
   OPENSHIFT_3_11:
     machine: true
@@ -102,7 +102,7 @@ jobs:
           command: |
             oc login -u admin -p admin
             oc new-project itests
-            mvn -B clean install -Pbuild -Pwith-examples
+            mvn -B clean install -Pbuild -Pwith-examples -Pwith-tests
 
   CLI_OPTIONS:
     machine: true

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,6 @@
     <module>testing</module>
     <module>starters</module>
     <module>doc</module>
-    <module>tests</module>
   </modules>
 
   <dependencyManagement>
@@ -409,6 +408,12 @@
       <properties>
         <javadoc.opts>-Xdoclint:none</javadoc.opts>
       </properties>
+    </profile>
+    <profile>
+      <id>with-tests</id>
+      <modules>
+        <module>tests</module>
+      </modules>
     </profile>
     <profile>
       <id>with-examples</id>


### PR DESCRIPTION
As we now have individual modules per tests, I'd rather use a different profile and keep them off releases to avoid polutting our public maven repo.