### PR TITLE
Fix typo in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -994,7 +994,7 @@ dekorate.kubernetes.expose=true
 An alternative way of configuration is via `application properties`:
 
 ```
-dekorate.kubernetes.expose=true
+dekorate.openshift.expose=true
 ```
 
 There are cases where the `Ingress` or `Route` host needs to be customized. This is done using the `host` parametes either via annotation or property configuration.


### PR DESCRIPTION
This fix the typo in `readme.md`