### PR TITLE
Kubernetes Container Resources

### DIFF
--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyLimitsMemoryDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyLimitsMemoryDecorator.java
@@ -21,7 +21,7 @@ import io.fabric8.kubernetes.api.model.Quantity;
 
 public class ApplyLimitsMemoryDecorator extends ApplicationContainerDecorator<ContainerFluent<?>> {
 
-  private static final String MEM = "mem";
+  private static final String MEM = "memory";
 
   private final String amount;
 

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyRequestsMemoryDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyRequestsMemoryDecorator.java
@@ -21,7 +21,7 @@ import io.fabric8.kubernetes.api.model.Quantity;
 
 public class ApplyRequestsMemoryDecorator extends ApplicationContainerDecorator<ContainerFluent<?>> {
 
-  private static final String MEM = "mem";
+  private static final String MEM = "memory";
 
   private final String amount;
 

--- a/tests/feat-429-container-resources/src/test/java/io/dekorate/annotationless/Feat429Test.java
+++ b/tests/feat-429-container-resources/src/test/java/io/dekorate/annotationless/Feat429Test.java
@@ -40,9 +40,9 @@ public class Feat429Test {
     Container c = d.getSpec().getTemplate().getSpec().getContainers().get(0);
     assertNotNull(c);
     assertEquals("100m", c.getResources().getRequests().get("cpu").toString());
-    assertEquals("64Mi", c.getResources().getRequests().get("mem").toString());
+    assertEquals("64Mi", c.getResources().getRequests().get("memory").toString());
     assertEquals("500m", c.getResources().getLimits().get("cpu").toString());
-    assertEquals("256Mi", c.getResources().getLimits().get("mem").toString());
+    assertEquals("256Mi", c.getResources().getLimits().get("memory").toString());
   }
 
   <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {


### PR DESCRIPTION
As stated here : https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/

The generated resources for memory limits/requests should be "memory" and not "mem"

Signed-off-by: Vincent Sourtin <sourin-v@bridgestone-bae.com>