### PR TITLE
fix: BuildConfig is in sync with DeploymentConfig

### DIFF
--- a/examples/spring-boot-on-openshift-example/src/test/java/io/dekorate/example/sbonopenshift/SpringBootOnOpenshiftTest.java
+++ b/examples/spring-boot-on-openshift-example/src/test/java/io/dekorate/example/sbonopenshift/SpringBootOnOpenshiftTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+package io.dekorate.example.sbonopenshift;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.deps.kubernetes.api.model.HasMetadata;
+import io.dekorate.deps.kubernetes.api.model.KubernetesList;
+import io.dekorate.deps.openshift.api.model.BuildConfig;
+import io.dekorate.deps.openshift.api.model.DeploymentConfig;
+import io.dekorate.utils.Serialization;
+
+class SpringBootOnOpenshiftTest {
+
+  @Test
+  public void shouldHaveMatchingOutputImageAndTrigger() {
+    KubernetesList list = Serialization.unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/openshift.yml"));
+    assertNotNull(list);
+    DeploymentConfig d = findFirst(list, DeploymentConfig.class).orElseThrow(() -> new IllegalStateException());
+    BuildConfig b = findFirst(list, BuildConfig.class).orElseThrow(() -> new IllegalStateException());
+    assertNotNull(d);
+    assertNotNull(b);
+    assertTrue(d.getSpec().getTriggers().stream().filter(t -> t.getImageChangeParams().getFrom().getName().equals(b.getSpec().getOutput().getTo().getName())).findFirst().isPresent());
+  }
+
+  <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {
+    return (Optional<T>) list.getItems().stream()
+      .filter(i -> t.isInstance(i))
+      .findFirst();
+  }
+}


### PR DESCRIPTION
This pull request introduces a slightly smarter way to find the version to use when creating buildconfig.

Instead of just using `latest` we use the `config.version` which is aware of the actual project version.