### PR TITLE
Make sure that YAML output doesn't mess with "int" types

### DIFF
--- a/core/src/main/java/io/dekorate/utils/Serialization.java
+++ b/core/src/main/java/io/dekorate/utils/Serialization.java
@@ -51,7 +51,10 @@ public class Serialization {
     configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
     configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, false);
   }};
-  private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory().enable(Feature.MINIMIZE_QUOTES))  {{
+  private static final ObjectMapper YAML_MAPPER = new ObjectMapper(
+    new YAMLFactory()
+      .enable(Feature.MINIMIZE_QUOTES)
+      .enable(Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS))  {{
     configure(SerializationFeature.INDENT_OUTPUT, true);
     configure(SerializationFeature.WRITE_NULL_MAP_VALUES, false);
     configure(SerializationFeature.WRITE_EMPTY_JSON_ARRAYS, false);


### PR DESCRIPTION
Currently, when outputting YAML, int values that are in strings, don't have quotes, causing issues
when the generated manifests are applied

Relates to: 
https://github.com/quarkusio/quarkus/issues/11134
https://github.com/quarkusio/quarkus/issues/11431