### PR TITLE
fix: Image field ignored in ImageConfiguration

### DIFF
--- a/core/src/main/java/io/dekorate/kubernetes/config/ImageConfiguration.java
+++ b/core/src/main/java/io/dekorate/kubernetes/config/ImageConfiguration.java
@@ -57,6 +57,7 @@ public class ImageConfiguration extends ApplicationConfiguration {
     this.group = group;
     this.name = name;
     this.version = version;
+    this.image = image;
     this.dockerFile = dockerFile;
     this.autoBuildEnabled = autoBuildEnabled;
     this.autoPushEnabled = autoPushEnabled;


### PR DESCRIPTION
Image configuration field in `@DockerBuild` was being ignored

## Relates to:
- https://github.com/fabric8io/fabric8-maven-plugin/issues/1483
- https://github.com/fabric8io/fabric8-maven-plugin/pull/1767