### PR TITLE
fix: maven & gradle utils return fallback version

### DIFF
--- a/core/src/main/java/io/dekorate/utils/Gradle.java
+++ b/core/src/main/java/io/dekorate/utils/Gradle.java
@@ -30,10 +30,10 @@ public class Gradle {
   public static String GRADLEW = "graldew";
   public static String DASH_VERSION = "-version";
 
-  public static String DOT_GRADLEW = "./" + GRADLEW;
-
   public static String NEW_LINE = "[\\n\\r]+";
   public static String SPACE = " ";
+
+  public static String FALLBACK_GRADLE_VERSION = "6.4";
 
   public static String getVersion(Path modulePath) {
     Path moduleGraldew = modulePath.resolve(GRADLEW);
@@ -52,7 +52,7 @@ public class Gradle {
     }
 
     if (!success) {
-      throw new IllegalStateException("Gradle version check failed!");
+      return FALLBACK_GRADLE_VERSION;
     }
 
     return getVersionFromOutput(new String(out.toByteArray()));

--- a/core/src/main/java/io/dekorate/utils/Maven.java
+++ b/core/src/main/java/io/dekorate/utils/Maven.java
@@ -30,10 +30,10 @@ public class Maven {
   public static String MVNW = "mvnw";
   public static String DASH_VERSION = "-version";
 
-  public static String DOT_MVNW = "./" + MVNW;
-
   public static String NEW_LINE = "[\\n\\r]+";
   public static String SPACE = " ";
+
+  public static String FALLBACK_MAVEN_VERSION = "3.6.3";
 
   public static String getVersion(Path modulePath) {
     Path moduleMvnw = modulePath.resolve(MVNW);
@@ -52,7 +52,7 @@ public class Maven {
     }
 
     if (!success) {
-      throw new IllegalStateException("Maven version check failed!");
+      return FALLBACK_MAVEN_VERSION;
     }
 
     return getVersionFromOutput(new String(out.toByteArray()));


### PR DESCRIPTION
It seems that in some cases the version check command may fail. It's extremely hard to troubleshoot why and that makes for a horrible user experience.

If we can't determine the build tool version, we should assume it. 
We already provide properties for expliclitly setting the version, so users not happy with the fallback version can always change that.