### PR TITLE
feat: Support image pull secrets via cli

### DIFF
--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/generator/DefaultKnativeApplicationGenerator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/generator/DefaultKnativeApplicationGenerator.java
@@ -19,12 +19,14 @@ import io.dekorate.config.DefaultConfiguration;
 import io.dekorate.knative.config.KnativeConfig;
 import io.dekorate.knative.config.KnativeConfigBuilder;
 import io.dekorate.kubernetes.configurator.ApplyDeployToApplicationConfiguration;
+import io.dekorate.kubernetes.configurator.ApplyImagePullSecretConfiguration;
 import io.dekorate.project.ApplyProjectInfo;
 
 public class DefaultKnativeApplicationGenerator implements KnativeApplicationGenerator {
 
     public DefaultKnativeApplicationGenerator () {
       on(new DefaultConfiguration<KnativeConfig>(new KnativeConfigBuilder()
+                                                   .accept(new ApplyImagePullSecretConfiguration())
                                                    .accept(new ApplyProjectInfo(getProject()))
                                                    .accept(new ApplyDeployToApplicationConfiguration())));
     }

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/generator/KnativeApplicationGenerator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/generator/KnativeApplicationGenerator.java
@@ -39,6 +39,7 @@ import io.dekorate.knative.config.KnativeConfigCustomAdapter;
 import io.dekorate.knative.handler.KnativeHandler;
 import io.dekorate.kubernetes.config.ImageConfiguration;
 import io.dekorate.kubernetes.configurator.ApplyBuildToImageConfiguration;
+import io.dekorate.kubernetes.configurator.ApplyImagePullSecretConfiguration;
 import io.dekorate.project.ApplyProjectInfo;
 import io.dekorate.project.Project;
 
@@ -60,6 +61,7 @@ public interface KnativeApplicationGenerator extends Generator, WithSession, Wit
     KnativeConfig knativeConfig = KnativeConfigCustomAdapter.newBuilder(getProject(), knativeApplication).build();
 
     on(new ConfigurationSupplier<>(KnativeConfigAdapter.newBuilder(element.getAnnotation(KnativeApplication.class))
+                                   .accept(new ApplyImagePullSecretConfiguration())
                                    .accept(new ApplyBuildToImageConfiguration())
                                    .accept(new ApplyProjectInfo(getProject()))));
   }
@@ -67,6 +69,7 @@ public interface KnativeApplicationGenerator extends Generator, WithSession, Wit
   default void add(Map map) {
     KnativeConfig knativeConfig = KnativeConfigAdapter.newBuilder((Map) map.get(KnativeApplication.class.getName())).build();
     on(new ConfigurationSupplier<>(KnativeConfigAdapter.newBuilder(propertiesMap(map, KnativeApplication.class))
+                                   .accept(new ApplyImagePullSecretConfiguration())
                                    .accept(new ApplyBuildToImageConfiguration())
                                    .accept(new ApplyProjectInfo(getProject()))));
   }

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/generator/DefaultKubernetesApplicationGenerator.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/generator/DefaultKubernetesApplicationGenerator.java
@@ -19,6 +19,7 @@ import io.dekorate.config.DefaultConfiguration;
 import io.dekorate.kubernetes.config.KubernetesConfig;
 import io.dekorate.kubernetes.config.KubernetesConfigBuilder;
 import io.dekorate.kubernetes.configurator.ApplyDeployToApplicationConfiguration;
+import io.dekorate.kubernetes.configurator.ApplyImagePullSecretConfiguration;
 import io.dekorate.project.ApplyProjectInfo;
 
 public class DefaultKubernetesApplicationGenerator implements KubernetesApplicationGenerator {
@@ -26,6 +27,7 @@ public class DefaultKubernetesApplicationGenerator implements KubernetesApplicat
     public DefaultKubernetesApplicationGenerator () {
       add(new DefaultConfiguration<KubernetesConfig>(new KubernetesConfigBuilder()
                                                      .accept(new ApplyProjectInfo(getProject()))
+                                                     .accept(new ApplyImagePullSecretConfiguration())
                                                      .accept(new ApplyDeployToApplicationConfiguration())));
     }
 }

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/generator/KubernetesApplicationGenerator.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/generator/KubernetesApplicationGenerator.java
@@ -31,6 +31,7 @@ import io.dekorate.kubernetes.adapter.KubernetesConfigAdapter;
 import io.dekorate.kubernetes.annotation.KubernetesApplication;
 import io.dekorate.kubernetes.config.KubernetesConfig;
 import io.dekorate.kubernetes.configurator.ApplyDeployToApplicationConfiguration;
+import io.dekorate.kubernetes.configurator.ApplyImagePullSecretConfiguration;
 import io.dekorate.kubernetes.configurator.ApplyBuildToImageConfiguration;
 import io.dekorate.kubernetes.handler.KubernetesHandler;
 import io.dekorate.kubernetes.listener.KubernetesSessionListener;
@@ -55,6 +56,7 @@ public interface KubernetesApplicationGenerator extends Generator, WithProject {
             KubernetesConfigAdapter
             .newBuilder(propertiesMap(map, KubernetesApplication.class))
             .accept(new ApplyBuildToImageConfiguration())
+            .accept(new ApplyImagePullSecretConfiguration())
             .accept(new ApplyDeployToApplicationConfiguration())
             .accept(new ApplyProjectInfo(getProject()))));
   }
@@ -65,6 +67,7 @@ public interface KubernetesApplicationGenerator extends Generator, WithProject {
             KubernetesConfigAdapter
             .newBuilder(application)
             .accept(new ApplyBuildToImageConfiguration())
+            .accept(new ApplyImagePullSecretConfiguration())
             .accept(new ApplyDeployToApplicationConfiguration())
             .accept(new ApplyProjectInfo(getProject()))));
   }

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/generator/DefaultOpenshiftApplicationGenerator.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/generator/DefaultOpenshiftApplicationGenerator.java
@@ -18,6 +18,7 @@ package io.dekorate.openshift.generator;
 import io.dekorate.Session;
 import io.dekorate.config.DefaultConfiguration;
 import io.dekorate.kubernetes.configurator.ApplyDeployToApplicationConfiguration;
+import io.dekorate.kubernetes.configurator.ApplyImagePullSecretConfiguration;
 import io.dekorate.openshift.config.OpenshiftConfig;
 import io.dekorate.openshift.config.OpenshiftConfigBuilder;
 import io.dekorate.project.ApplyProjectInfo;
@@ -26,6 +27,7 @@ public class DefaultOpenshiftApplicationGenerator implements OpenshiftApplicatio
 
     public DefaultOpenshiftApplicationGenerator () {
       on(new DefaultConfiguration<OpenshiftConfig>(new OpenshiftConfigBuilder()
+                                                   .accept(new ApplyImagePullSecretConfiguration())
                                                    .accept(new ApplyProjectInfo(getProject()))
                                                    .accept(new ApplyDeployToApplicationConfiguration())));
     }

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/generator/OpenshiftApplicationGenerator.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/generator/OpenshiftApplicationGenerator.java
@@ -29,6 +29,7 @@ import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.config.PropertyConfiguration;
 import io.dekorate.deps.kubernetes.api.model.KubernetesListBuilder;
 import io.dekorate.kubernetes.configurator.ApplyDeployToApplicationConfiguration;
+import io.dekorate.kubernetes.configurator.ApplyImagePullSecretConfiguration;
 import io.dekorate.openshift.adapter.OpenshiftConfigAdapter;
 import io.dekorate.openshift.annotation.OpenshiftApplication;
 import io.dekorate.openshift.config.OpenshiftConfig;
@@ -52,12 +53,14 @@ public interface OpenshiftApplicationGenerator extends Generator, WithSession, W
 
   default void add(Element element) {
     on(new AnnotationConfiguration<>(OpenshiftConfigAdapter.newBuilder(element.getAnnotation(OpenshiftApplication.class))
+                                     .accept(new ApplyImagePullSecretConfiguration())
                                      .accept(new ApplyDeployToApplicationConfiguration())
                                      .accept(new ApplyProjectInfo(getProject()))));
   }
 
   default void add(Map map) {
     on(new PropertyConfiguration<>(OpenshiftConfigAdapter.newBuilder(propertiesMap(map, OpenshiftApplication.class))
+                                   .accept(new ApplyImagePullSecretConfiguration())
                                    .accept(new ApplyDeployToApplicationConfiguration())
                                    .accept(new ApplyProjectInfo(getProject()))));
   }

--- a/core/src/main/java/io/dekorate/kubernetes/configurator/ApplyImagePullSecretConfiguration.java
+++ b/core/src/main/java/io/dekorate/kubernetes/configurator/ApplyImagePullSecretConfiguration.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+package io.dekorate.kubernetes.configurator;
+
+import java.util.Arrays;
+
+import io.dekorate.kubernetes.config.BaseConfigFluent;
+import io.dekorate.kubernetes.config.Configurator;
+import io.dekorate.utils.Strings;
+
+public class ApplyImagePullSecretConfiguration extends Configurator<BaseConfigFluent> {
+
+  private static final String EMPTY = "";
+  private static final String COMA = ",";
+  private static final String IMAGE_PULL_SECRETS = "dekorate.image-pull-secrets";
+
+  @Override
+  public void visit(BaseConfigFluent config) {
+    Arrays.stream(System.getProperty(IMAGE_PULL_SECRETS, EMPTY).split(COMA))
+      .map(String::trim)
+      .filter(Strings::isNotNullOrEmpty)
+      .forEach(s -> config.addNewImagePullSecret(s));
+  }
+}

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddImagePullSecretDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddImagePullSecretDecorator.java
@@ -19,6 +19,7 @@ package io.dekorate.kubernetes.decorator;
 
 import io.dekorate.deps.kubernetes.api.model.ObjectMeta;
 import io.dekorate.deps.kubernetes.api.model.PodSpecFluent;
+import io.dekorate.utils.Strings;
 
 public class AddImagePullSecretDecorator extends NamedResourceDecorator<PodSpecFluent<?>> {
 
@@ -30,8 +31,10 @@ public class AddImagePullSecretDecorator extends NamedResourceDecorator<PodSpecF
   }
 
   public void andThenVisit(PodSpecFluent<?> podSpec, ObjectMeta resourceMeta) {
-    podSpec.addNewImagePullSecret()
-      .withName(imagePullSecret)
-      .endImagePullSecret();
+    if (Strings.isNotNullOrEmpty(imagePullSecret) && !podSpec.hasMatchingImagePullSecret(r -> imagePullSecret.equals(r.getName()))) {
+       podSpec.addNewImagePullSecret()
+         .withName(imagePullSecret)
+       .endImagePullSecret();
+    }
   }
 }


### PR DESCRIPTION
This pr allows setting image pull secrets for kubernets, openshift and knative via: `dekorate.image-pull-secrets=<my secret>`.

This is needed for tekton support.