### PR TITLE
feat (#499): Maven workspace is now working

### DIFF
--- a/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/annotation/TektonApplication.java
+++ b/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/annotation/TektonApplication.java
@@ -15,31 +15,18 @@
  */
 package io.dekorate.tekton.annotation;
 
-import io.dekorate.kubernetes.annotation.Annotation;
-import io.dekorate.kubernetes.annotation.AwsElasticBlockStoreVolume;
-import io.dekorate.kubernetes.annotation.AzureDiskVolume;
-import io.dekorate.kubernetes.annotation.AzureFileVolume;
-import io.dekorate.kubernetes.annotation.Container;
-import io.dekorate.kubernetes.annotation.GitRepoVolume;
-import io.dekorate.kubernetes.annotation.ImagePullPolicy;
-import io.dekorate.kubernetes.annotation.Label;
-import io.dekorate.kubernetes.annotation.Mount;
-import io.dekorate.kubernetes.annotation.PersistentVolumeClaimVolume;
-import io.dekorate.kubernetes.annotation.Port;
-import io.dekorate.kubernetes.annotation.Probe;
-import io.dekorate.kubernetes.annotation.SecretVolume;
-import io.dekorate.kubernetes.annotation.ServiceType;
-import io.dekorate.kubernetes.annotation.ConfigMapVolume;
-import io.dekorate.kubernetes.annotation.Env;
-import io.dekorate.kubernetes.config.ApplicationConfiguration;
-import io.sundr.builder.annotations.Adapter;
-import io.sundr.builder.annotations.Buildable;
-import io.sundr.builder.annotations.Pojo;
-
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+
+import io.dekorate.kubernetes.annotation.Annotation;
+import io.dekorate.kubernetes.annotation.Label;
+import io.dekorate.kubernetes.annotation.PersistentVolumeClaim;
+import io.dekorate.kubernetes.config.ApplicationConfiguration;
+import io.sundr.builder.annotations.Adapter;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.Pojo;
 
 
 @Buildable(builderPackage = "io.dekorate.deps.kubernetes.api.builder")
@@ -48,7 +35,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TektonApplication {
 
-  String DEFAULT_ARTIFACT_REPOSITORY_PATH = "/workspaces/maven";
   String DEFAULT_DEPLOYER_IMAGE = "lachlanevenson/k8s-kubectl:v1.18.0";
 
   /**
@@ -107,44 +93,43 @@ public @interface TektonApplication {
    */
   String sourceWorkspace() default "source";
 
-  /*
-   * The name of an existing pvc.
-   * @return The existing PVC or empty string if none is specified.
+  /**
+   * The name of an external PVC to be used for the source workspace.
+   * @return the name or empty String if the PVC is meant to be generated.
    */
-  String sourceWorkspaceClaim() default "";
+  String externalSourceWorkspaceClaim() default "";
 
   /*
-   * The size requirement of the generated PVC in gigs.
-   * This only makes sense for generated PVCs.
-   * @return the size, or 1Gi (default).
-   */
-  int sourceWorkspaceSize() default 1;
-
-  /*
-   * The storage class requirement of the generated PVC
-   * This only makes sense for generated PVCs.
-   * @return the storage class or standard (default).
-   */
-  String sourceWorkspaceStorageClass() default "standard";
+   * The persistent volume claim configuration for the source workspace.
+   * The option only makes sense when the PVC is going to be generated (no external pvc specified).
+   * @return The PVC configuration.
+  */
+  PersistentVolumeClaim sourceWorkspaceClaim() default @PersistentVolumeClaim();
 
   /**
    * The name of workspace to use as a maven artifact repository.
    * @return the workspace name.
    */
-  String artifactRepositoryWorkspace() default "";
+  String m2Workspace() default "m2";
 
   /**
-   * The path where the artifact repository workspace will be mounted.
-   * @return the mounting path.
+   * The name of an external PVC to be used for the m2 artifact repository.
+   * @return the name or empty String if the PVC is meant to be generated.
    */
-  String artifactRepositoryPath() default DEFAULT_ARTIFACT_REPOSITORY_PATH;
+  String externalM2WorkspaceClaim() default "";
+
+  /*
+   * The persistent volume claim configuration for the artifact repository.
+   * The option only makes sense when the PVC is going to be generated (no external pvc specified).
+   * @return The PVC configuration.
+  */
+  PersistentVolumeClaim m2WorkspaceClaim() default @PersistentVolumeClaim();
 
   /**
    * The builder image to use.
    * @return The builder image, or empty if the image should be inferred.
    */
   String builderImage() default "";
-
 
   /*
    * The builder command to use.

--- a/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/decorator/AddPvcToPipelineRunDecorator.java
+++ b/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/decorator/AddPvcToPipelineRunDecorator.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+package io.dekorate.tekton.decorator;
+
+import io.dekorate.deps.kubernetes.api.model.ObjectMeta;
+import io.dekorate.deps.tekton.pipeline.v1beta1.PipelineRunSpecFluent;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+
+public class AddPvcToPipelineRunDecorator extends NamedResourceDecorator<PipelineRunSpecFluent<?>> {
+
+  private final String workspace;
+  private final String claim;
+  private final boolean readOnly;
+
+  public AddPvcToPipelineRunDecorator(String name, String workspace, String claim, boolean readOnly) {
+    super(name);
+    this.workspace = workspace;
+    this.claim = claim;
+    this.readOnly = readOnly;
+  }
+
+  @Override
+  public void andThenVisit(PipelineRunSpecFluent<?> spec, ObjectMeta meta) {
+    spec.addNewWorkspace()
+      .withName(workspace)
+      .withNewPersistentVolumeClaim(claim, readOnly)
+      .endWorkspace();
+  }
+}

--- a/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/decorator/AddPvcToTaskRunDecorator.java
+++ b/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/decorator/AddPvcToTaskRunDecorator.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+package io.dekorate.tekton.decorator;
+
+import io.dekorate.deps.kubernetes.api.model.ObjectMeta;
+import io.dekorate.deps.tekton.pipeline.v1beta1.TaskRunSpecFluent;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+
+public class AddPvcToTaskRunDecorator extends NamedResourceDecorator<TaskRunSpecFluent<?>> {
+
+  private final String workspace;
+  private final String claim;
+  private final boolean readOnly;
+
+  public AddPvcToTaskRunDecorator(String name, String workspace, String claim, boolean readOnly) {
+    super(name);
+    this.workspace = workspace;
+    this.claim = claim;
+    this.readOnly = readOnly;
+  }
+
+  @Override
+  public void andThenVisit(TaskRunSpecFluent<?> spec, ObjectMeta meta) {
+     spec.addNewWorkspace()
+      .withName(workspace)
+      .withNewPersistentVolumeClaim(claim, readOnly)
+      .endWorkspace();
+  }
+}

--- a/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/decorator/AddWorkspaceToPipelineTaskDecorator.java
+++ b/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/decorator/AddWorkspaceToPipelineTaskDecorator.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+package io.dekorate.tekton.decorator;
+
+import io.dekorate.deps.tekton.pipeline.v1beta1.PipelineSpecFluent;
+import io.dekorate.utils.Strings;
+
+public class AddWorkspaceToPipelineTaskDecorator extends NamedPipelineDecorator {
+
+  private final String taskName;
+  private final String id;
+  private final String workspace;
+
+  public AddWorkspaceToPipelineTaskDecorator(String pipelineName, String taskName, String id, String workspace) {
+    super(pipelineName);
+    this.taskName = taskName;
+    this.id = id;
+    this.workspace = workspace;
+  }
+
+  @Override
+  public void andThenVisit(PipelineSpecFluent<?> spec) {
+    //If no task name is specified we need to add the workspace to all pipeline tasks.
+    spec.editMatchingTask(t -> Strings.isNullOrEmpty(taskName) ? true : taskName.equals(t.getName())).addNewWorkspace().withName(id).withWorkspace(workspace).endWorkspace().endTask();
+  }
+}

--- a/core/src/main/java/io/dekorate/kubernetes/annotation/AccessMode.java
+++ b/core/src/main/java/io/dekorate/kubernetes/annotation/AccessMode.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+package io.dekorate.kubernetes.annotation;
+
+public enum AccessMode {
+
+  ReadWriteOnce, // the volume can be mounted as read-write by a single node
+  ReadOnlyMany, // the volume can be mounted read-only by many nodes
+  ReadWriteMany; // the volume can be mounted as read-write by many nodes
+
+}

--- a/core/src/main/java/io/dekorate/kubernetes/annotation/PersistentVolumeClaim.java
+++ b/core/src/main/java/io/dekorate/kubernetes/annotation/PersistentVolumeClaim.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.kubernetes.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.dekorate.kubernetes.config.ApplicationConfiguration;
+import io.sundr.builder.annotations.Adapter;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.Pojo;
+
+
+@Buildable(builderPackage = "io.dekorate.deps.kubernetes.api.builder")
+@Pojo(name = "PersistentVolumeClaimConfig", mutable = true, superClass = ApplicationConfiguration.class, relativePath = "../config", withStaticAdapterMethod = false, adapter = @Adapter(relativePath = "../adapter", withMapAdapterMethod = true))
+@Target({ElementType.CONSTRUCTOR, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PersistentVolumeClaim {
+
+  /*
+   * The name of the claim.
+   * @return the name, or 'source' if no name specified.
+   */
+  String name() default "";
+
+  /*
+   * The size requirement of the generated PVC in gigs.
+   * This only makes sense for generated PVCs.
+   * @return the size, or 1Gi (default).
+   */
+  int size() default 1;
+
+  /*
+   * The unit (e.g. Ki, Mi, Gi) of the generated PVC for the source workspace.
+   * @return The unit, defaults in Gi.
+  */
+  String unit() default "Gi";
+
+  /*
+   * The storage class requirement of the generated PVC
+   * This only makes sense for generated PVCs.
+   * @return the storage class or standard (default).
+   */
+  String storageClass() default "standard";
+
+
+  AccessMode accessMode() default AccessMode.ReadWriteOnce;
+
+  /*
+   * The labels to use as matchLabels in the generated PVC selector.
+   * @return
+   */
+  Label[] matchLabels() default {};
+
+}

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -28,6 +28,7 @@
     <module>spring-boot-with-prometheus-on-kubernetes-example</module>
     <module>spring-boot-with-jaeger-on-kubernetes-example</module>
     <module>spring-boot-with-tekton-example</module>
+    <module>spring-boot-with-tekton-and-m2-pvc-example</module>
     <module>pojo-to-custom-resource-example</module>
     <module>thorntail-on-kubernetes-example</module>
     <module>thorntail-on-openshift-example</module>

--- a/examples/spring-boot-with-tekton-and-m2-pvc-example/Dockerfile
+++ b/examples/spring-boot-with-tekton-and-m2-pvc-example/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:8u171-alpine3.7
+RUN apk --no-cache add curl
+COPY target/*.jar spring-on-kubernetes-example.jar
+CMD java ${JAVA_OPTS} -jar spring-on-kubernetes-example.jar

--- a/examples/spring-boot-with-tekton-and-m2-pvc-example/pom.xml
+++ b/examples/spring-boot-with-tekton-and-m2-pvc-example/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>examples</artifactId>
+    <groupId>io.dekorate</groupId>
+    <version>0.12-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>spring-boot-with-tekton-and-m2-pvc-example</artifactId>
+  <name>Dekorate :: Examples :: Spring Boot with Tekton and m2 PVC</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+
+    <version.spring-boot>2.1.13.RELEASE</version.spring-boot>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>tekton-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-junit-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring-boot}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.maven-failsafe-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <includes>
+                <include>**/*IT.class</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/spring-boot-with-tekton-and-m2-pvc-example/readme.md
+++ b/examples/spring-boot-with-tekton-and-m2-pvc-example/readme.md
@@ -1,0 +1,59 @@
+# Spring Boot on Kubernetes 
+
+The purpose of this example is to demonstrate the following:
+
+- How you can use the kubernetes-spring-stater.
+- How Dekorate detects that this is a web app and automatically configures services and probe.
+- How you can end-to-end test the application.
+- How you can trigger a docker build after the compilation.
+
+
+The application is using:
+
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    
+Which contains all the required modules, including the annotation processors that detect spring web applications.
+
+The [Main.class](src/main/java/io/dekorate/example/sbonkubernetes/Main.java) is annotated with `@KubernetesApplication` which triggers the resource generation.
+It's also annotated with `@EnableDockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
+`dekorate.build=true` to the build for example:
+
+    mvn clean install -Ddekorate.build=true
+
+Note: Dekorate is not going to generate a Dockerfile for you. It expects to find one in the root of the module and it also expects to find the `docker` binary
+pointing to a running docker daemon.
+
+
+The spring web application processor will detect our [Controller.java](src/main/java/io/dekorate/example/sbonkubernetes/Controller.java), and will:
+
+- add container port 8080
+- expose port 8080 as a service
+- add readiness and liveness probes.
+
+## Integration testing
+
+For the purpose of integration testing it includes:
+
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-junit-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+This annotation will bring in the junit5 extension that dekorate provides, that allows you to run integration tests via the '@KubernetesIntegrationTest' annotation.
+The integration test is [SpringBootOnKubernetesIT.java](src/test/java/io/dekorate/example/sbonkubernetes/SpringBootOnKubernetesIT.java) and it demonstrates:
+
+- how you can deploy the application for end to end testing
+- how use can use the kubernetes client from within the test to connect to the application.
+
+The test are going to be automatically run when building the application. For example:
+
+    mvn clean install
+    
+Note: To run the integration tests an actual kubernetes environment is required.
+As the integration test requires a docker build to run, the tests will only run if an existing `Dockerfile` is found, and if the docker daemon used is the one use by kubernetes.

--- a/examples/spring-boot-with-tekton-and-m2-pvc-example/src/main/java/io/dekorate/example/sbonkubernetes/Controller.java
+++ b/examples/spring-boot-with-tekton-and-m2-pvc-example/src/main/java/io/dekorate/example/sbonkubernetes/Controller.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example.sbonkubernetes;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class Controller {
+
+  @RequestMapping("/")
+  public String hello() {
+    return "Hello world";
+  }
+}

--- a/examples/spring-boot-with-tekton-and-m2-pvc-example/src/main/java/io/dekorate/example/sbonkubernetes/Main.java
+++ b/examples/spring-boot-with-tekton-and-m2-pvc-example/src/main/java/io/dekorate/example/sbonkubernetes/Main.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example.sbonkubernetes;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Main.class, args);
+  }
+
+}

--- a/examples/spring-boot-with-tekton-and-m2-pvc-example/src/main/resources/application.properties
+++ b/examples/spring-boot-with-tekton-and-m2-pvc-example/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+dekorate.tekton.m2-workspace-claim.name=m2-pvc
+dekorate.tekton.m2-workspace-claim.size=1
+dekorate.tekton.m2-workspace-claim.unit=Gi
+dekorate.tekton.m2-workspace-claim.matchLables[0].key=volume-type
+dekorate.tekton.m2-workspace-claim.matchLables[0].value=m2

--- a/examples/spring-boot-with-tekton-and-m2-pvc-example/src/test/java/io/dekorate/example/sbonkubernetes/SpringBootWithTektonTest.java
+++ b/examples/spring-boot-with-tekton-and-m2-pvc-example/src/test/java/io/dekorate/example/sbonkubernetes/SpringBootWithTektonTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example.sbonkubernetes;
+
+import io.dekorate.deps.kubernetes.api.model.HasMetadata;
+import io.dekorate.deps.kubernetes.api.model.KubernetesList;
+import io.dekorate.deps.tekton.pipeline.v1beta1.Pipeline;
+import io.dekorate.deps.tekton.pipeline.v1beta1.PipelineRun;
+import io.dekorate.deps.tekton.pipeline.v1beta1.PipelineTask;
+import io.dekorate.deps.tekton.pipeline.v1beta1.Task;
+import io.dekorate.deps.tekton.pipeline.v1beta1.TaskRun;
+import io.dekorate.deps.tekton.pipeline.v1beta1.WorkspaceBinding;
+import io.dekorate.utils.Serialization;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SpringBootWithTektonTest {
+
+  @Test
+  public void shouldContainPipelineWithM2Workspace() {
+    KubernetesList list = Serialization.unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/tekton-pipeline.yml"));
+    assertNotNull(list);
+    Pipeline p = findFirst(list, Pipeline.class).orElseThrow(() -> new IllegalStateException());
+    assertNotNull(p);
+    assertTrue(p.getSpec().getWorkspaces().stream().filter(w -> w.getName().equals("pipeline-m2-ws")).findAny().isPresent(), "Pipeline should contain workspace named 'pipeline-m2-ws'");
+    Optional<PipelineTask> buildTask = findTask("build", p);
+    assertTrue(buildTask.isPresent());
+
+    assertTrue(buildTask.get().getWorkspaces().stream().filter(w -> w.getName().equals("m2") && w.getWorkspace().equals("pipeline-m2-ws")).findAny().isPresent(), "Build task should contain workspace 'm2 -> pipeline-m2-ws'");
+  }
+
+  @Test
+  public void shouldContainPipelineRun() {
+    KubernetesList list = Serialization.unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/tekton-pipeline-run.yml"));
+    assertNotNull(list);
+    PipelineRun p = findFirst(list, PipelineRun.class).orElseThrow(() -> new IllegalStateException());
+    assertNotNull(p);
+    Optional<WorkspaceBinding> binding  = p.getSpec().getWorkspaces().stream().filter(w -> w.getName().equals("pipeline-m2-ws")).findAny();
+    assertTrue(binding.isPresent(), "PipelineRun should contain workspace binding named 'pipeline-m2-ws'");
+    assertEquals(binding.get().getPersistentVolumeClaim().getClaimName(), "m2-pvc");
+  }
+
+  @Test
+  public void shouldContainTaskWithM2Workspace() {
+    KubernetesList list = Serialization.unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/tekton-task.yml"));
+    assertNotNull(list);
+    Task t = findFirst(list, Task.class).orElseThrow(() -> new IllegalStateException());
+    assertNotNull(t);
+    assertTrue(t.getSpec().getWorkspaces().stream().filter(w -> w.getName().equals("m2")).findAny().isPresent(), "Pipeline should contain workspace named 'pipeline-m2-ws'");
+  }
+
+  @Test
+  public void shouldContainTaskRunWithM2PvcBinding() {
+    KubernetesList list = Serialization.unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/tekton-task-run.yml"));
+    assertNotNull(list);
+    TaskRun t = findFirst(list, TaskRun.class).orElseThrow(() -> new IllegalStateException());
+    assertNotNull(t);
+
+    Optional<WorkspaceBinding> binding  = t.getSpec().getWorkspaces().stream().filter(w -> w.getName().equals("m2")).findAny();
+    assertTrue(binding.isPresent(), "PipelineRun should contain workspace binding named 'pipeline-m2-ws'");
+    assertEquals(binding.get().getPersistentVolumeClaim().getClaimName(), "m2-pvc");
+  }
+
+
+  Optional<PipelineTask> findTask(String name, Pipeline p) {
+    return p.getSpec().getTasks().stream().filter(t -> name.equals(t.getName())).findFirst();
+  }
+
+  <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {
+    return (Optional<T>) list.getItems().stream()
+      .filter(i -> t.isInstance(i))
+      .findFirst();
+  }
+}

--- a/examples/spring-boot-with-tekton-example/src/main/resources/application.properties
+++ b/examples/spring-boot-with-tekton-example/src/main/resources/application.properties
@@ -1,2 +1,4 @@
 server.port=9090
-dekorate.docker.group=testme
+dekorate.tekton.source-workspace-claim.name=claim-mine
+dekorate.tekton.source-workspace-claim.match-labels[0].key=foo
+dekorate.tekton.source-workspace-claim.match-labels[0].value=bar


### PR DESCRIPTION
Fixes #499 

The pull request:
- introduces new `@PersistentVolumeClain` annotation for configuring PVCs.
- tekton configuration reuses `@PersistentVolumeClaim` to setup `source and `m2` workspaces.
- adds m2 examples & tests.