### PR TITLE
fix (#442): S2iBuildService now uses whatever name was given to the

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
             oc login -u admin -p admin
             oc new-project itests
             oc import-image fabric8/s2i-java:2.3 --from=docker.io/fabric8/s2i-java:2.3 --confirm
+            oc tag --source docker docker.io/fabric8/s2i-java:2.3 s2i-java:2.3
             mvn -B clean install -Pbuild -Pwith-examples -Pwith-tests
 
   CLI_OPTIONS:
@@ -156,6 +157,7 @@ jobs:
             oc login -u admin -p admin
             oc new-project dekorate-os-build
             oc import-image fabric8/s2i-java:2.3 --from=docker.io/fabric8/s2i-java:2.3 --confirm
+            oc tag --source docker docker.io/fabric8/s2i-java:2.3 s2i-java:2.3
             mvn -B clean install -DskipTests -Ddekorate.build=true -pl :spring-boot-on-openshift-example -Pwith-examples -Dapp.name=sbo-one
             docker images 
             IMAGES=`oc get istag | grep sbo-one | wc -l`
@@ -166,6 +168,7 @@ jobs:
             oc login -u admin -p admin
             oc new-project dekorate-os-deploy
             oc import-image fabric8/s2i-java:2.3 --from=docker.io/fabric8/s2i-java:2.3 --confirm
+            oc tag --source docker docker.io/fabric8/s2i-java:2.3 s2i-java:2.3
             mvn -B clean install -DskipTests -Ddekorate.deploy=true -pl :spring-boot-on-openshift-example -Pwith-examples -Dapp.name=sbo-two
             docker images | grep sbo-two
             IMAGES=`docker images | grep sbo-two | wc -l`

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/handler/OpenshiftHandler.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/handler/OpenshiftHandler.java
@@ -112,7 +112,7 @@ public class OpenshiftHandler extends AbstractKubernetesHandler<OpenshiftConfig>
       resources.decorate(OPENSHIFT, new AddServiceDecorator(config));
     }
 
-    addDecorators(OPENSHIFT, config);
+    addDecorators(OPENSHIFT, config, imageConfig);
   }
 
   @Override
@@ -122,11 +122,10 @@ public class OpenshiftHandler extends AbstractKubernetesHandler<OpenshiftConfig>
   }
 
 
-  @Override
-  protected void addDecorators(String group, OpenshiftConfig config) {
+  protected void addDecorators(String group, OpenshiftConfig config, ImageConfiguration imageConfig) {
     super.addDecorators(group, config);
     resources.decorate(group, new ApplyReplicasDecorator(config.getReplicas()));
-    resources.decorate(group, new ApplyDeploymentTriggerDecorator(config.getName(), config.getName() + ":" + config.getVersion()));
+    resources.decorate(group, new ApplyDeploymentTriggerDecorator(config.getName(), imageConfig.getName() + ":" + imageConfig.getVersion()));
     resources.decorate(group, new AddRouteDecorator(config));
   }
 

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/decorator/AddBuildConfigResourceDecorator.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/decorator/AddBuildConfigResourceDecorator.java
@@ -53,14 +53,14 @@ public class AddBuildConfigResourceDecorator extends ResourceProvidingDecorator<
     String version = meta.getLabels().getOrDefault(Labels.VERSION, LATEST);
     list.addToItems(new BuildConfigBuilder()
       .withNewMetadata()
-      .withName(meta.getName())
+      .withName(config.getName())
       .withLabels(meta.getLabels())
       .endMetadata()
       .withNewSpec()
       .withNewOutput()
       .withNewTo()
       .withKind(IMAGESTREAMTAG)
-      .withName(meta.getName() + ":" + version)
+      .withName(config.getName() + ":" + version)
       .endTo()
       .endOutput()
       .withNewSource()
@@ -78,6 +78,4 @@ public class AddBuildConfigResourceDecorator extends ResourceProvidingDecorator<
       .endStrategy()
       .endSpec());
   }
-
-
 }

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/decorator/AddOutputImageStreamResourceDecorator.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/decorator/AddOutputImageStreamResourceDecorator.java
@@ -20,13 +20,17 @@ package io.dekorate.s2i.decorator;
 import io.dekorate.deps.kubernetes.api.model.KubernetesListBuilder;
 import io.dekorate.deps.kubernetes.api.model.ObjectMeta;
 import io.dekorate.deps.openshift.api.model.ImageStreamBuilder;
-import io.dekorate.doc.Description;
 import io.dekorate.kubernetes.decorator.ResourceProvidingDecorator;
+import io.dekorate.s2i.config.S2iBuildConfig;
+import io.dekorate.doc.Description;
 
 @Description("Add a output ImageStream resource to the list of generated resources.")
 public class AddOutputImageStreamResourceDecorator extends ResourceProvidingDecorator<KubernetesListBuilder> {
 
-  public AddOutputImageStreamResourceDecorator() {
+  private final S2iBuildConfig config;
+
+  public AddOutputImageStreamResourceDecorator(S2iBuildConfig config) {
+    this.config=config;
   }
 
   public void visit(KubernetesListBuilder list) {
@@ -34,7 +38,7 @@ public class AddOutputImageStreamResourceDecorator extends ResourceProvidingDeco
 
     list.addToItems(new ImageStreamBuilder()
       .withNewMetadata()
-      .withName(meta.getName())
+      .withName(config.getName())
       .withLabels(meta.getLabels())
       .endMetadata()
       .withNewSpec()

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/generator/S2iBuildGenerator.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/generator/S2iBuildGenerator.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2018 The original authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
 **/
 
 package io.dekorate.s2i.generator;
@@ -31,6 +31,7 @@ import io.dekorate.WithSession;
 import io.dekorate.config.AnnotationConfiguration;
 import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.config.PropertyConfiguration;
+import io.dekorate.kubernetes.configurator.ApplyBuildToImageConfiguration;
 import io.dekorate.project.ApplyProjectInfo;
 import io.dekorate.s2i.adapter.*;
 import io.dekorate.s2i.annotation.S2iBuild;
@@ -52,6 +53,7 @@ public interface S2iBuildGenerator extends Generator, WithSession, WithProject {
   @Override
   default void add(Map map) {
     on(new PropertyConfiguration<S2iBuildConfig>(S2iBuildConfigAdapter.newBuilder(propertiesMap(map, S2iBuild.class))
+                                                 .accept(new ApplyBuildToImageConfiguration())
                                                  .accept(new ApplyProjectInfo(getProject()))));
   }
 
@@ -59,8 +61,12 @@ public interface S2iBuildGenerator extends Generator, WithSession, WithProject {
   default void add(Element element) {
     S2iBuild enableS2iBuild = element.getAnnotation(S2iBuild.class);
     on(enableS2iBuild != null
-       ? new AnnotationConfiguration<S2iBuildConfig>(S2iBuildConfigAdapter.newBuilder(enableS2iBuild).accept(new ApplyProjectInfo(getProject())))
-       : new AnnotationConfiguration<S2iBuildConfig>(new S2iBuildConfigBuilder().accept(new ApplyProjectInfo(getProject()))));
+       ? new AnnotationConfiguration<S2iBuildConfig>(S2iBuildConfigAdapter.newBuilder(enableS2iBuild)
+                                                     .accept(new ApplyBuildToImageConfiguration())
+                                                     .accept(new ApplyProjectInfo(getProject())))
+       : new AnnotationConfiguration<S2iBuildConfig>(new S2iBuildConfigBuilder()
+                                                     .accept(new ApplyBuildToImageConfiguration())
+                                                     .accept(new ApplyProjectInfo(getProject()))));
   }
 
   default void on(ConfigurationSupplier<S2iBuildConfig> config) {

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/handler/S2iHanlder.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/handler/S2iHanlder.java
@@ -70,7 +70,7 @@ public class S2iHanlder implements Handler<S2iBuildConfig>, HandlerFactory, With
       LOGGER.info("Processing s2i configuration.");
       //TODO: We are temporarily limit S2i to openshift until we find a better way to handle this (#367).
       resources.decorate(OPENSHIFT, new AddBuilderImageStreamResourceDecorator(config));
-      resources.decorate(OPENSHIFT, new AddOutputImageStreamResourceDecorator());
+      resources.decorate(OPENSHIFT, new AddOutputImageStreamResourceDecorator(config));
       resources.decorate(OPENSHIFT, new AddBuildConfigResourceDecorator(config));
 
       for (Env env : config.getBuildEnvVars()) {

--- a/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/OpenshiftExtension.java
+++ b/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/OpenshiftExtension.java
@@ -176,10 +176,9 @@ public class OpenshiftExtension implements ExecutionCondition, BeforeAllCallback
       if (failed) {
         displayDiagnostics(context);
       }
-      getOpenshiftResources(context).getItems().stream().forEach(r -> {
+      getOpenshiftResources(context).getItems().stream().filter(r -> !(r instanceof ImageStream)).forEach(r -> {
         try {
-          LOGGER.info("Deleting: " + r.getKind() + " name:" + r.getMetadata().getName() + ". Deleted:"
-              + client.resource(r).delete());
+          LOGGER.info("Deleting: " + r.getKind() + " name:" + r.getMetadata().getName() + ". Deleted:" + client.resource(r).delete());
         } catch (Exception e) {
         }
       });

--- a/tests/issue-442-build-config-name/pom.xml
+++ b/tests/issue-442-build-config-name/pom.xml
@@ -39,10 +39,15 @@ limitations under the License.
   </properties>
 
   <dependencies>
-
     <dependency>
       <groupId>io.dekorate</groupId>
       <artifactId>openshift-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-junit</artifactId>
       <version>${project.version}</version>
     </dependency>
 

--- a/tests/issue-442-build-config-name/pom.xml
+++ b/tests/issue-442-build-config-name/pom.xml
@@ -77,6 +77,25 @@ limitations under the License.
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.maven-failsafe-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <includes>
+                <include>**/*IT.class</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${version.maven-compiler-plugin}</version>
         <configuration>
@@ -86,4 +105,5 @@ limitations under the License.
       </plugin>
     </plugins>
   </build>
+
 </project>

--- a/tests/issue-442-build-config-name/src/test/java/io/dekorate/examples/kuberentes/Issue442BuildConfigNameIT.java
+++ b/tests/issue-442-build-config-name/src/test/java/io/dekorate/examples/kuberentes/Issue442BuildConfigNameIT.java
@@ -6,7 +6,7 @@ import io.dekorate.testing.annotation.Inject;
 import io.dekorate.testing.openshift.annotation.OpenshiftIntegrationTest;
 
 @OpenshiftIntegrationTest
-public class Issue442BuildConfigNameIntegrationTest {
+public class Issue442BuildConfigNameIT {
 
   @Test
   void shouldBeUpAndRunning() {

--- a/tests/issue-442-build-config-name/src/test/java/io/dekorate/examples/kuberentes/Issue442BuildConfigNameIntegrationTest.java
+++ b/tests/issue-442-build-config-name/src/test/java/io/dekorate/examples/kuberentes/Issue442BuildConfigNameIntegrationTest.java
@@ -1,0 +1,15 @@
+package io.dekorate.examples.kubernetes;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.testing.annotation.Inject;
+import io.dekorate.testing.openshift.annotation.OpenshiftIntegrationTest;
+
+@OpenshiftIntegrationTest
+public class Issue442BuildConfigNameIntegrationTest {
+
+  @Test
+  void shouldBeUpAndRunning() {
+    //We just want to check that the image is build. An empty test is good enough for this.
+  }
+}

--- a/tests/issue-442-build-config-name/src/test/java/io/dekorate/examples/kuberentes/Issue442BuildConfigNameTest.java
+++ b/tests/issue-442-build-config-name/src/test/java/io/dekorate/examples/kuberentes/Issue442BuildConfigNameTest.java
@@ -30,12 +30,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class Issue442BuildConfigNameTest {
 
   @Test
-  public void shouldHaveCustomBuildConfigNameYaml() {
+  public void shouldHaveModuleBuildConfigNameYaml() {
     KubernetesList list = Serialization.unmarshalAsList(Issue442BuildConfigNameTest.class.getClassLoader().getResourceAsStream("META-INF/dekorate/openshift.yml"));
     assertNotNull(list);
     BuildConfig b = findFirst(list, BuildConfig.class).orElseThrow(() -> new IllegalStateException());
     assertNotNull(b);
-    assertEquals("o-name", b.getMetadata().getName());
+    assertEquals("issue-442-build-config-name", b.getMetadata().getName());
   }
 
   <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {


### PR DESCRIPTION
resource. S2i resources aligned with the rest of the converntions. Added tests.

This pull request is meant to do the following:

- Have openshift resources correctly refer to s2i resources  (imagestreams, etc).
- Have openshift shutdown hooks, correctly identify s2i names.
- Have s2i build service retain imagestreams (workaround ci related issues).
- Add integration test for the above.
- Deal with circleci issues and missing s2i-java tags.