### PR TITLE
feature: use default registry if registry value absent

### DIFF
--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/handler/KubernetesHandler.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/handler/KubernetesHandler.java
@@ -247,7 +247,7 @@ public class KubernetesHandler extends AbstractKubernetesHandler<KubernetesConfi
         .withGroup(imageConfig.getGroup() != null ? imageConfig.getGroup() : null)
         .withName(imageConfig.getName() != null ? imageConfig.getName() : appConfig.getName())
         .withVersion(imageConfig.getVersion() != null ? imageConfig.getVersion() : appConfig.getVersion())
-        .withRegistry(imageConfig.getRegistry() != null ? imageConfig.getRegistry() : null)
+        .withRegistry(imageConfig.getRegistry() != null ? imageConfig.getRegistry() : DEFAULT_REGISTRY)
         .withDockerFile(imageConfig.getDockerFile() != null ? imageConfig.getDockerFile() : "Dockerfile")
         .withAutoBuildEnabled(imageConfig.isAutoBuildEnabled() ? imageConfig.isAutoBuildEnabled() : false)
         .withAutoPushEnabled(imageConfig.isAutoPushEnabled() ? imageConfig.isAutoPushEnabled() : false)


### PR DESCRIPTION
I think we should use `DEFAULT_REGISTRY` if no value provided for registry, as done in OpenShiftHandler. WDYT, @iocanel ?