### PR TITLE
Make all loggers use the one created with the session

### DIFF
--- a/core/src/main/java/io/dekorate/LoggerFactory.java
+++ b/core/src/main/java/io/dekorate/LoggerFactory.java
@@ -35,6 +35,10 @@ public abstract class LoggerFactory<C> {
   }
 
   protected abstract Logger create(C context);
+
+  public static synchronized void setLogger(Logger logger) {
+    LOGGER = logger;
+  }
   
   public static Logger getLogger() {
     if (LOGGER != null) {

--- a/core/src/main/java/io/dekorate/Session.java
+++ b/core/src/main/java/io/dekorate/Session.java
@@ -93,6 +93,7 @@ public class Session {
   }
 
   protected Session(Logger logger) {
+    LoggerFactory.setLogger(logger);
     LOGGER = logger;
     LOGGER.info("Initializing dekorate session.");
   }


### PR DESCRIPTION
We need to do this because otherwise other loggers won't
use the same logger