### PR TITLE
docs: fix Quarkus kubernetes target folder

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -942,7 +942,7 @@ The extension can be added to any [quarkus](https://quarkus.io) project:
 
     mvn quarkus:add-extension -Dextensions="io.quarkus:quarkus-kubernetes"
     
-After the project compilation the generated manifests will be available under: `target/wiring-classes/META-INF/kubernetes/`.
+After the project compilation the generated manifests will be available under: `target/kubernetes/`.
 
 At the moment this extension will handle ports, health checks etc, with zero configuration from the user side.
 


### PR DESCRIPTION
According to the docs: https://quarkus.io/guides/deploying-to-kubernetes#kubernetes the folder is target/kubernetes