### PR TITLE
chore: Add link do contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+## Contributing to the Dekorate
+
+Contribution guide is maintained in [documentation folder](./assets/contributor-guidelines.md)


### PR DESCRIPTION
## Motivation

Contributing.md is standard for github repositories. I did not want to move file from original assets folder as there is value of keeping the docs in the same folder. That is why we adding contributing guide but linking to the other document. 

