### PR TITLE
fix (#507) Prevent NPE when port is not named. Add tests.

### DIFF
--- a/tests/issue-507-spring-boot-server-port/pom.xml
+++ b/tests/issue-507-spring-boot-server-port/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <artifactId>dekorate-tests</artifactId>
+    <groupId>io.dekorate</groupId>
+    <version>0.12-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>issue-507-spring-boot-server-port</artifactId>
+  <name>Dekorate :: Tests :: Annotations :: Kubernetes :: Spring Boot server port #503</name>
+  <description>Spring Boot server.port property is properlly respected</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <inherited>true</inherited>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/issue-507-spring-boot-server-port/src/main/java/io/dekorate/annotationless/DemoApplication.java
+++ b/tests/issue-507-spring-boot-server-port/src/main/java/io/dekorate/annotationless/DemoApplication.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.annotationless;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(DemoApplication.class, args);
+	}
+
+}

--- a/tests/issue-507-spring-boot-server-port/src/main/java/io/dekorate/annotationless/HelloController.java
+++ b/tests/issue-507-spring-boot-server-port/src/main/java/io/dekorate/annotationless/HelloController.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate.annotationless;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+  private static final String HELLO = "hello world!";
+
+    @RequestMapping("/")
+    public String hello() {
+        return HELLO;
+    }
+}

--- a/tests/issue-507-spring-boot-server-port/src/main/resources/application.properties
+++ b/tests/issue-507-spring-boot-server-port/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+server.port=8081
+dekorate.kubernetes.replicas=2
+dekorate.docker.registry=gcr.io
+dekorate.docker.group=mygroup
+dekorate.docker.version=@project.version@

--- a/tests/issue-507-spring-boot-server-port/src/test/java/io/dekorate/annotationless/Issue507Test.java
+++ b/tests/issue-507-spring-boot-server-port/src/test/java/io/dekorate/annotationless/Issue507Test.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dekorate.annotationless;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.deps.kubernetes.api.model.Container;
+import io.dekorate.deps.kubernetes.api.model.HasMetadata;
+import io.dekorate.deps.kubernetes.api.model.KubernetesList;
+import io.dekorate.deps.kubernetes.api.model.apps.Deployment;
+import io.dekorate.utils.Serialization;
+
+public class Issue507Test {
+
+   @Test
+  public void shouldHaveMatchingPortNumber() {
+    KubernetesList list = Serialization.unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/kubernetes.yml"));
+    assertNotNull(list);
+    Deployment d = findFirst(list, Deployment.class).orElseThrow(() -> new IllegalStateException());
+    assertNotNull(d);
+    Container c = d.getSpec().getTemplate().getSpec().getContainers().get(0);
+    assertNotNull(c);
+    assertTrue(c.getPorts().stream().filter(p -> "http".equals(p.getName()) && 8081 == p.getContainerPort()).findAny().isPresent());
+  }
+
+  <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {
+    return (Optional<T>) list.getItems().stream()
+      .filter(i -> t.isInstance(i))
+      .findFirst();
+  }
+
+}

--- a/tests/issue-507-unamed-port/pom.xml
+++ b/tests/issue-507-unamed-port/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <artifactId>dekorate-tests</artifactId>
+    <groupId>io.dekorate</groupId>
+    <version>0.12-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>issue-507-spring-unamed-port</artifactId>
+  <name>Dekorate :: Tests :: Annotations :: Kubernetes :: Unamed port #507</name>
+  <description>Port defintion without a port name is causing NPE</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <inherited>true</inherited>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/issue-507-unamed-port/src/main/java/io/dekorate/annotationless/DemoApplication.java
+++ b/tests/issue-507-unamed-port/src/main/java/io/dekorate/annotationless/DemoApplication.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.annotationless;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(DemoApplication.class, args);
+	}
+
+}

--- a/tests/issue-507-unamed-port/src/main/java/io/dekorate/annotationless/HelloController.java
+++ b/tests/issue-507-unamed-port/src/main/java/io/dekorate/annotationless/HelloController.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate.annotationless;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+  private static final String HELLO = "hello world!";
+
+    @RequestMapping("/")
+    public String hello() {
+        return HELLO;
+    }
+}

--- a/tests/issue-507-unamed-port/src/main/resources/application.properties
+++ b/tests/issue-507-unamed-port/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+dekorate.kubernetes.ports[0].container-port=8082

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -48,6 +48,8 @@
       <module>feat-458-kubernetes-and-openshift-labels</module>
       <module>issue-473-env-from-field</module>
       <module>issue-503-partial-s2i-config</module>
+      <module>issue-507-spring-boot-server-port</module>
+      <module>issue-507-unamed-port</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Fixes: #507 

Also adds test cases, to verify the fix and an additional test to verify `server.port` support.