### PR TITLE
feat (#609): Allow adding/removing labels to/from selectors

### DIFF
--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/handler/KnativeHandler.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/handler/KnativeHandler.java
@@ -209,7 +209,7 @@ public class KnativeHandler extends AbstractKubernetesHandler<KnativeConfig> imp
                         : imageConfig.getRegistry(),
                     imageConfig.getGroup(), imageConfig.getName(), imageConfig.getVersion());
 
-    return new ServiceBuilder().withNewMetadata().withName(config.getName()).withLabels(Labels.createLabels(config))
+    return new ServiceBuilder().withNewMetadata().withName(config.getName())
         .endMetadata().withNewSpec().withNewTemplate().withNewSpec().addNewContainer().withName(config.getName())
         .withImage(image).endContainer().endSpec().endTemplate().endSpec().build();
   }

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/handler/KubernetesHandler.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/handler/KubernetesHandler.java
@@ -46,7 +46,6 @@ import io.dekorate.kubernetes.decorator.AddServiceResourceDecorator;
 import io.dekorate.kubernetes.decorator.ApplyDeploymentStrategyDecorator;
 import io.dekorate.kubernetes.decorator.ApplyHeadlessDecorator;
 import io.dekorate.kubernetes.decorator.ApplyImageDecorator;
-import io.dekorate.kubernetes.decorator.ApplyLabelSelectorDecorator;
 import io.dekorate.kubernetes.decorator.ApplyReplicasDecorator;
 import io.dekorate.project.ApplyProjectInfo;
 import io.dekorate.project.Project;
@@ -163,7 +162,6 @@ public class KubernetesHandler extends AbstractKubernetesHandler<KubernetesConfi
         resources.decorate(group, new AddIngressRuleDecorator(config.getName(), config.getHost(), p));
     });
 
-    resources.decorate(group, new ApplyLabelSelectorDecorator(createSelector(config)));
   }
 
   /**

--- a/annotations/openshift-annotations/pom.xml
+++ b/annotations/openshift-annotations/pom.xml
@@ -170,7 +170,7 @@ limitations under the License.
                     <include>io/dekorate/openshift/listener/**</include>
                     <include>io/dekorate/openshift/util/**</include>
                     <include>io/dekorate/openshift/*</include>
-                    <include>META-INF/services/io.dekorate.Generator</include>
+                    <include>META-INF/services/io.dekorate.*</include>
                     <include>META-INF/MANIFEST.MF</include>
                   </includes>
                 </filter>

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/AddLabelToDeploymentConfigSelectorDecorator.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/AddLabelToDeploymentConfigSelectorDecorator.java
@@ -1,0 +1,35 @@
+
+package io.dekorate.openshift.decorator;
+
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.openshift.api.model.DeploymentConfigSpecFluent;
+
+public class AddLabelToDeploymentConfigSelectorDecorator extends NamedResourceDecorator<DeploymentConfigSpecFluent<?>> {
+
+  private String key;
+  private String value;
+
+ 	public AddLabelToDeploymentConfigSelectorDecorator(String name, String key, String value) {
+		super(name);
+		this.key = key;
+		this.value = value;
+	}
+
+	public AddLabelToDeploymentConfigSelectorDecorator(String kind, String name, String key, String value) {
+		super(kind, name);
+		this.key = key;
+		this.value = value;
+	}   
+
+	@Override
+	public void andThenVisit(DeploymentConfigSpecFluent<?> spec, ObjectMeta resourceMeta) {
+    spec.addToSelector(key, value);
+	}
+
+	@Override
+	public Class<? extends Decorator>[] before() {
+		return new Class[] { RemoveLabelFromDeploymentConfigSelectorDecorator.class };
+	}
+}

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/DeploymentConfigSelectorDecoratorFactory.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/DeploymentConfigSelectorDecoratorFactory.java
@@ -1,0 +1,23 @@
+
+package io.dekorate.openshift.decorator;
+
+import io.dekorate.SelectorDecoratorFactory;
+
+public class DeploymentConfigSelectorDecoratorFactory implements SelectorDecoratorFactory {
+
+  @Override
+  public AddLabelToDeploymentConfigSelectorDecorator createAddToSelectorDecorator(String name, String key,
+      String value) {
+    return new AddLabelToDeploymentConfigSelectorDecorator(name, key, value);
+  }
+
+  @Override
+  public RemoveLabelFromDeploymentConfigSelectorDecorator createRemoveFromSelectorDecorator(String name, String key) {
+    return new RemoveLabelFromDeploymentConfigSelectorDecorator(name, key);
+  }
+
+  @Override
+  public String kind() {
+    return "DeploymentConfig";
+  }
+}

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/RemoveLabelFromDeploymentConfigSelectorDecorator.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/RemoveLabelFromDeploymentConfigSelectorDecorator.java
@@ -1,0 +1,31 @@
+package io.dekorate.openshift.decorator;
+
+import io.dekorate.kubernetes.decorator.Decorator;
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.openshift.api.model.DeploymentConfigSpecFluent;
+
+public class RemoveLabelFromDeploymentConfigSelectorDecorator extends NamedResourceDecorator<DeploymentConfigSpecFluent<?>> {
+
+  private String key;
+
+ 	public RemoveLabelFromDeploymentConfigSelectorDecorator(String name, String key) {
+		super(name);
+		this.key = key;
+	}
+
+	public RemoveLabelFromDeploymentConfigSelectorDecorator(String kind, String name, String key) {
+		super(kind, name);
+		this.key = key;
+	}   
+
+	@Override
+	public void andThenVisit(DeploymentConfigSpecFluent<?> spec, ObjectMeta resourceMeta) {
+    spec.removeFromSelector(key);
+	}
+
+	@Override
+	public Class<? extends Decorator>[] before() {
+		return new Class[] { AddLabelToDeploymentConfigSelectorDecorator.class };
+	}
+}

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/handler/OpenshiftHandler.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/handler/OpenshiftHandler.java
@@ -166,17 +166,13 @@ public class OpenshiftHandler extends AbstractKubernetesHandler<OpenshiftConfig>
    * @return          The deployment config.
    */
   public DeploymentConfig createDeploymentConfig(OpenshiftConfig config, ImageConfiguration imageConfig)  {
-    Map<String, String> labels = Labels.createLabels(config);
-
     return new DeploymentConfigBuilder()
       .withNewMetadata()
       .withName(config.getName())
-      .withLabels(labels)
       .endMetadata()
       .withNewSpec()
       .withReplicas(1)
-      .withTemplate(createPodTemplateSpec(config, imageConfig, labels))
-      .withSelector(labels)
+      .withTemplate(createPodTemplateSpec(config, imageConfig))
       .endSpec()
       .build();
   }
@@ -186,11 +182,10 @@ public class OpenshiftHandler extends AbstractKubernetesHandler<OpenshiftConfig>
    * @param config   The sesssion.
    * @return          The pod template specification.
    */
-  public PodTemplateSpec createPodTemplateSpec(OpenshiftConfig config, ImageConfiguration imageConfig, Map<String, String> labels) {
+  public PodTemplateSpec createPodTemplateSpec(OpenshiftConfig config, ImageConfiguration imageConfig) {
     return new PodTemplateSpecBuilder()
       .withSpec(createPodSpec(config, imageConfig))
       .withNewMetadata()
-      .withLabels(labels)
       .endMetadata()
       .build();
   }

--- a/annotations/openshift-annotations/src/main/resources/META-INF/services/io.dekorate.SelectorDecoratorFactory
+++ b/annotations/openshift-annotations/src/main/resources/META-INF/services/io.dekorate.SelectorDecoratorFactory
@@ -1,0 +1,1 @@
+io.dekorate.openshift.decorator.DeploymentConfigSelectorDecoratorFactory

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/decorator/AddBuildConfigResourceDecorator.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/decorator/AddBuildConfigResourceDecorator.java
@@ -55,7 +55,7 @@ public class AddBuildConfigResourceDecorator extends ResourceProvidingDecorator<
 
     //First we need to consult the labels
     String fallbackVersion = Strings.isNotNullOrEmpty(config.getVersion()) ? config.getVersion() : LATEST;
-    String version = meta.getLabels().getOrDefault(Labels.VERSION, fallbackVersion);
+    String version = meta.getLabels() != null ? meta.getLabels().getOrDefault(Labels.VERSION, fallbackVersion) : fallbackVersion;
 
     if (contains(list, "build.openshift.io/v1", "BuildConfig", config.getName())) {
       return;

--- a/core/src/main/java/io/dekorate/AbstractKubernetesHandler.java
+++ b/core/src/main/java/io/dekorate/AbstractKubernetesHandler.java
@@ -15,6 +15,10 @@
  */
 package io.dekorate;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import io.dekorate.kubernetes.annotation.ImagePullPolicy;
 import io.dekorate.kubernetes.config.Annotation;
 import io.dekorate.kubernetes.config.AwsElasticBlockStoreVolume;
@@ -45,11 +49,13 @@ import io.dekorate.kubernetes.decorator.AddPvcVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddReadinessProbeDecorator;
 import io.dekorate.kubernetes.decorator.AddSecretVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddSidecarDecorator;
+import io.dekorate.kubernetes.decorator.AddToSelectorDecorator;
 import io.dekorate.kubernetes.decorator.AddVcsUrlAnnotationDecorator;
 import io.dekorate.kubernetes.decorator.ApplyArgsDecorator;
 import io.dekorate.kubernetes.decorator.ApplyCommandDecorator;
 import io.dekorate.kubernetes.decorator.ApplyImagePullPolicyDecorator;
 import io.dekorate.kubernetes.decorator.ApplyServiceAccountNamedDecorator;
+import io.dekorate.utils.Labels;
 import io.dekorate.utils.Probes;
 import io.dekorate.utils.Strings;
 
@@ -98,9 +104,11 @@ public abstract class AbstractKubernetesHandler<C extends BaseConfig> implements
     resources.decorate(new AddVcsUrlAnnotationDecorator());
     resources.decorate(new AddCommitIdAnnotationDecorator());
 
-    for (Label label : config.getLabels()) {
-      resources.decorate(new AddLabelDecorator(label));
-    }
+    Labels.createLabels(config).forEach( (k,v) -> {
+            resources.decorate(group, new AddLabelDecorator(new Label(k,v)));
+            resources.decorate(group, new AddToSelectorDecorator(k, v));
+    });
+
     for (Annotation annotation : config.getAnnotations()) {
       resources.decorate(new AddAnnotationDecorator(annotation));
     }

--- a/core/src/main/java/io/dekorate/SelectorDecoratorFactories.java
+++ b/core/src/main/java/io/dekorate/SelectorDecoratorFactories.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2020 Original Authors
+ *     
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+package io.dekorate;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+public class SelectorDecoratorFactories {
+
+  public static Optional<SelectorDecoratorFactory> find(String kind) {
+    return stream().filter(s -> s.kind().equalsIgnoreCase(kind)).findFirst();
+  }
+    
+  private static Stream<SelectorDecoratorFactory> stream() {
+     ServiceLoader<SelectorDecoratorFactory> loader = ServiceLoader.load(SelectorDecoratorFactory.class, SelectorDecoratorFactory.class.getClassLoader());
+     return StreamSupport.stream(loader.spliterator(), false);
+  }
+
+
+}

--- a/core/src/main/java/io/dekorate/SelectorDecoratorFactory.java
+++ b/core/src/main/java/io/dekorate/SelectorDecoratorFactory.java
@@ -1,0 +1,17 @@
+
+package io.dekorate;
+
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+
+/**
+ * A factory for creating {@link SelectorDecorator} instances.
+ */
+public interface SelectorDecoratorFactory {
+
+  String kind();
+
+ <D extends NamedResourceDecorator<?>> D createAddToSelectorDecorator(String name, String key, String value); 
+
+ <D extends NamedResourceDecorator<?>> D createRemoveFromSelectorDecorator(String name, String key); 
+  
+}

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddLabelDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddLabelDecorator.java
@@ -15,16 +15,17 @@
  */
 package io.dekorate.kubernetes.decorator;
 
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.dekorate.doc.Description;
 import io.dekorate.kubernetes.config.Label;
+import io.dekorate.utils.Metadata;
 
 /**
  * A decorator that adds a label to resources.
  */
 @Description("Add a label to the all metadata.")
-public class AddLabelDecorator extends NamedResourceDecorator<ObjectMetaBuilder> {
+public class AddLabelDecorator extends NamedResourceDecorator<VisitableBuilder> {
 
   private final Label label;
 
@@ -42,8 +43,8 @@ public class AddLabelDecorator extends NamedResourceDecorator<ObjectMetaBuilder>
   }
 
   @Override
-  public void andThenVisit(ObjectMetaBuilder builder, ObjectMeta resourceMeta) {
-    builder.addToLabels(label.getKey(), label.getValue());
+  public void andThenVisit(VisitableBuilder builder, ObjectMeta resourceMeta) {
+    Metadata.addToLabels(builder, label.getKey(), label.getValue());
   }
 
   public Label getLabel() {

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddLabelToServiceSelectorDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddLabelToServiceSelectorDecorator.java
@@ -1,0 +1,34 @@
+
+package io.dekorate.kubernetes.decorator;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ServiceSpecFluent;
+
+public class AddLabelToServiceSelectorDecorator extends NamedResourceDecorator<ServiceSpecFluent<?>> {
+
+  private String key;
+  private String value;
+
+ 	public AddLabelToServiceSelectorDecorator(String name, String key, String value) {
+		super(name);
+		this.key = key;
+		this.value = value;
+	}
+
+	public AddLabelToServiceSelectorDecorator(String kind, String name, String key, String value) {
+		super(kind, name);
+		this.key = key;
+		this.value = value;
+	}   
+
+	@Override
+	public void andThenVisit(ServiceSpecFluent<?> spec, ObjectMeta resourceMeta) {
+    spec.addToSelector(key, value);
+	}
+
+	@Override
+	public Class<? extends Decorator>[] before() {
+		return new Class[] { RemoveLabelFromServiceSelectorDecorator.class };
+	}
+ 
+}

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddToMatchingLabelsDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddToMatchingLabelsDecorator.java
@@ -1,0 +1,33 @@
+
+package io.dekorate.kubernetes.decorator;
+
+import io.fabric8.kubernetes.api.model.LabelSelectorFluent;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+public class AddToMatchingLabelsDecorator extends NamedResourceDecorator<LabelSelectorFluent<?>> {
+
+  private String key;
+  private String value;
+
+ 	public AddToMatchingLabelsDecorator(String name, String key, String value) {
+		super(name);
+		this.key = key;
+		this.value = value;
+  }
+
+	public AddToMatchingLabelsDecorator(String kind, String name, String key, String value) {
+		super(kind, name);
+		this.key = key;
+		this.value = value;
+	}   
+
+	@Override
+	public void andThenVisit(LabelSelectorFluent<?> selector, ObjectMeta resourceMeta) {
+    selector.addToMatchLabels(key, value);
+	}
+
+  @Override
+  public Class<? extends Decorator>[] after() {
+    return new Class[] { ApplyLabelSelectorDecorator.class };
+  }
+}

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddToSelectorDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddToSelectorDecorator.java
@@ -29,6 +29,12 @@ public class AddToSelectorDecorator extends NamedResourceDecorator<VisitableBuil
   private final String key;
   private final String value;
 
+	public AddToSelectorDecorator(String key, String value) {
+		super(ANY);
+		this.key = key;
+		this.value = value;
+	}
+
 	public AddToSelectorDecorator(String name, String key, String value) {
 		super(name);
 		this.key = key;

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddToSelectorDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddToSelectorDecorator.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (C) 2020 Original Authors
+ *     
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+package io.dekorate.kubernetes.decorator;
+
+import java.util.Optional;
+
+import io.dekorate.SelectorDecoratorFactories;
+import io.dekorate.SelectorDecoratorFactory;
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+public class AddToSelectorDecorator extends NamedResourceDecorator<VisitableBuilder> {
+
+  private final String key;
+  private final String value;
+
+	public AddToSelectorDecorator(String name, String key, String value) {
+		super(name);
+		this.key = key;
+		this.value = value;
+	}
+
+	public AddToSelectorDecorator(String kind, String name, String key, String value) {
+		super(kind, name);
+		this.key = key;
+		this.value = value;
+	}
+
+
+	@Override
+	public void andThenVisit(VisitableBuilder builder ,String kind, ObjectMeta resourceMeta) {
+    Optional<SelectorDecoratorFactory> factory = SelectorDecoratorFactories.find(kind);
+    factory.ifPresent(f -> f.createAddToSelectorDecorator(resourceMeta.getName(), key, value));
+	}
+
+	@Override
+	public void andThenVisit(VisitableBuilder item, ObjectMeta resourceMeta) {
+    //Not needed
+	}
+}

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/RemoveFromMatchingLabelsDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/RemoveFromMatchingLabelsDecorator.java
@@ -1,0 +1,29 @@
+package io.dekorate.kubernetes.decorator;
+
+import io.fabric8.kubernetes.api.model.LabelSelectorFluent;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+public class RemoveFromMatchingLabelsDecorator extends NamedResourceDecorator<LabelSelectorFluent<?>> {
+
+  private String key;
+
+  public RemoveFromMatchingLabelsDecorator(String name, String key) {
+    super(name);
+    this.key = key;
+  }
+
+  public RemoveFromMatchingLabelsDecorator(String kind, String name, String key) {
+    super(kind, name);
+    this.key = key;
+  }
+
+  @Override
+  public void andThenVisit(LabelSelectorFluent<?> selector, ObjectMeta resourceMeta) {
+    selector.removeFromMatchLabels(key);
+  }
+
+  @Override
+  public Class<? extends Decorator>[] after() {
+    return new Class[] { ApplyLabelSelectorDecorator.class };
+  }
+}

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/RemoveFromSelectorDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/RemoveFromSelectorDecorator.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (C) 2020 Original Authors
+ *     
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+**/
+
+package io.dekorate.kubernetes.decorator;
+
+import java.util.Optional;
+
+import io.dekorate.SelectorDecoratorFactories;
+import io.dekorate.SelectorDecoratorFactory;
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+public class RemoveFromSelectorDecorator extends NamedResourceDecorator<VisitableBuilder> {
+
+  private final String key;
+
+	public RemoveFromSelectorDecorator(String name, String key) {
+		super(name);
+		this.key = key;
+	}
+
+	public RemoveFromSelectorDecorator(String kind, String name, String key) {
+		super(kind, name);
+		this.key = key;
+	}
+
+
+	@Override
+	public void andThenVisit(VisitableBuilder builder ,String kind, ObjectMeta resourceMeta) {
+    Optional<SelectorDecoratorFactory> factory = SelectorDecoratorFactories.find(kind);
+    factory.ifPresent(f -> f.createRemoveFromSelectorDecorator(resourceMeta.getName(), key));
+	}
+
+	@Override
+	public void andThenVisit(VisitableBuilder item, ObjectMeta resourceMeta) {
+    //Not needed
+	}
+}

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/RemoveLabelDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/RemoveLabelDecorator.java
@@ -15,15 +15,16 @@
  */
 package io.dekorate.kubernetes.decorator;
 
+import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
-import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.dekorate.doc.Description;
+import io.dekorate.utils.Metadata;
 
 /**
  * A decorator that removes a label.
  */
 @Description("Remove a label from the all metadata.")
-public class RemoveLabelDecorator extends NamedResourceDecorator<ObjectMetaBuilder> {
+public class RemoveLabelDecorator extends NamedResourceDecorator<VisitableBuilder> {
 
   private final String labelKey;
 
@@ -37,8 +38,8 @@ public class RemoveLabelDecorator extends NamedResourceDecorator<ObjectMetaBuild
   }
 
   @Override
-  public void andThenVisit(ObjectMetaBuilder builder, ObjectMeta resourceMeta) {
-    builder.removeFromLabels(labelKey);
+  public void andThenVisit(VisitableBuilder builder, ObjectMeta resourceMeta) {
+    Metadata.removeFromLabels(builder, labelKey);
   }
 
   public String getLabelKey() {

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/RemoveLabelFromServiceSelectorDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/RemoveLabelFromServiceSelectorDecorator.java
@@ -1,0 +1,30 @@
+package io.dekorate.kubernetes.decorator;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ServiceSpecFluent;
+
+public class RemoveLabelFromServiceSelectorDecorator extends NamedResourceDecorator<ServiceSpecFluent<?>> {
+
+  private String key;
+
+ 	public RemoveLabelFromServiceSelectorDecorator(String name, String key) {
+		super(name);
+		this.key = key;
+	}
+
+	public RemoveLabelFromServiceSelectorDecorator(String kind, String name, String key) {
+		super(kind, name);
+		this.key = key;
+	}   
+
+	@Override
+	public void andThenVisit(ServiceSpecFluent<?> spec, ObjectMeta resourceMeta) {
+    spec.removeFromSelector(key);
+	}
+
+	@Override
+	public Class<? extends Decorator>[] after() {
+		return new Class[] { AddLabelToServiceSelectorDecorator.class };
+	}
+  
+}

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ServiceSelectorDecoratorFactory.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ServiceSelectorDecoratorFactory.java
@@ -1,0 +1,22 @@
+
+package io.dekorate.kubernetes.decorator;
+
+import io.dekorate.SelectorDecoratorFactory;
+
+public class ServiceSelectorDecoratorFactory implements SelectorDecoratorFactory {
+
+  @Override
+  public AddLabelToServiceSelectorDecorator createAddToSelectorDecorator(String name, String key, String value) {
+    return new AddLabelToServiceSelectorDecorator(name, key, value);
+  }
+
+  @Override
+  public RemoveLabelFromServiceSelectorDecorator createRemoveFromSelectorDecorator(String name, String key) {
+    return new RemoveLabelFromServiceSelectorDecorator(name, key);
+  }
+
+  @Override
+  public String kind() {
+    return "Service";
+  }
+}

--- a/core/src/main/java/io/dekorate/utils/Metadata.java
+++ b/core/src/main/java/io/dekorate/utils/Metadata.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.builder.Predicate;
 import io.fabric8.kubernetes.api.builder.VisitableBuilder;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.ObjectMetaFluent;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -52,6 +53,40 @@ public class Metadata {
       //ignore
     }
     return Optional.empty();
+  }
+
+  public static boolean addToLabels(Builder builder, String key, String value) {
+    try {
+      Method editMethod = builder.getClass().getMethod("editOrNewMetadata");
+      Object o = editMethod.invoke(builder);
+      if (o instanceof ObjectMetaFluent) {
+        ObjectMetaFluent fluent = (ObjectMetaFluent) o;
+        fluent.addToLabels(key, value);
+        Method endMethod = fluent.getClass().getMethod("endMetadata");
+        endMethod.invoke(fluent);
+        return true;
+      }
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      //ignore
+    }
+    return false;
+  }
+
+  public static boolean removeFromLabels(Builder builder, String key) {
+    try {
+      Method editMethod = builder.getClass().getMethod("editOrNewMetadata");
+      Object o = editMethod.invoke(builder);
+      if (o instanceof ObjectMetaFluent) {
+        ObjectMetaFluent fluent = (ObjectMetaFluent) o;
+        fluent.removeFromLabels(key);
+        Method endMethod = fluent.getClass().getMethod("endMetadata");
+        endMethod.invoke(fluent);
+        return true;
+      }
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      //ignore
+    }
+    return false;
   }
 
   /**

--- a/core/src/main/resources/META-INF/services/io.dekorate.SelectorDecoratorFactory
+++ b/core/src/main/resources/META-INF/services/io.dekorate.SelectorDecoratorFactory
@@ -1,1 +1,1 @@
-io.dekorate.kubernetes.dekorator.ServiceSelectorDecoratorFactory
+io.dekorate.kubernetes.decorator.ServiceSelectorDecoratorFactory

--- a/core/src/main/resources/META-INF/services/io.dekorate.SelectorDecoratorFactory
+++ b/core/src/main/resources/META-INF/services/io.dekorate.SelectorDecoratorFactory
@@ -1,0 +1,1 @@
+io.dekorate.kubernetes.dekorator.ServiceSelectorDecoratorFactory

--- a/examples/halkyon-example/src/test/java/io/dekorate/examples/ComponentSpringBootExampleTest.java
+++ b/examples/halkyon-example/src/test/java/io/dekorate/examples/ComponentSpringBootExampleTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ComponentSpringBootExampleTest {
   
@@ -38,7 +37,7 @@ public class ComponentSpringBootExampleTest {
     Component component = (Component) items.get(0);
     assertEquals("Component", component.getKind());
     assertEquals("halkyon-example", component.getMetadata().getName());
-    assertEquals(1, component.getMetadata().getLabels().size());
+    assertEquals(2, component.getMetadata().getLabels().size());
     assertNotNull(component.getSpec().getBuildConfig());
     assertNotNull(component.getSpec().getBuildConfig().getUrl());
   }


### PR DESCRIPTION
The pull request introduces a more fine grained control over labels and selectors.
Up until now, labels and selectors were `hardcoded` in the base resources created by dekorate.

- Adding or removing labels didn't have any impact on selectors.
- Labels were not added in the provided resources.
- There was no single way to decorate selectors.

The pull request changes all three items above:
- Added and SPI for managing selector decorators
- Added a generic add/remove selector decorator.
- Labels are now added via decorators