### PR TITLE
fix (#517) optional is now excluded for env var source and key selector.

### DIFF
--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddEnvVarDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddEnvVarDecorator.java
@@ -90,9 +90,9 @@ public class AddEnvVarDecorator extends ApplicationContainerDecorator<ContainerB
   private void populateFromSecret(ContainerBuilder builder) {
     if (Strings.isNotNullOrEmpty(env.getName()) && Strings.isNotNullOrEmpty(env.getValue())) {
       builder.addNewEnv().withName(env.getName()).withNewValueFrom()
-          .withNewSecretKeyRef(env.getValue(), env.getSecret(), false).endValueFrom().endEnv();
+          .withNewSecretKeyRef(env.getValue(), env.getSecret(), null).endValueFrom().endEnv();
     } else {
-      builder.addNewEnvFrom().withNewSecretRef(env.getSecret(), false).endEnvFrom();
+      builder.addNewEnvFrom().withNewSecretRef(env.getSecret(), null).endEnvFrom();
     }
   }
 
@@ -108,9 +108,9 @@ public class AddEnvVarDecorator extends ApplicationContainerDecorator<ContainerB
   private void populateFromConfigMap(ContainerBuilder builder) {
     if (Strings.isNotNullOrEmpty(env.getName()) && Strings.isNotNullOrEmpty(env.getValue())) {
       builder.addNewEnv().withName(env.getName()).withNewValueFrom()
-          .withNewConfigMapKeyRef(env.getValue(), env.getConfigmap(), false).endValueFrom().endEnv();
+          .withNewConfigMapKeyRef(env.getValue(), env.getConfigmap(), null).endValueFrom().endEnv();
     } else {
-      builder.addNewEnvFrom().withNewConfigMapRef(env.getConfigmap(), false).endEnvFrom();
+      builder.addNewEnvFrom().withNewConfigMapRef(env.getConfigmap(), null).endEnvFrom();
     }
   }
 

--- a/tests/issue-517-exclude-optional/pom.xml
+++ b/tests/issue-517-exclude-optional/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <artifactId>dekorate-tests</artifactId>
+    <groupId>io.dekorate</groupId>
+    <version>0.12-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>issue-517-exclude-optional</artifactId>
+  <name>Dekorate :: Tests :: Annotations :: Kubernetes :: Exclude Optional #517</name>
+  <description>Optional fields is excluded from Key ref and Env Sources</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <inherited>true</inherited>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/issue-517-exclude-optional/src/main/java/io/dekorate/annotationless/DemoApplication.java
+++ b/tests/issue-517-exclude-optional/src/main/java/io/dekorate/annotationless/DemoApplication.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.annotationless;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(DemoApplication.class, args);
+	}
+
+}

--- a/tests/issue-517-exclude-optional/src/main/java/io/dekorate/annotationless/HelloController.java
+++ b/tests/issue-517-exclude-optional/src/main/java/io/dekorate/annotationless/HelloController.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate.annotationless;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+  private static final String HELLO = "hello world!";
+
+    @RequestMapping("/")
+    public String hello() {
+        return HELLO;
+    }
+}

--- a/tests/issue-517-exclude-optional/src/main/resources/application.properties
+++ b/tests/issue-517-exclude-optional/src/main/resources/application.properties
@@ -1,0 +1,12 @@
+dekorate.kubernetes.env-vars[0].name=DB_NAME
+dekorate.kubernetes.env-vars[0].secret=db-secret
+dekorate.kubernetes.env-vars[0].value=db.name
+
+dekorate.kubernetes.env-vars[1].secret=m2-secret
+
+dekorate.kubernetes.env-vars[2].name=DB_NAME
+dekorate.kubernetes.env-vars[2].configmap=db-secret
+dekorate.kubernetes.env-vars[2].value=db.name
+
+dekorate.kubernetes.env-vars[3].configmap=m2-secret
+

--- a/tests/issue-517-exclude-optional/src/test/java/io/dekorate/kubernetes/Issue517Test.java
+++ b/tests/issue-517-exclude-optional/src/test/java/io/dekorate/kubernetes/Issue517Test.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate.kubernetes;
+
+import io.dekorate.utils.Serialization;
+import io.dekorate.utils.Strings;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+
+public class Issue517Test {
+
+  public void shouldNotContainOptional() {
+    String s = Strings.read(Issue517Test.class.getClassLoader().getResourceAsStream("META-INF/dekorate/kubernetes.yml"));
+    assertFalse(s.contains("optional"));
+  }
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -50,6 +50,7 @@
       <module>issue-503-partial-s2i-config</module>
       <module>issue-507-spring-boot-server-port</module>
       <module>issue-507-unamed-port</module>
+      <module>issue-517-exclude-optional</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Fixes #517 

As it was not possible to address the issue on Serialization level, we address just the case with `optional` on decorator level.