### PR TITLE
fix (#420): Explicit configuration is always considered applicable.

### DIFF
--- a/annotations/jib-annotations/src/main/java/io/dekorate/jib/buildservice/JibBuildServiceFactory.java
+++ b/annotations/jib-annotations/src/main/java/io/dekorate/jib/buildservice/JibBuildServiceFactory.java
@@ -24,6 +24,7 @@ import java.util.List;
 import io.dekorate.BuildService;
 import io.dekorate.BuildServiceApplicablility;
 import io.dekorate.BuildServiceFactory;
+import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.deps.kubernetes.api.model.HasMetadata;
 import io.dekorate.jib.config.JibBuildConfig;
 import io.dekorate.kubernetes.config.ImageConfiguration;
@@ -67,5 +68,13 @@ public class JibBuildServiceFactory implements BuildServiceFactory {
 	@Override
 	public BuildService create(Project project, ImageConfiguration config, Collection<HasMetadata> resources) {
 		return new JibBuildService(project, config);
+	}
+
+	@Override
+	public BuildServiceApplicablility checkApplicablility(Project project, ConfigurationSupplier<ImageConfiguration> supplier) {
+    if (supplier.isExplicit()) {
+      return new BuildServiceApplicablility(true, "Jib has been explicitly configured!");
+    }
+    return checkApplicablility(project, supplier.get());
 	}
 }

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/generator/KnativeApplicationGenerator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/generator/KnativeApplicationGenerator.java
@@ -86,7 +86,7 @@ public interface KnativeApplicationGenerator extends Generator, WithSession, Wit
       Project project = getProject();
       Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
       KnativeConfig config = session.configurators().get(KnativeConfig.class).get();
-      Optional<ImageConfiguration> imageConfiguration = session.configurators().get(ImageConfiguration.class, BuildServiceFactories.matches(project));
+      Optional<ImageConfiguration> imageConfiguration = session.configurators().getImageConfig(BuildServiceFactories.supplierMatches(project));
       imageConfiguration.ifPresent(i -> {
         String name = i.getName();
         if (i.isAutoBuildEnabled() || config.isAutoDeployEnabled()) {

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/handler/KnativeHandler.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/handler/KnativeHandler.java
@@ -133,7 +133,7 @@ public class KnativeHandler extends AbstractKubernetesHandler<KnativeConfig> imp
   }
 
   private static ImageConfiguration getImageConfiguration(Project project, KnativeConfig config, Configurators configurators) {
-    return configurators.get(ImageConfiguration.class, BuildServiceFactories.matches(project)).map(i -> merge(config, i)).orElse(ImageConfiguration.from(config));
+    return configurators.getImageConfig(BuildServiceFactories.supplierMatches(project)).map(i -> merge(config, i)).orElse(ImageConfiguration.from(config));
   }
 
   private static ImageConfiguration merge(KnativeConfig config, ImageConfiguration imageConfig) {

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/handler/KubernetesHandler.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/handler/KubernetesHandler.java
@@ -221,9 +221,9 @@ public class KubernetesHandler extends AbstractKubernetesHandler<KubernetesConfi
   }
   
   private static ImageConfiguration getImageConfiguration(Project project, KubernetesConfig appConfig, Configurators configurators) {
-    Optional<ImageConfiguration> origin = configurators.get(ImageConfiguration.class,
-                                                            BuildServiceFactories.matches(project));
-    return configurators.get(ImageConfiguration.class, BuildServiceFactories.matches(project)).map(i -> merge(appConfig, i)).orElse(ImageConfiguration.from(appConfig));
+    Optional<ImageConfiguration> origin = configurators.getImageConfig(BuildServiceFactories.supplierMatches(project));
+
+    return configurators.getImageConfig(BuildServiceFactories.supplierMatches(project)).map(i -> merge(appConfig, i)).orElse(ImageConfiguration.from(appConfig));
   }
 
   private static ImageConfiguration merge(KubernetesConfig appConfig, ImageConfiguration imageConfig) {

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/listener/KubernetesSessionListener.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/listener/KubernetesSessionListener.java
@@ -51,7 +51,7 @@ public class KubernetesSessionListener implements SessionListener, WithProject, 
     Session session = getSession();
     Project project = getProject();
     Optional<KubernetesConfig> optionalAppConfig = session.configurators().get(KubernetesConfig.class);
-    Optional<ImageConfiguration> optionalImageConfig = session.configurators().get(ImageConfiguration.class, BuildServiceFactories.matches(project));
+    Optional<ImageConfiguration> optionalImageConfig = session.configurators().getImageConfig(BuildServiceFactories.supplierMatches(project));
     if (!optionalAppConfig.isPresent() || !optionalImageConfig.isPresent()) {
       return;
     }

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/handler/OpenshiftHandler.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/handler/OpenshiftHandler.java
@@ -204,7 +204,7 @@ public class OpenshiftHandler extends AbstractKubernetesHandler<OpenshiftConfig>
   }
  
   private static ImageConfiguration getImageConfiguration(Project project, OpenshiftConfig config, Configurators configurators) {
-    return configurators.get(ImageConfiguration.class, BuildServiceFactories.matches(project)).map(i -> merge(config, i)).orElse(ImageConfiguration.from(config));
+    return configurators.getImageConfig(BuildServiceFactories.supplierMatches(project)).map(i -> merge(config, i)).orElse(ImageConfiguration.from(config));
   }
 
   private static ImageConfiguration merge(OpenshiftConfig config, ImageConfiguration imageConfig) {

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/listener/OpenshiftSessionListener.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/listener/OpenshiftSessionListener.java
@@ -55,8 +55,7 @@ public class OpenshiftSessionListener implements SessionListener, WithProject, W
     try {
       Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
       Optional<OpenshiftConfig> optionalAppConfig = session.configurators().get(OpenshiftConfig.class);
-      Optional<ImageConfiguration> optionalImageConfig = session.configurators().get(ImageConfiguration.class,
-          BuildServiceFactories.matches(project));
+      Optional<ImageConfiguration> optionalImageConfig = session.configurators().getImageConfig(BuildServiceFactories.supplierMatches(project));
 
       if (!optionalAppConfig.isPresent() || !optionalImageConfig.isPresent()) {
         return;

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/buildservice/S2iBuildServiceFactory.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/buildservice/S2iBuildServiceFactory.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import io.dekorate.BuildService;
 import io.dekorate.BuildServiceApplicablility;
 import io.dekorate.BuildServiceFactory;
+import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.deps.kubernetes.api.model.HasMetadata;
 import io.dekorate.kubernetes.config.ImageConfiguration;
 import io.dekorate.project.Project;
@@ -55,6 +56,14 @@ public class S2iBuildServiceFactory implements BuildServiceFactory {
 	@Override
 	public BuildServiceApplicablility checkApplicablility(Project project, ImageConfiguration config) {
 		return new BuildServiceApplicablility(true, MESSAGE_OK);
+	}
+
+	@Override
+	public BuildServiceApplicablility checkApplicablility(Project project, ConfigurationSupplier<ImageConfiguration> supplier) {
+    if (supplier.isExplicit()) {
+      return new BuildServiceApplicablility(true, MESSAGE_OK);
+    }
+    return checkApplicablility(project, supplier.get());
 	}
 
 }

--- a/core/src/main/java/io/dekorate/AbstractKubernetesHandler.java
+++ b/core/src/main/java/io/dekorate/AbstractKubernetesHandler.java
@@ -42,7 +42,6 @@ import io.dekorate.kubernetes.decorator.AddPortDecorator;
 import io.dekorate.kubernetes.decorator.AddPvcVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddReadinessProbeDecorator;
 import io.dekorate.kubernetes.decorator.AddSecretVolumeDecorator;
-import io.dekorate.kubernetes.decorator.AddServiceDecorator;
 import io.dekorate.kubernetes.decorator.AddSidecarDecorator;
 import io.dekorate.kubernetes.decorator.ApplyArgsDecorator;
 import io.dekorate.kubernetes.decorator.ApplyCommandDecorator;

--- a/core/src/main/java/io/dekorate/BuildServiceFactories.java
+++ b/core/src/main/java/io/dekorate/BuildServiceFactories.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.deps.kubernetes.api.model.HasMetadata;
 import io.dekorate.kubernetes.config.ImageConfiguration;
 import io.dekorate.project.Project;
@@ -40,11 +41,20 @@ public class BuildServiceFactories {
         .findFirst();
   }
 
+  public static Optional<BuildServiceFactory> find(Project project, ConfigurationSupplier<ImageConfiguration> supplier) {
+    return stream().filter(f -> f.checkApplicablility(project, supplier).isApplicable()).sorted()
+        .findFirst();
+  }
+
   public static Function<ImageConfiguration, BuildService> create(Project project, Collection<HasMetadata> items) {
     return c -> find(project, c).orElseThrow(() -> new IllegalStateException("No applicable BuildServiceFactory found.")).create(project, c, items);
   }
 
-  public static Predicate<ImageConfiguration> matches(Project project) {
+  public static Predicate<ImageConfiguration> configMatches(Project project) {
+    return c -> find(project, c).isPresent();
+  }
+
+  public static Predicate<ConfigurationSupplier<ImageConfiguration>> supplierMatches(Project project) {
     return c -> find(project, c).isPresent();
   }
 

--- a/core/src/main/java/io/dekorate/BuildServiceFactory.java
+++ b/core/src/main/java/io/dekorate/BuildServiceFactory.java
@@ -19,6 +19,7 @@ package io.dekorate;
 
 import java.util.Collection;
 
+import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.deps.kubernetes.api.model.HasMetadata;
 import io.dekorate.kubernetes.config.ImageConfiguration;
 import io.dekorate.project.Project;
@@ -30,6 +31,8 @@ public interface BuildServiceFactory extends Comparable<BuildServiceFactory> {
   String name();
   
   BuildServiceApplicablility checkApplicablility(Project project, ImageConfiguration config);
+
+  BuildServiceApplicablility checkApplicablility(Project project, ConfigurationSupplier<ImageConfiguration> supplier);
 
   BuildService create(Project project, ImageConfiguration config);
   

--- a/core/src/main/java/io/dekorate/config/AnnotationConfiguration.java
+++ b/core/src/main/java/io/dekorate/config/AnnotationConfiguration.java
@@ -22,11 +22,11 @@ public class AnnotationConfiguration<C> extends ConfigurationSupplier<C> {
 
 
 	public AnnotationConfiguration() {
-    super(null);
+    super(null, true);
 	}
 
   public AnnotationConfiguration(VisitableBuilder<C, ?> builder) {
-    super(builder);
+    super(builder, true);
   }
 
 	@Override

--- a/core/src/main/java/io/dekorate/config/ConfigurationSupplier.java
+++ b/core/src/main/java/io/dekorate/config/ConfigurationSupplier.java
@@ -31,17 +31,27 @@ import java.util.function.Supplier;
 public class ConfigurationSupplier<C> implements Supplier<C>, Comparable<ConfigurationSupplier<C>> {
 
   private final VisitableBuilder<C, ?> builder;
+  private final boolean explicit;
 
   public static ConfigurationSupplier<?> empty() {
     return new ConfigurationSupplier<>(null);
   }
 
   public ConfigurationSupplier (VisitableBuilder<C, ?> builder) {
+    this(builder, false);
+  }
+
+  public ConfigurationSupplier (VisitableBuilder<C, ?> builder, boolean explicit) {
     this.builder = builder; 
+    this.explicit = explicit;
   }
 
   public boolean hasConfiguration() {
     return builder != null;
+  }
+
+  public boolean isExplicit() {
+    return explicit;
   }
 
   private void checkBuilder() {
@@ -79,4 +89,5 @@ public class ConfigurationSupplier<C> implements Supplier<C>, Comparable<Configu
   public int compareTo(ConfigurationSupplier<C> o) {
     return 0;
   }
+
 }

--- a/core/src/main/java/io/dekorate/config/PropertyConfiguration.java
+++ b/core/src/main/java/io/dekorate/config/PropertyConfiguration.java
@@ -25,11 +25,11 @@ import io.dekorate.deps.kubernetes.api.builder.VisitableBuilder;
 public class PropertyConfiguration<C> extends ConfigurationSupplier<C> {
 
 	public PropertyConfiguration() {
-    super(null);
+    super(null, true);
 	}
 
   public PropertyConfiguration(VisitableBuilder<C, ?> builder) {
-    super(builder);
+    super(builder, true);
   }
 
   @Override

--- a/testing/core-junit/src/main/java/io/dekorate/testing/WithImageConfig.java
+++ b/testing/core-junit/src/main/java/io/dekorate/testing/WithImageConfig.java
@@ -37,7 +37,7 @@ public interface WithImageConfig extends WithProject {
       .map(r -> WithImageConfig.class.getClassLoader().getResource(r))
       .filter(u -> u != null)
       .map(u -> Serialization.unmarshal(u, ImageConfiguration.class))
-      .filter(BuildServiceFactories.matches(getProject()))
+      .filter(BuildServiceFactories.configMatches(getProject()))
       .filter(i -> type.isInstance(i))
       .map(i -> (C) i);
   }


### PR DESCRIPTION
We recently added support for multple different image configurations (docker, jib, s2i).
Each config is meant to be used only in projects where its actually applicable.

For instance it doesn't make sense to use docker config, if no docker files are provided.

However, if the use has provided explicitly configuration for cases like this, we should consider it applicable no matter what.