### PR TITLE
doc(#538) Automatically bump release version in docs

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -5,6 +5,18 @@
 # curl -s https://raw.githubusercontent.com/shellib/grab/master/install.sh | bash
 #
 
+source $(grab github.com/shellib/cli)
 source $(grab github.com/shellib/maven as maven)
 
+release_version=$(readopt --release-version $*)
+if [ -z $release_version ]; then
+  echo "Option --release_version is required!"
+  exit 1
+fi
+
+# Update the docs with the releae version
+./scripts/ChangeVersion.java readme.md io.dekorate $release_version > readme.md.versionChanged
+mv readme.md.versionChanged reamde.md
+git add readme.md
+git commit -m "doc: Update dekorate version in docs to $release_version"
 maven::release $*

--- a/scripts/ChangeVersion.java
+++ b/scripts/ChangeVersion.java
@@ -1,0 +1,51 @@
+//usr/bin/env jbang "$0" "$@" ; exit $?
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+
+public class ChangeVersion {
+
+  public static void main(String[] args) {
+    if (args.length < 2) {
+      throw new RuntimeException("Usage: ChangeVersion.java <filename> <groupId> <version>");
+
+    }
+    String file = args[0];
+    String groupId = args[1];
+    String version = args[2];
+
+    AtomicBoolean inDependency = new AtomicBoolean();
+    AtomicBoolean inGroupId = new AtomicBoolean();
+
+    AtomicBoolean inPath = new AtomicBoolean();
+
+    try {
+    Files.lines(Paths.get(file))
+      .map(l -> {
+        if (l.contains("<dependency>")) {
+          inDependency.set(true);
+        } else if (l.contains("</dependency>")) {
+          inDependency.set(false);
+          inGroupId.set(false);
+        } else if (l.contains("<path>")) {
+          inPath.set(true);
+        } else if (l.contains("</path>")) {
+          inPath.set(false);
+          inGroupId.set(false);
+        } else if ((inDependency.get() || inPath.get()) && l.contains("<groupId>") && l.contains(groupId)) {
+          inGroupId.set(true);
+        } else if ((inDependency.get() || inPath.get()) && l.contains("<groupId>") && !l.contains(groupId)) {
+          inGroupId.set(false);
+        } else if (inGroupId.get() && l.contains("<version>")) {
+          String trimmed = l.replaceAll("[ ]*", "");
+          return l.replace(trimmed, "<version>"+version+"</version>");
+        } 
+        return l;
+      }).forEach(System.out::println);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
Resolves: #538  

The pull request updates the release script so that it always updates dekorate version in our readme.md.

The script invokes a jbang script that parses line by line and changes the version in all `dependency` and `path` elements that have `io.dekorate` as `groupId`.