### PR TITLE
Allow generating manifests outside target

### DIFF
--- a/annotations/knative-annotations/src/test/java/io/dekorate/knative/generator/KnativeApplicationGeneratorTest.java
+++ b/annotations/knative-annotations/src/test/java/io/dekorate/knative/generator/KnativeApplicationGeneratorTest.java
@@ -46,15 +46,14 @@ class KnativeApplicationGeneratorTest {
   @Test
   public void shouldGenerateKnativeAndWriteToTheFilesystem()  {
     WithProject withProject = new WithProject() {};
-    withProject.setProject(FileProjectFactory.create(new File(".")));
+    withProject.setProject(FileProjectFactory.create(new File(".")).withDekorateOutputDir(tempDir.toAbsolutePath().toString()).withDekorateMetaDir(tempDir.toAbsolutePath().toString()));
+    SessionWriter writer = new SimpleFileWriter(withProject.getProject());
 
-    SessionWriter writer = new SimpleFileWriter(tempDir);
     Session session = Session.getSession();
     session.setWriter(writer);
 
     KnativeApplicationGenerator generator = new KnativeApplicationGenerator() {};
     generator.setProject(FileProjectFactory.create(new File(".")));
-    System.out.println("Project root:" + generator.getProject());
 
     Map<String, Object> map = new HashMap<String, Object>() {{
       put(KnativeApplication.class.getName(), new HashMap<String, Object>() {{

--- a/annotations/kubernetes-annotations/src/test/java/io/dekorate/kubernetes/generator/KubernetesApplicationGeneratorTest.java
+++ b/annotations/kubernetes-annotations/src/test/java/io/dekorate/kubernetes/generator/KubernetesApplicationGeneratorTest.java
@@ -42,9 +42,9 @@ class KubernetesApplicationGeneratorTest {
     Path tempDir = Files.createTempDirectory("dekorate");
 
     WithProject withProject = new WithProject() {};
-    withProject.setProject(FileProjectFactory.create(new File(".")));
+    withProject.setProject(FileProjectFactory.create(new File(".")).withDekorateOutputDir(tempDir.toAbsolutePath().toString()).withDekorateMetaDir(tempDir.toAbsolutePath().toString()));
 
-    SessionWriter writer = new SimpleFileWriter(tempDir, false);
+    SessionWriter writer = new SimpleFileWriter(withProject.getProject(), false);
     Session session = Session.getSession();
     session.setWriter(writer);
 

--- a/annotations/openshift-annotations/src/test/java/io/dekorate/openshift/generator/OpenshiftApplicationGeneratorTest.java
+++ b/annotations/openshift-annotations/src/test/java/io/dekorate/openshift/generator/OpenshiftApplicationGeneratorTest.java
@@ -46,9 +46,9 @@ class OpenshiftApplicationGeneratorTest {
   @Test
   public void shouldGenerateOpenshiftAndWriteToTheFilesystem()  {
     WithProject withProject = new WithProject() {};
-    withProject.setProject(FileProjectFactory.create(new File(".")));
 
-    SessionWriter writer = new SimpleFileWriter(tempDir);
+    withProject.setProject(FileProjectFactory.create(new File(".")).withDekorateOutputDir(tempDir.toAbsolutePath().toString()).withDekorateMetaDir(tempDir.toAbsolutePath().toString()));
+    SessionWriter writer = new SimpleFileWriter(withProject.getProject());
     Session session = Session.getSession();
     session.setWriter(writer);
 

--- a/annotations/option-annotations/src/main/java/io/dekorate/option/annotation/GeneratorOptions.java
+++ b/annotations/option-annotations/src/main/java/io/dekorate/option/annotation/GeneratorOptions.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
       superClass = Configuration.class,
       withStaticBuilderMethod = false,
       withStaticAdapterMethod = false,
-      adapter = @Adapter(suffix = "Adapter", relativePath = "../adapter"))
+      adapter = @Adapter(suffix = "Adapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ElementType.CONSTRUCTOR, ElementType.TYPE})
 @Retention(RetentionPolicy.SOURCE)
 public @interface GeneratorOptions {

--- a/annotations/option-annotations/src/main/java/io/dekorate/option/generator/DefaultOptionsGenerator.java
+++ b/annotations/option-annotations/src/main/java/io/dekorate/option/generator/DefaultOptionsGenerator.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+package io.dekorate.option.generator;
+
+public class DefaultOptionsGenerator implements OptionsGenerator {
+
+}

--- a/annotations/option-annotations/src/main/java/io/dekorate/option/generator/JvmOptionsGenerator.java
+++ b/annotations/option-annotations/src/main/java/io/dekorate/option/generator/JvmOptionsGenerator.java
@@ -15,6 +15,7 @@
  */
 package io.dekorate.option.generator;
 
+import java.lang.annotation.Annotation;
 import java.util.Map;
 
 import javax.lang.model.element.Element;
@@ -32,12 +33,17 @@ import io.dekorate.option.configurator.ApplyJvmOptsConfigurator;
 public interface JvmOptionsGenerator extends Generator  {
 
   String JVM = "jvm";
-   
+
   @Override
   default String getKey() {
     return JVM;
   }
-    
+
+  @Override
+  default Class<? extends Annotation> getAnnotation() {
+    return JvmOptions.class;
+  }
+
   @Override
   default void add(Element element) {
     JvmOptions jvmOptions = element.getAnnotation(JvmOptions.class);
@@ -60,4 +66,5 @@ public interface JvmOptionsGenerator extends Generator  {
     session.configurators().add(config);
     session.configurators().add(new ApplyJvmOptsConfigurator(config));
   }
+
 }

--- a/annotations/option-annotations/src/main/java/io/dekorate/option/generator/OptionsGenerator.java
+++ b/annotations/option-annotations/src/main/java/io/dekorate/option/generator/OptionsGenerator.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+package io.dekorate.option.generator;
+
+import java.io.File;
+import java.lang.annotation.Annotation;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.lang.model.element.Element;
+
+import io.dekorate.Generator;
+import io.dekorate.WithProject;
+import io.dekorate.config.AnnotationConfiguration;
+import io.dekorate.config.ConfigurationSupplier;
+import io.dekorate.config.PropertyConfiguration;
+import io.dekorate.option.adapter.GeneratorConfigAdapter;
+import io.dekorate.option.annotation.GeneratorOptions;
+import io.dekorate.option.config.GeneratorConfig;
+import io.dekorate.option.config.GeneratorConfigBuilder;
+import io.dekorate.processor.SimpleFileWriter;
+import io.dekorate.utils.Strings;
+
+public interface OptionsGenerator extends Generator, WithProject {
+
+    String OPTIONS = "options";
+    String INPUT_DIR = "dekorate.input.dir";
+    String OUTPUT_DIR = "dekorate.output.dir";
+
+    @Override
+    default String getKey() {
+        return OPTIONS;
+    }
+
+    @Override
+    default Class<? extends Annotation> getAnnotation() {
+        return GeneratorOptions.class;
+    }
+
+    @Override
+    default void add(Element element) {
+        GeneratorOptions options = element.getAnnotation(GeneratorOptions.class);
+        if (options != null) {
+            AnnotationConfiguration<GeneratorConfig> config = new AnnotationConfiguration<>(GeneratorConfigAdapter.newBuilder(options));
+            on(config);
+        }
+    }
+
+    @Override
+    default void add(Map map) {
+        on(new PropertyConfiguration<>(GeneratorConfigAdapter.newBuilder(propertiesMap(map, GeneratorOptions.class))));
+    }
+
+    default void on(ConfigurationSupplier<GeneratorConfig> config) {
+        GeneratorConfig c = config.get();
+        configurePaths(c.getInputPath(), c.getOutputPath());
+    }
+
+    default void configurePaths(String defaultInputPath, String defaultOutputPath) {
+        final String inputPath = System.getProperty(INPUT_DIR, defaultInputPath);
+        final String outputPath = Optional.ofNullable(System.getProperty(OUTPUT_DIR)).map(path -> {
+            resolve(path).mkdirs();
+            return path;
+        }).orElse(defaultOutputPath);
+        if (isInputPathValid(inputPath)) {
+            applyToProject(p -> p.withDekorateInputDir(inputPath));
+            getSession().configurators().add(new ConfigurationSupplier<>(new GeneratorConfigBuilder()));
+        }
+
+        if (isOutputPathValid(outputPath)) {
+            applyToProject(p -> p.withDekorateOutputDir(outputPath));
+            getSession().setWriter(new SimpleFileWriter(getProject().getBuildInfo().getClassOutputDir().resolve(getProject().getDekorateMetaDir()), resolve(outputPath).toPath()));
+        }
+    }
+
+    default boolean isInputPathValid(String path) {
+        return Strings.isNotNullOrEmpty(path) && resolve(path).exists();
+    }
+
+    default boolean isOutputPathValid(String path) {
+        return Strings.isNotNullOrEmpty(path) && (resolve(path).exists() || resolve(path).mkdirs());
+    }
+
+    default File resolve(String unixPath) {
+        return new File(getProject().getBuildInfo().getClassOutputDir().toFile(), unixPath.replace('/', File.separatorChar));
+    }
+}

--- a/annotations/option-annotations/src/main/resources/META-INF/services/io.dekorate.Generator
+++ b/annotations/option-annotations/src/main/resources/META-INF/services/io.dekorate.Generator
@@ -1,1 +1,2 @@
+io.dekorate.option.generator.DefaultOptionsGenerator
 io.dekorate.option.generator.DefaultJvmOptionsGenerator

--- a/annotations/tekton-annotations/src/test/java/io/dekorate/tekton/generator/TektonApplicationGeneratorTest.java
+++ b/annotations/tekton-annotations/src/test/java/io/dekorate/tekton/generator/TektonApplicationGeneratorTest.java
@@ -44,9 +44,8 @@ class TektonApplicationGeneratorTest {
   @Test
   public void shouldGenerateTektonAndWriteToTheFilesystem()  {
     WithProject withProject = new WithProject() {};
-    withProject.setProject(FileProjectFactory.create(new File(".")));
-
-    SessionWriter writer = new SimpleFileWriter(tempDir);
+    withProject.setProject(FileProjectFactory.create(new File(".")).withDekorateOutputDir(tempDir.toAbsolutePath().toString()).withDekorateMetaDir(tempDir.toAbsolutePath().toString()));
+    SessionWriter writer = new SimpleFileWriter(withProject.getProject(), false);
     Session session = Session.getSession();
     session.setWriter(writer);
 

--- a/core/src/main/java/io/dekorate/SessionWriter.java
+++ b/core/src/main/java/io/dekorate/SessionWriter.java
@@ -27,7 +27,7 @@ public interface SessionWriter extends WithProject {
 
   String PACKAGE = "";
   String FILENAME = "%s.%s";
-  String CONFIG = ".config/%s.%s";
+  String CONFIG = "config/%s.%s";
   String PROJECT_ONLY = ".project.%s";
   String PROJECT = "META-INF/dekorate/" + PROJECT_ONLY;
   String[] STRIP = {"^Editable", "BuildConfig$", "Config$"};

--- a/core/src/main/java/io/dekorate/processor/AbstractAnnotationProcessor.java
+++ b/core/src/main/java/io/dekorate/processor/AbstractAnnotationProcessor.java
@@ -76,7 +76,7 @@ public abstract class AbstractAnnotationProcessor extends AbstractProcessor impl
       session.setReader(new AptReader(processingEnv));
     }
     if (!session.hasWriter()) {
-      session.setWriter(new AptWriter(processingEnv));
+      session.setWriter(new AptWriter(getProject(), processingEnv));
     }
     return session;
   }

--- a/core/src/main/java/io/dekorate/processor/AptWriter.java
+++ b/core/src/main/java/io/dekorate/processor/AptWriter.java
@@ -30,12 +30,13 @@ import javax.tools.FileObject;
 import javax.tools.StandardLocation;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.Path;
 import java.util.AbstractMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-public class AptWriter implements SessionWriter, WithProject {
+public class AptWriter extends SimpleFileWriter implements SessionWriter, WithProject {
 
   protected static final String PACKAGE = "";
   protected static final String FILENAME = "%s.%s";
@@ -50,7 +51,8 @@ public class AptWriter implements SessionWriter, WithProject {
   private final ProcessingEnvironment processingEnv;
   private final Logger LOGGER = LoggerFactory.getLogger();
 
-  public AptWriter(ProcessingEnvironment processingEnv) {
+  public AptWriter(Project project, ProcessingEnvironment processingEnv) {
+    super(project);
     this.processingEnv = processingEnv;
   }
 
@@ -67,47 +69,6 @@ public class AptWriter implements SessionWriter, WithProject {
     configurations.forEach(c -> write(c));
     write(getProject());
     return null;
-  }
-
-  /**
-   * Writes a {@link Configuration}.
-   * @param config  The target session configurations.
-   * @return Map Entry containing the file system path of the written configuration and the actual content as the value
-   */
-  public Map.Entry<String, String> write(Configuration config) {
-    try {
-      String name = config.getClass().getSimpleName();
-      for (String s : STRIP) {
-        name = name.replaceAll(s, "");
-      }
-      name = name.toLowerCase();
-      FileObject yml = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, PACKAGE, getProject().getDekorateOutputDir() + "/" + String.format(CONFIG, name, YML));
-      try (Writer writer = yml.openWriter()) {
-        final String value = Serialization.asYaml(config);
-        writer.write(value);
-        return new AbstractMap.SimpleEntry<>(yml.toString(), value);
-      }
-    } catch (IOException e) {
-      throw new RuntimeException("Error writing resources", e);
-    }
-  }
-
-  /**
-   * Writes a {@link Project}.
-   * @param project  The project.
-   * @return Map Entry containing the file system path of the written project and the actual content as the value
-   */
-  public Map.Entry<String, String> write(Project project) {
-    try {
-      FileObject yml = processingEnv.getFiler().createResource(StandardLocation.CLASS_OUTPUT, PACKAGE, String.format(PROJECT, YML));
-      try (Writer writer = yml.openWriter()) {
-        final String value = Serialization.asYaml(project);
-        writer.write(value);
-        return new AbstractMap.SimpleEntry<>(yml.toString(), value);
-      }
-    } catch (IOException e) {
-      throw new RuntimeException("Error writing resources", e);
-    }
   }
 
   /**

--- a/core/src/main/java/io/dekorate/processor/SimpleFileWriter.java
+++ b/core/src/main/java/io/dekorate/processor/SimpleFileWriter.java
@@ -31,15 +31,25 @@ import java.util.Map;
 
 public class SimpleFileWriter implements SessionWriter, WithProject {
 
-  private final Path outputdir;
+  private final Path metaDir;
+  private final Path outputDir;
   private final boolean doWrite;
 
-  public SimpleFileWriter(Path outputdir) {
-    this(outputdir, true);
+  public SimpleFileWriter(Project project) {
+    this(project, true);
   }
 
-  public SimpleFileWriter(Path outputdir, boolean doWrite) {
-    this.outputdir = outputdir;
+  public SimpleFileWriter(Project project, boolean doWrite) {
+    this(project.getBuildInfo().getClassOutputDir().resolve(project.getDekorateMetaDir()), project.getBuildInfo().getClassOutputDir().resolve(project.getDekorateOutputDir()), doWrite);
+  }
+
+  public SimpleFileWriter(Path metaDir, Path outputDir) {
+    this(metaDir, outputDir, true);
+  }
+
+  public SimpleFileWriter(Path metaDir, Path outputDir, boolean doWrite) {
+    this.metaDir = metaDir;
+    this.outputDir = outputDir;
     this.doWrite = doWrite;
   }
 
@@ -55,7 +65,7 @@ public class SimpleFileWriter implements SessionWriter, WithProject {
         name = name.replaceAll(s, "");
       }
       name = name.toLowerCase();
-      final Path yml = outputdir.resolve(String.format(CONFIG, name, YML));
+      final Path yml = metaDir.resolve(String.format(CONFIG, name, YML));
       final String value = Serialization.asYaml(config);
       if (doWrite) {
         yml.toFile().getParentFile().mkdirs();
@@ -78,7 +88,7 @@ public class SimpleFileWriter implements SessionWriter, WithProject {
    */
   public Map.Entry<String, String> write(Project project) {
     try {
-      final Path yml = outputdir.resolve(String.format(PROJECT_ONLY, YML));
+      final Path yml = metaDir.resolve(String.format(PROJECT_ONLY, YML));
       final String value = Serialization.asYaml(project);
       if (doWrite) {
         yml.toFile().getParentFile().mkdirs();
@@ -102,10 +112,11 @@ public class SimpleFileWriter implements SessionWriter, WithProject {
    * @return Map containing the file system paths of the output files as keys and their actual content as the values
    */
   public Map<String, String> write(String group, KubernetesList list) {
+
     try {
       //write json representation
       final Map<String, String> result = new HashMap<>();
-      final Path json = outputdir.resolve(String.format(FILENAME, group, JSON));
+      final Path json = outputDir.resolve(String.format(FILENAME, group, JSON));
       final String jsonValue = Serialization.asJson(list);
       if (doWrite) {
         json.toFile().getParentFile().mkdirs();
@@ -118,7 +129,7 @@ public class SimpleFileWriter implements SessionWriter, WithProject {
       }
 
       //write yml representation
-      final Path yml = outputdir.resolve(String.format(FILENAME, group, YML));
+      final Path yml = outputDir.resolve(String.format(FILENAME, group, YML));
       final String yamlValue = Serialization.asYaml(list);
       if (doWrite) {
         yml.toFile().getParentFile().mkdirs();

--- a/core/src/main/java/io/dekorate/project/Project.java
+++ b/core/src/main/java/io/dekorate/project/Project.java
@@ -30,10 +30,12 @@ import io.sundr.builder.annotations.Buildable;
 public class Project {
 
   private static String DEFAULT_DEKORATE_OUTPUT_DIR = "META-INF/dekorate";
+  private static String DEFAULT_DEKORATE_META_DIR = "../.dekorate";
 
   private final Path root;
   private final String dekorateInputDir;
   private final String dekorateOutputDir;
+  private final String dekorateMetaDir;
   private final BuildInfo buildInfo;
   private final ScmInfo scmInfo;
 
@@ -42,17 +44,18 @@ public class Project {
   }
 
   public Project(Path root, BuildInfo buildInfo, ScmInfo scmInfo) {
-    this(root, null, DEFAULT_DEKORATE_OUTPUT_DIR, buildInfo, scmInfo);
+    this(root, null, DEFAULT_DEKORATE_META_DIR, DEFAULT_DEKORATE_OUTPUT_DIR, buildInfo, scmInfo);
   }
 
-  public Project(Path root, String dekorateInputDir, String dekorateOutputDir, BuildInfo buildInfo) {
-    this(root, dekorateInputDir, dekorateOutputDir, buildInfo, null);
+  public Project(Path root, String dekorateInputDir, String dekorateMetaDir, String dekorateOutputDir, BuildInfo buildInfo) {
+    this(root, dekorateInputDir, dekorateMetaDir, dekorateOutputDir, buildInfo, null);
   }
 
   @Buildable(builderPackage = "io.dekorate.deps.kubernetes.api.builder")
-  public Project(Path root, String dekorateInputDir, String dekorateOutputDir, BuildInfo buildInfo, ScmInfo scmInfo) {
+  public Project(Path root, String dekorateInputDir, String dekorateMetaDir, String dekorateOutputDir, BuildInfo buildInfo, ScmInfo scmInfo) {
     this.root = root;
     this.dekorateInputDir = dekorateInputDir;
+    this.dekorateMetaDir = dekorateMetaDir;
     this.dekorateOutputDir = dekorateOutputDir;
     this.buildInfo = buildInfo;
     this.scmInfo = scmInfo;
@@ -74,16 +77,24 @@ public class Project {
     return dekorateInputDir;
   }
 
+  public String getDekorateMetaDir() {
+    return this.dekorateMetaDir;
+  }
+
   public String getDekorateOutputDir() {
     return dekorateOutputDir;
   }
 
   public Project withDekorateInputDir(String dekorateInputDir) {
-   return new Project(root, dekorateInputDir, dekorateOutputDir, buildInfo);
+      return new Project(root, dekorateInputDir, dekorateMetaDir, dekorateOutputDir, buildInfo);
+  }
+
+  public Project withDekorateMetaDir(String dekorateMetaDir) {
+    return new Project(root, dekorateInputDir, dekorateMetaDir, dekorateOutputDir, buildInfo);
   }
 
   public Project withDekorateOutputDir(String dekorateOutputDir) {
-    return new Project(root, dekorateInputDir, dekorateOutputDir, buildInfo);
+    return new Project(root, dekorateInputDir, dekorateMetaDir, dekorateOutputDir, buildInfo);
   }
 
   public Map<String, Object> parseResourceFile(String resourceName) {

--- a/testing/core-junit/src/main/java/io/dekorate/testing/WithImageConfig.java
+++ b/testing/core-junit/src/main/java/io/dekorate/testing/WithImageConfig.java
@@ -1,42 +1,46 @@
 /**
  * Copyright 2018 The original authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
 **/
 
 package io.dekorate.testing;
 
-import java.net.URL;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.stream.Stream;
 
 import io.dekorate.BuildServiceFactories;
 import io.dekorate.kubernetes.config.ImageConfiguration;
+import io.dekorate.project.Project;
 import io.dekorate.utils.Serialization;
 
 public interface WithImageConfig extends WithProject {
 
-  String DEKORATE_ROOT = "META-INF/dekorate";
-  String CONFIG_PATH = DEKORATE_ROOT + "/.config/%s.yml";
+  String CONFIG_YML = "%s.yml";
+  String CONFIG_DIR = "config";
 
   default <C extends ImageConfiguration> Stream<C> stream(Class<C> type) {
+    final Project project = getProject();
+    final Path configDir = project.getBuildInfo().getClassOutputDir().resolve(project.getDekorateMetaDir()).resolve(CONFIG_DIR);
+
     return BuildServiceFactories.names()
       .stream()
-      .map(n -> String.format(CONFIG_PATH, n))
-      .map(r -> WithImageConfig.class.getClassLoader().getResource(r))
-      .filter(u -> u != null)
-      .map(u -> Serialization.unmarshal(u, ImageConfiguration.class))
+      .map(n -> String.format(CONFIG_YML, n))
+      .map(s -> configDir.resolve(s))
+      .filter(p -> p.toFile().exists())
+      .map(p -> Serialization.unmarshal(p.toFile(), ImageConfiguration.class))
       .filter(BuildServiceFactories.configMatches(getProject()))
       .filter(i -> type.isInstance(i))
       .map(i -> (C) i);
@@ -49,4 +53,5 @@ public interface WithImageConfig extends WithProject {
   default Optional<ImageConfiguration> getImageConfig() {
     return stream(ImageConfiguration.class).findFirst();
   }
+
 }

--- a/testing/core-junit/src/main/java/io/dekorate/testing/WithProject.java
+++ b/testing/core-junit/src/main/java/io/dekorate/testing/WithProject.java
@@ -16,25 +16,28 @@
 package io.dekorate.testing;
 
 import io.dekorate.DekorateException;
+import io.dekorate.project.FileProjectFactory;
 import io.dekorate.project.Project;
 import io.dekorate.utils.Serialization;
 
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
 
 public interface WithProject {
 
-  String PROJECT_DESCRIPTOR_PATH = "META-INF/dekorate/.project.yml";
+  String PROJECT_YML = ".project.yml";
 
   default Project getProject() {
-    return getProject(PROJECT_DESCRIPTOR_PATH);
+    Project p =  new FileProjectFactory().create(new File("."));
+    return getProject(p.getBuildInfo().getClassOutputDir().resolve(p.getDekorateMetaDir()).resolve(PROJECT_YML).toAbsolutePath().toString());
   }
 
   default Project getProject(String projectDescriptorPath) {
-    URL url = WithProject.class.getClassLoader().getResource(projectDescriptorPath);
-    if (url != null) {
-      try (InputStream is = url.openStream())  {
+    System.err.println("Getting project from:" + projectDescriptorPath);
+    if (projectDescriptorPath != null) {
+      try (InputStream is = new FileInputStream(new File(projectDescriptorPath)))  {
         return Serialization.unmarshal(is, Project.class);
       } catch (IOException e) {
         throw DekorateException.launderThrowable(e);


### PR DESCRIPTION
This pull request makes it possible to write manifests outside of target by leveraging the property `dekorate.options.output-path`. 

The property was already available via annotations, but now it can be set from .yml/.property files too.

Also, this pull request moves geenrated metadata in they own special place `../.dekorate` relative to output classes directory.