### PR TITLE
Align group, name and version

### DIFF
--- a/annotations/docker-annotations/src/main/java/io/dekorate/docker/config/DefaultDockerBuildConfigGenerator.java
+++ b/annotations/docker-annotations/src/main/java/io/dekorate/docker/config/DefaultDockerBuildConfigGenerator.java
@@ -18,19 +18,20 @@
 package io.dekorate.docker.config;
 
 import io.dekorate.ConfigurationRegistry;
+import io.dekorate.WithProject;
 import io.dekorate.config.DefaultConfiguration;
 import io.dekorate.project.ApplyProjectInfo;
 import io.dekorate.kubernetes.configurator.ApplyBuildToImageConfiguration;
 
-public class DefaultDockerBuildConfigGenerator implements DockerBuildConfigGenerator {
+public class DefaultDockerBuildConfigGenerator implements DockerBuildConfigGenerator, WithProject {
 
   private final ConfigurationRegistry configurationRegistry;
 
   public DefaultDockerBuildConfigGenerator(ConfigurationRegistry configurationRegistry) {
     this.configurationRegistry = configurationRegistry;
-    on(new DefaultConfiguration<DockerBuildConfig>(new DockerBuildConfigBuilder()
-        .accept(new ApplyProjectInfo(getProject()))
-        .accept(new ApplyBuildToImageConfiguration())));
+    this.configurationRegistry.add(new ApplyProjectInfo(getProject()));
+    this.configurationRegistry.add(new ApplyBuildToImageConfiguration());
+    on(new DefaultConfiguration<DockerBuildConfig>(new DockerBuildConfigBuilder()));
   }
 
   @Override

--- a/annotations/docker-annotations/src/main/java/io/dekorate/docker/config/DockerBuildConfigGenerator.java
+++ b/annotations/docker-annotations/src/main/java/io/dekorate/docker/config/DockerBuildConfigGenerator.java
@@ -20,18 +20,14 @@ package io.dekorate.docker.config;
 import java.util.Map;
 
 import io.dekorate.ConfigurationGenerator;
-import io.dekorate.Session;
 import io.dekorate.WithProject;
 import io.dekorate.config.AnnotationConfiguration;
 import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.config.PropertyConfiguration;
 import io.dekorate.docker.adapter.DockerBuildConfigAdapter;
-import io.dekorate.docker.config.DockerBuildConfig;
 import io.dekorate.kubernetes.config.Configuration;
-import io.dekorate.kubernetes.configurator.ApplyBuildToImageConfiguration;
-import io.dekorate.project.ApplyProjectInfo;
 
-public interface DockerBuildConfigGenerator extends ConfigurationGenerator,  WithProject {
+public interface DockerBuildConfigGenerator extends ConfigurationGenerator {
 
   default String getKey() {
     return "docker";
@@ -43,18 +39,12 @@ public interface DockerBuildConfigGenerator extends ConfigurationGenerator,  Wit
 
   @Override
   default void addAnnotationConfiguration(Map map) {
-    on(new AnnotationConfiguration<DockerBuildConfig>(
-        DockerBuildConfigAdapter.newBuilder(propertiesMap(map, DockerBuildConfig.class))
-            .accept(new ApplyProjectInfo(getProject()))
-            .accept(new ApplyBuildToImageConfiguration())));
+    on(new AnnotationConfiguration<DockerBuildConfig>(DockerBuildConfigAdapter.newBuilder(propertiesMap(map, DockerBuildConfig.class))));
   }
 
   @Override
   default void addPropertyConfiguration(Map map) {
-    on(new PropertyConfiguration<DockerBuildConfig>(
-        DockerBuildConfigAdapter.newBuilder(propertiesMap(map, DockerBuildConfig.class))
-            .accept(new ApplyProjectInfo(getProject()))
-            .accept(new ApplyBuildToImageConfiguration())));
+    on(new PropertyConfiguration<DockerBuildConfig>(DockerBuildConfigAdapter.newBuilder(propertiesMap(map, DockerBuildConfig.class))));
   }
 
   default void on(ConfigurationSupplier<DockerBuildConfig> config) {

--- a/annotations/jib-annotations/src/main/java/io/dekorate/jib/config/DefaultJibBuildConfigGenerator.java
+++ b/annotations/jib-annotations/src/main/java/io/dekorate/jib/config/DefaultJibBuildConfigGenerator.java
@@ -28,9 +28,9 @@ public class DefaultJibBuildConfigGenerator implements JibBuildConifgGenerator {
   
   public DefaultJibBuildConfigGenerator(ConfigurationRegistry configurationRegistry) {
     this.configurationRegistry = configurationRegistry;
-    on(new DefaultConfiguration<JibBuildConfig>(new JibBuildConfigBuilder()
-        .accept(new ApplyProjectInfo(getProject()))
-        .accept(new ApplyBuildToImageConfiguration())));
+    this.configurationRegistry.add(new ApplyProjectInfo(getProject()));
+    this.configurationRegistry.add(new ApplyBuildToImageConfiguration());
+    on(new DefaultConfiguration<JibBuildConfig>(new JibBuildConfigBuilder()));
   }
 
   public ConfigurationRegistry getConfigurationRegistry() {

--- a/annotations/jib-annotations/src/main/java/io/dekorate/jib/config/JibBuildConifgGenerator.java
+++ b/annotations/jib-annotations/src/main/java/io/dekorate/jib/config/JibBuildConifgGenerator.java
@@ -24,10 +24,7 @@ import io.dekorate.config.AnnotationConfiguration;
 import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.config.PropertyConfiguration;
 import io.dekorate.jib.adapter.JibBuildConfigAdapter;
-import io.dekorate.jib.config.JibBuildConfig;
 import io.dekorate.kubernetes.config.Configuration;
-import io.dekorate.kubernetes.configurator.ApplyBuildToImageConfiguration;
-import io.dekorate.project.ApplyProjectInfo;
 
 public interface JibBuildConifgGenerator extends ConfigurationGenerator, WithProject {
 
@@ -44,20 +41,12 @@ public interface JibBuildConifgGenerator extends ConfigurationGenerator, WithPro
 
   @Override
   default void addAnnotationConfiguration(Map map) {
-    on(new AnnotationConfiguration<>(
-        JibBuildConfigAdapter
-            .newBuilder(propertiesMap(map, JibBuildConfig.class))
-            .accept(new ApplyProjectInfo(getProject()))
-            .accept(new ApplyBuildToImageConfiguration())));
+    on(new AnnotationConfiguration<>(JibBuildConfigAdapter.newBuilder(propertiesMap(map, JibBuildConfig.class))));
   }
 
   @Override
   default void addPropertyConfiguration(Map map) {
-    on(new PropertyConfiguration<>(
-        JibBuildConfigAdapter
-            .newBuilder(propertiesMap(map, JibBuildConfig.class))
-            .accept(new ApplyProjectInfo(getProject()))
-            .accept(new ApplyBuildToImageConfiguration())));
+    on(new PropertyConfiguration<>(JibBuildConfigAdapter.newBuilder(propertiesMap(map, JibBuildConfig.class))));
   }
 
   default void on(ConfigurationSupplier<JibBuildConfig> config) {

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/config/DefaultKnativeConfigGenerator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/config/DefaultKnativeConfigGenerator.java
@@ -16,20 +16,22 @@
 package io.dekorate.knative.config;
 
 import io.dekorate.ConfigurationRegistry;
+import io.dekorate.WithProject;
 import io.dekorate.config.DefaultConfiguration;
 import io.dekorate.kubernetes.configurator.ApplyDeployToApplicationConfiguration;
 import io.dekorate.kubernetes.configurator.ApplyImagePullSecretConfiguration;
 import io.dekorate.project.ApplyProjectInfo;
 
-public class DefaultKnativeConfigGenerator implements KnativeConfigGenerator {
+public class DefaultKnativeConfigGenerator implements KnativeConfigGenerator, WithProject {
 
   private final ConfigurationRegistry configurationRegistry;
 
   public DefaultKnativeConfigGenerator(ConfigurationRegistry configurationRegistry) {
     this.configurationRegistry = configurationRegistry;
-    on(new DefaultConfiguration<KnativeConfig>(
-        new KnativeConfigBuilder().accept(new ApplyImagePullSecretConfiguration())
-            .accept(new ApplyProjectInfo(getProject())).accept(new ApplyDeployToApplicationConfiguration())));
+    on(new DefaultConfiguration<KnativeConfig>(new KnativeConfigBuilder()));
+    this.configurationRegistry.add(new ApplyImagePullSecretConfiguration());
+    this.configurationRegistry.add(new ApplyProjectInfo(getProject()));
+    this.configurationRegistry.add(new ApplyDeployToApplicationConfiguration());
   }
 
   public ConfigurationRegistry getConfigurationRegistry() {

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/config/KnativeConfigGenerator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/config/KnativeConfigGenerator.java
@@ -18,17 +18,13 @@ package io.dekorate.knative.config;
 import java.util.Map;
 
 import io.dekorate.ConfigurationGenerator;
-import io.dekorate.WithProject;
 import io.dekorate.config.AnnotationConfiguration;
 import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.config.PropertyConfiguration;
 import io.dekorate.knative.adapter.KnativeConfigAdapter;
 import io.dekorate.kubernetes.config.Configuration;
-import io.dekorate.kubernetes.configurator.ApplyBuildToImageConfiguration;
-import io.dekorate.kubernetes.configurator.ApplyImagePullSecretConfiguration;
-import io.dekorate.project.ApplyProjectInfo;
 
-public interface KnativeConfigGenerator extends ConfigurationGenerator, WithProject {
+public interface KnativeConfigGenerator extends ConfigurationGenerator {
 
   String KNATIVE = "knative";
 
@@ -41,17 +37,11 @@ public interface KnativeConfigGenerator extends ConfigurationGenerator, WithProj
   }
 
   default void addAnnotationConfiguration(Map map) {
-    on(new AnnotationConfiguration<>(KnativeConfigAdapter.newBuilder(propertiesMap(map, KnativeConfig.class))
-        .accept(new ApplyImagePullSecretConfiguration())
-        .accept(new ApplyBuildToImageConfiguration())
-        .accept(new ApplyProjectInfo(getProject()))));
+    on(new AnnotationConfiguration<>(KnativeConfigAdapter.newBuilder(propertiesMap(map, KnativeConfig.class))));
   }
 
   default void addPropertyConfiguration(Map map) {
-    on(new PropertyConfiguration<>(KnativeConfigAdapter.newBuilder(propertiesMap(map, KnativeConfig.class))
-        .accept(new ApplyImagePullSecretConfiguration())
-        .accept(new ApplyBuildToImageConfiguration())
-        .accept(new ApplyProjectInfo(getProject()))));
+    on(new PropertyConfiguration<>(KnativeConfigAdapter.newBuilder(propertiesMap(map, KnativeConfig.class))));
   }
 
   default void on(ConfigurationSupplier<KnativeConfig> config) {

--- a/annotations/knative-annotations/src/test/java/io/dekorate/knative/config/KnativeConfigGeneratorTest.java
+++ b/annotations/knative-annotations/src/test/java/io/dekorate/knative/config/KnativeConfigGeneratorTest.java
@@ -54,7 +54,7 @@ class KnativeConfigGeneratorTest {
     Session session = Session.getSession();
     session.setWriter(writer);
 
-    KnativeConfigGenerator generator = new DefaultKnativeConfigGenerator(session.getConfigurationRegistry());
+    DefaultKnativeConfigGenerator generator = new DefaultKnativeConfigGenerator(session.getConfigurationRegistry());
     generator.setProject(FileProjectFactory.create(new File(".")));
 
     Map<String, Object> map = new HashMap<String, Object>() {

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/config/DefaultKubernetesConfigGenerator.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/config/DefaultKubernetesConfigGenerator.java
@@ -28,11 +28,11 @@ public class DefaultKubernetesConfigGenerator implements KubernetesConfigGenerat
   
   public DefaultKubernetesConfigGenerator(ConfigurationRegistry configurationRegistry) {
     this.configurationRegistry = configurationRegistry;
-    add(new DefaultConfiguration<KubernetesConfig>(new KubernetesConfigBuilder()
-        .accept(new ApplyProjectInfo(getProject()))
-        .accept(new ApplyImagePullSecretConfiguration())
-        .accept(new PopulateWebPort())
-        .accept(new ApplyDeployToApplicationConfiguration())));
+    this.configurationRegistry.add(new ApplyProjectInfo(getProject()));
+    this.configurationRegistry.add(new ApplyImagePullSecretConfiguration());
+    this.configurationRegistry.add(new PopulateWebPort());
+    this.configurationRegistry.add(new ApplyDeployToApplicationConfiguration());
+    add(new DefaultConfiguration<KubernetesConfig>(new KubernetesConfigBuilder()));
   }
 
   @Override

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/config/KubernetesConfigGenerator.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/config/KubernetesConfigGenerator.java
@@ -23,11 +23,6 @@ import io.dekorate.config.AnnotationConfiguration;
 import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.config.PropertyConfiguration;
 import io.dekorate.kubernetes.adapter.KubernetesConfigAdapter;
-import io.dekorate.kubernetes.configurator.ApplyBuildToImageConfiguration;
-import io.dekorate.kubernetes.configurator.ApplyDeployToApplicationConfiguration;
-import io.dekorate.kubernetes.configurator.ApplyImagePullSecretConfiguration;
-import io.dekorate.kubernetes.configurator.PopulateWebPort;
-import io.dekorate.project.ApplyProjectInfo;
 
 public interface KubernetesConfigGenerator extends ConfigurationGenerator, WithProject {
 
@@ -42,26 +37,12 @@ public interface KubernetesConfigGenerator extends ConfigurationGenerator, WithP
 
   @Override
   default void addAnnotationConfiguration(Map map) {
-    add(new AnnotationConfiguration<>(
-        KubernetesConfigAdapter
-            .newBuilder(propertiesMap(map, KubernetesConfig.class))
-            .accept(new ApplyBuildToImageConfiguration())
-            .accept(new ApplyImagePullSecretConfiguration())
-            .accept(new ApplyDeployToApplicationConfiguration())
-            .accept(new PopulateWebPort())
-            .accept(new ApplyProjectInfo(getProject()))));
+    add(new AnnotationConfiguration<>(KubernetesConfigAdapter.newBuilder(propertiesMap(map, KubernetesConfig.class))));
   }
 
   @Override
   default void addPropertyConfiguration(Map map) {
-    add(new PropertyConfiguration<>(
-        KubernetesConfigAdapter
-            .newBuilder(propertiesMap(map, KubernetesConfig.class))
-            .accept(new ApplyBuildToImageConfiguration())
-            .accept(new ApplyImagePullSecretConfiguration())
-            .accept(new ApplyDeployToApplicationConfiguration())
-            .accept(new PopulateWebPort())
-            .accept(new ApplyProjectInfo(getProject()))));
+    add(new PropertyConfiguration<>(KubernetesConfigAdapter.newBuilder(propertiesMap(map, KubernetesConfig.class))));
   }
 
   default void add(ConfigurationSupplier<KubernetesConfig> config) {

--- a/annotations/kubernetes-annotations/src/test/java/io/dekorate/kubernetes/config/KubernetesConfigGeneratorTest.java
+++ b/annotations/kubernetes-annotations/src/test/java/io/dekorate/kubernetes/config/KubernetesConfigGeneratorTest.java
@@ -58,7 +58,7 @@ class KubernetesConfigGeneratorTest {
         put(KubernetesConfig.class.getName(), new HashMap<String, Object>() {
           {
             put("name", "generator-test");
-            put("group", "generator-test-group");
+            put("partOf", "generator-test-group");
             put("version", "latest");
             put("replicas", 2);
             put("ports", new Map[] { new HashMap<String, Object>() {

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/config/DefaultOpenshiftConfigGenerator.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/config/DefaultOpenshiftConfigGenerator.java
@@ -16,21 +16,25 @@
 package io.dekorate.openshift.config;
 
 import io.dekorate.ConfigurationRegistry;
+import io.dekorate.WithProject;
 import io.dekorate.config.DefaultConfiguration;
 import io.dekorate.kubernetes.configurator.ApplyDeployToApplicationConfiguration;
 import io.dekorate.kubernetes.configurator.ApplyImagePullSecretConfiguration;
 import io.dekorate.kubernetes.configurator.PopulateWebPort;
 import io.dekorate.project.ApplyProjectInfo;
 
-public class DefaultOpenshiftConfigGenerator implements OpenshiftConfigGenerator {
+public class DefaultOpenshiftConfigGenerator implements OpenshiftConfigGenerator, WithProject {
 
   private final ConfigurationRegistry configurationRegistry;
 
   public DefaultOpenshiftConfigGenerator(ConfigurationRegistry configurationRegistry) {
     this.configurationRegistry = configurationRegistry;
-    on(new DefaultConfiguration<OpenshiftConfig>(new OpenshiftConfigBuilder()
-        .accept(new ApplyImagePullSecretConfiguration()).accept(new ApplyProjectInfo(getProject()))
-        .accept(new PopulateWebPort()).accept(new ApplyDeployToApplicationConfiguration())));
+    on(new DefaultConfiguration<OpenshiftConfig>(new OpenshiftConfigBuilder()));
+
+    this.configurationRegistry.add(new ApplyImagePullSecretConfiguration());
+    this.configurationRegistry.add(new ApplyProjectInfo(getProject()));
+    this.configurationRegistry.add(new PopulateWebPort());
+    this.configurationRegistry.add(new ApplyDeployToApplicationConfiguration());
   }
 
   public ConfigurationRegistry getConfigurationRegistry() {

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/config/OpenshiftConfigGenerator.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/config/OpenshiftConfigGenerator.java
@@ -18,22 +18,14 @@ package io.dekorate.openshift.config;
 import java.util.Map;
 
 import io.dekorate.ConfigurationGenerator;
-import io.dekorate.Session;
-import io.dekorate.WithProject;
-import io.dekorate.WithSession;
 import io.dekorate.config.AnnotationConfiguration;
 import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.config.PropertyConfiguration;
 import io.dekorate.kubernetes.config.Configuration;
-import io.dekorate.kubernetes.configurator.ApplyDeployToApplicationConfiguration;
-import io.dekorate.kubernetes.configurator.ApplyImagePullSecretConfiguration;
-import io.dekorate.kubernetes.configurator.PopulateWebPort;
 import io.dekorate.openshift.adapter.OpenshiftConfigAdapter;
 import io.dekorate.openshift.listener.OpenshiftSessionListener;
-import io.dekorate.project.ApplyProjectInfo;
-import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 
-public interface OpenshiftConfigGenerator extends ConfigurationGenerator, WithSession, WithProject {
+public interface OpenshiftConfigGenerator extends ConfigurationGenerator {
 
   String OPENSHIFT = "openshift";
   OpenshiftSessionListener LISTENER = new OpenshiftSessionListener();
@@ -47,19 +39,11 @@ public interface OpenshiftConfigGenerator extends ConfigurationGenerator, WithSe
   }
 
   default void addAnnotationConfiguration(Map map) {
-    on(new AnnotationConfiguration<>(OpenshiftConfigAdapter.newBuilder(propertiesMap(map, OpenshiftConfig.class))
-        .accept(new ApplyImagePullSecretConfiguration())
-        .accept(new ApplyDeployToApplicationConfiguration())
-        .accept(new PopulateWebPort())
-        .accept(new ApplyProjectInfo(getProject()))));
+    on(new AnnotationConfiguration<>(OpenshiftConfigAdapter.newBuilder(propertiesMap(map, OpenshiftConfig.class))));
   }
 
   default void addPropertyConfiguration(Map map) {
-    on(new PropertyConfiguration<>(OpenshiftConfigAdapter.newBuilder(propertiesMap(map, OpenshiftConfig.class))
-        .accept(new ApplyImagePullSecretConfiguration())
-        .accept(new ApplyDeployToApplicationConfiguration())
-        .accept(new PopulateWebPort())
-        .accept(new ApplyProjectInfo(getProject()))));
+    on(new PropertyConfiguration<>(OpenshiftConfigAdapter.newBuilder(propertiesMap(map, OpenshiftConfig.class))));
   }
 
   default void on(ConfigurationSupplier<OpenshiftConfig> config) {

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/config/DefaultS2iBuildConfigGenerator.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/config/DefaultS2iBuildConfigGenerator.java
@@ -29,9 +29,9 @@ public class DefaultS2iBuildConfigGenerator implements S2iBuildConfigGenerator, 
   
   public DefaultS2iBuildConfigGenerator(ConfigurationRegistry configurationRegistry) {
     this.configurationRegistry = configurationRegistry;
-    on(new DefaultConfiguration<S2iBuildConfig>(new S2iBuildConfigBuilder()
-        .accept(new ApplyProjectInfo(getProject()))
-        .accept(new ApplyBuildToImageConfiguration())));
+    this.configurationRegistry.add(new ApplyProjectInfo(getProject()));
+    this.configurationRegistry.add(new ApplyBuildToImageConfiguration());
+    on(new DefaultConfiguration<S2iBuildConfig>(new S2iBuildConfigBuilder()));
   }
 
   public ConfigurationRegistry getConfigurationRegistry() {

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/config/S2iBuildConfigGenerator.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/config/S2iBuildConfigGenerator.java
@@ -25,8 +25,6 @@ import io.dekorate.config.AnnotationConfiguration;
 import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.config.PropertyConfiguration;
 import io.dekorate.kubernetes.config.Configuration;
-import io.dekorate.kubernetes.configurator.ApplyBuildToImageConfiguration;
-import io.dekorate.project.ApplyProjectInfo;
 import io.dekorate.s2i.adapter.S2iBuildConfigAdapter;
 
 public interface S2iBuildConfigGenerator extends ConfigurationGenerator, WithProject {
@@ -43,17 +41,12 @@ public interface S2iBuildConfigGenerator extends ConfigurationGenerator, WithPro
 
   @Override
   default void addAnnotationConfiguration(Map map) {
-    on(new AnnotationConfiguration<S2iBuildConfig>(
-        S2iBuildConfigAdapter.newBuilder(propertiesMap(map, S2iBuildConfig.class))
-            .accept(new ApplyBuildToImageConfiguration())
-            .accept(new ApplyProjectInfo(getProject()))));
+    on(new AnnotationConfiguration<S2iBuildConfig>(S2iBuildConfigAdapter.newBuilder(propertiesMap(map, S2iBuildConfig.class))));
   }
 
   @Override
   default void addPropertyConfiguration(Map map) {
-    on(new PropertyConfiguration<S2iBuildConfig>(S2iBuildConfigAdapter.newBuilder(propertiesMap(map, S2iBuildConfig.class))
-        .accept(new ApplyBuildToImageConfiguration())
-        .accept(new ApplyProjectInfo(getProject()))));
+    on(new PropertyConfiguration<S2iBuildConfig>(S2iBuildConfigAdapter.newBuilder(propertiesMap(map, S2iBuildConfig.class))));
   }
 
   default void on(ConfigurationSupplier<S2iBuildConfig> config) {

--- a/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/config/DefaultServiceBindingConfigGenerator.java
+++ b/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/config/DefaultServiceBindingConfigGenerator.java
@@ -1,13 +1,16 @@
 package io.dekorate.servicebinding.config;
 
 import io.dekorate.ConfigurationRegistry;
+import io.dekorate.WithProject;
+import io.dekorate.project.ApplyProjectInfo;
 
-public class DefaultServiceBindingConfigGenerator implements ServiceBindingConfigGenerator {
+public class DefaultServiceBindingConfigGenerator implements ServiceBindingConfigGenerator, WithProject {
 
   private final ConfigurationRegistry configurationRegistry;
 
   public DefaultServiceBindingConfigGenerator(ConfigurationRegistry configurationRegistry) {
     this.configurationRegistry = configurationRegistry;
+    this.configurationRegistry.add(new ApplyProjectInfo(getProject()));
   }
 
   public ConfigurationRegistry getConfigurationRegistry() {

--- a/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/config/ServiceBindingConfigGenerator.java
+++ b/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/config/ServiceBindingConfigGenerator.java
@@ -18,15 +18,13 @@ package io.dekorate.servicebinding.config;
 import java.util.Map;
 
 import io.dekorate.ConfigurationGenerator;
-import io.dekorate.WithProject;
 import io.dekorate.config.AnnotationConfiguration;
 import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.config.PropertyConfiguration;
 import io.dekorate.kubernetes.config.Configuration;
 import io.dekorate.servicebinding.adapter.ServiceBindingConfigAdapter;
-import io.dekorate.servicebinding.configurator.ApplyProjectInfo;
 
-public interface ServiceBindingConfigGenerator extends ConfigurationGenerator, WithProject {
+public interface ServiceBindingConfigGenerator extends ConfigurationGenerator {
 
   String SERVICEBINDING = "servicebinding";
 
@@ -40,14 +38,12 @@ public interface ServiceBindingConfigGenerator extends ConfigurationGenerator, W
 
   @Override
   default void addAnnotationConfiguration(Map map) {
-    add(new AnnotationConfiguration<>(ServiceBindingConfigAdapter
-        .newBuilder(propertiesMap(map, ServiceBindingConfig.class)).accept(new ApplyProjectInfo(getProject()))));
+    add(new AnnotationConfiguration<>(ServiceBindingConfigAdapter.newBuilder(propertiesMap(map, ServiceBindingConfig.class))));
   }
 
   @Override
   default void addPropertyConfiguration(Map map) {
-    add(new PropertyConfiguration<>(ServiceBindingConfigAdapter
-        .newBuilder(propertiesMap(map, ServiceBindingConfig.class)).accept(new ApplyProjectInfo(getProject()))));
+    add(new PropertyConfiguration<>(ServiceBindingConfigAdapter.newBuilder(propertiesMap(map, ServiceBindingConfig.class))));
   }
 
   default void add(ConfigurationSupplier<ServiceBindingConfig> config) {

--- a/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/config/DefaultTektonConfigGenerator.java
+++ b/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/config/DefaultTektonConfigGenerator.java
@@ -16,19 +16,20 @@
 package io.dekorate.tekton.config;
 
 import io.dekorate.ConfigurationRegistry;
+import io.dekorate.WithProject;
 import io.dekorate.config.DefaultConfiguration;
 import io.dekorate.kubernetes.configurator.ApplyDeployToApplicationConfiguration;
 import io.dekorate.project.ApplyProjectInfo;
 
-public class DefaultTektonConfigGenerator implements TektonConfigGenerator {
+public class DefaultTektonConfigGenerator implements TektonConfigGenerator, WithProject{
 
   private final ConfigurationRegistry configurationRegistry;
 
   public DefaultTektonConfigGenerator(ConfigurationRegistry configurationRegistry) {
     this.configurationRegistry = configurationRegistry;
-    on(new DefaultConfiguration<TektonConfig>(new TektonConfigBuilder()
-        .accept(new ApplyProjectInfo(getProject()))
-        .accept(new ApplyDeployToApplicationConfiguration())));
+    this.configurationRegistry.add(new ApplyProjectInfo(getProject()));
+    this.configurationRegistry.add(new ApplyDeployToApplicationConfiguration());
+    on(new DefaultConfiguration<TektonConfig>(new TektonConfigBuilder()));
   }
 
   public ConfigurationRegistry getConfigurationRegistry() {

--- a/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/config/TektonConfigGenerator.java
+++ b/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/config/TektonConfigGenerator.java
@@ -18,15 +18,12 @@ package io.dekorate.tekton.config;
 import java.util.Map;
 
 import io.dekorate.ConfigurationGenerator;
-import io.dekorate.WithProject;
 import io.dekorate.config.ConfigurationSupplier;
 import io.dekorate.config.PropertyConfiguration;
 import io.dekorate.kubernetes.config.Configuration;
-import io.dekorate.kubernetes.configurator.ApplyBuildToImageConfiguration;
-import io.dekorate.project.ApplyProjectInfo;
 import io.dekorate.tekton.adapter.TektonConfigAdapter;
 
-public interface TektonConfigGenerator extends ConfigurationGenerator, WithProject  {
+public interface TektonConfigGenerator extends ConfigurationGenerator {
 
   String TEKTON = "tekton";
 
@@ -39,15 +36,11 @@ public interface TektonConfigGenerator extends ConfigurationGenerator, WithProje
   }
 
   default void addAnnotationConfiguration(Map map) {
-    on(new ConfigurationSupplier<>(TektonConfigAdapter.newBuilder(propertiesMap(map, TektonConfig.class))
-        .accept(new ApplyBuildToImageConfiguration())
-        .accept(new ApplyProjectInfo(getProject()))));
+    on(new ConfigurationSupplier<>(TektonConfigAdapter.newBuilder(propertiesMap(map, TektonConfig.class))));
   }
 
   default void addPropertyConfiguration(Map map) {
-    on(new PropertyConfiguration<>(TektonConfigAdapter.newBuilder(propertiesMap(map, TektonConfig.class))
-        .accept(new ApplyBuildToImageConfiguration())
-        .accept(new ApplyProjectInfo(getProject()))));
+    on(new PropertyConfiguration<>(TektonConfigAdapter.newBuilder(propertiesMap(map, TektonConfig.class))));
   }
 
   default void on(ConfigurationSupplier<TektonConfig> config) {

--- a/annotations/tekton-annotations/src/test/java/io/dekorate/tekton/config/TektonConfigGeneratorTest.java
+++ b/annotations/tekton-annotations/src/test/java/io/dekorate/tekton/config/TektonConfigGeneratorTest.java
@@ -30,7 +30,6 @@ import io.dekorate.SessionWriter;
 import io.dekorate.WithProject;
 import io.dekorate.processor.SimpleFileWriter;
 import io.dekorate.project.FileProjectFactory;
-import io.dekorate.tekton.config.TektonConfig;
 
 class TektonConfigGeneratorTest {
   static Path tempDir;
@@ -48,7 +47,7 @@ class TektonConfigGeneratorTest {
     Session session = Session.getSession();
     session.setWriter(writer);
 
-    TektonConfigGenerator generator = new DefaultTektonConfigGenerator(session.getConfigurationRegistry());
+    DefaultTektonConfigGenerator generator = new DefaultTektonConfigGenerator(session.getConfigurationRegistry());
     generator.setProject(FileProjectFactory.create(new File(".")));
     System.out.println("Project root:" + generator.getProject());
 

--- a/core/src/main/java/io/dekorate/ConfigurationRegistry.java
+++ b/core/src/main/java/io/dekorate/ConfigurationRegistry.java
@@ -30,6 +30,7 @@ import java.util.stream.Stream;
 
 import io.dekorate.config.MultiConfiguration;
 import io.dekorate.config.ConfigurationSupplier;
+import io.dekorate.kubernetes.config.ApplicationConfiguration;
 import io.dekorate.kubernetes.config.Configuration;
 import io.dekorate.kubernetes.config.Configurator;
 import io.dekorate.kubernetes.config.ImageConfiguration;
@@ -98,10 +99,43 @@ public class ConfigurationRegistry {
   }
 
   //
+  // Application Config specifics
+  //
+
+  public boolean hasApplicationConfiguration() {
+    return applicationConfigurationStream().count() > 0;
+  }
+
+  public Stream<? extends ApplicationConfiguration> applicationConfigurationStream() {
+    return suppliers.values()
+        .stream()
+        .map(l -> combine(l.stream()
+            .map(s -> s.configure(configurators))
+            .filter(s -> s.get() instanceof ApplicationConfiguration)
+            .map(s -> (ConfigurationSupplier<ApplicationConfiguration>) s)
+            .collect(Collectors.toList())));
+  }
+
+  public Stream<? extends ApplicationConfiguration> applicationConfigurationStream(Predicate<ConfigurationSupplier<ApplicationConfiguration>> predicate) {
+    return suppliers.values()
+        .stream()
+        .map(l -> combine(l.stream()
+            .map(s -> s.configure(configurators))
+            .filter(s -> s.get() instanceof ApplicationConfiguration)
+            .map(s -> (ConfigurationSupplier<ApplicationConfiguration>) s)
+            .filter(predicate)
+            .collect(Collectors.toList())));
+  }
+
+  //
   // Image Config specifics
   //
 
-  private Stream<? extends ImageConfiguration> imageConfigStream() {
+  public boolean hasImageConfiguration() {
+    return imageConfigurationStream().count() > 0;
+  }
+
+  public Stream<? extends ImageConfiguration> imageConfigurationStream() {
     return suppliers.values()
         .stream()
         .map(l -> combine(l.stream()
@@ -111,8 +145,7 @@ public class ConfigurationRegistry {
             .collect(Collectors.toList())));
   }
 
-  private Stream<? extends ImageConfiguration> imageConfigStream(
-      Predicate<ConfigurationSupplier<ImageConfiguration>> predicate) {
+  public Stream<? extends ImageConfiguration> imageConfigurationStream(Predicate<ConfigurationSupplier<ImageConfiguration>> predicate) {
     return suppliers.values()
         .stream()
         .map(l -> combine(l.stream()
@@ -129,13 +162,13 @@ public class ConfigurationRegistry {
 
   //Copy
   public Optional<ImageConfiguration> getImageConfig(Predicate<ConfigurationSupplier<ImageConfiguration>> predicate) {
-    return imageConfigStream(predicate).filter(i -> i instanceof ImageConfiguration)
+    return imageConfigurationStream(predicate).filter(i -> i instanceof ImageConfiguration)
         .map(i -> (ImageConfiguration) i)
         .findFirst();
   }
 
   public <C extends ImageConfiguration> Optional<C> getImageConfig(Class<C> type, Predicate<C> predicate) {
-    return imageConfigStream().filter(i -> type.isInstance(i))
+    return imageConfigurationStream().filter(i -> type.isInstance(i))
         .map(i -> (C) i)
         .filter(predicate)
         .findFirst();
@@ -146,11 +179,12 @@ public class ConfigurationRegistry {
   }
 
   public <C extends ImageConfiguration> List<C> getAllImageConfigs(Class<C> type, Predicate<C> predicate) {
-    return imageConfigStream().filter(i -> type.isInstance(i))
+    return imageConfigurationStream().filter(i -> type.isInstance(i))
         .map(i -> (C) i)
         .filter(predicate)
         .collect(Collectors.toList());
   }
+
 
   private static <C extends Configuration> C combine(ConfigurationSupplier<C> origin, ConfigurationSupplier<C> override) {
     return Beans.combine(origin.get(), override.get());

--- a/core/src/main/java/io/dekorate/DefaultCoordinates.java
+++ b/core/src/main/java/io/dekorate/DefaultCoordinates.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate;
+
+public class DefaultCoordinates implements Coordinates {
+
+  private final String partOf;
+  private final String name;
+  private final String version;
+
+  public DefaultCoordinates(String partOf, String name, String version) {
+    this.partOf = partOf;
+    this.name = name;
+    this.version = version;
+  }
+
+  public String getPartOf() {
+    return partOf;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getVersion() {
+    return version;
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((name == null) ? 0 : name.hashCode());
+    result = prime * result + ((partOf == null) ? 0 : partOf.hashCode());
+    result = prime * result + ((version == null) ? 0 : version.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DefaultCoordinates other = (DefaultCoordinates) obj;
+    if (name == null) {
+      if (other.name != null)
+        return false;
+    } else if (!name.equals(other.name))
+      return false;
+    if (partOf == null) {
+      if (other.partOf != null)
+        return false;
+    } else if (!partOf.equals(other.partOf))
+      return false;
+    if (version == null) {
+      if (other.version != null)
+        return false;
+    } else if (!version.equals(other.version))
+      return false;
+    return true;
+  }
+}

--- a/core/src/main/java/io/dekorate/Logger.java
+++ b/core/src/main/java/io/dekorate/Logger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 The original authors.
+ * Copyright 2018 The ordinal authors.
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,40 @@ package io.dekorate;
 
 public interface Logger {
 
-  String DEBUG = "DEBUG";
-  String INFO = "INFO";
-  String WARN = "WARN";
-  String ERROR = "ERROR";
+  static enum Level {
+    OFF,
+    ERROR,
+    WARN,
+    INFO,
+    DEBUG;
+  }
+
+  String THRESHOLD = "io.dekorate.log.level";
+
+  default Level getLogLevel() {
+   String threshold = System.getProperty(THRESHOLD, "INFO");
+   try {
+     return Enum.valueOf(Level.class, threshold.toUpperCase());
+   } catch (IllegalArgumentException e) {
+     return Level.INFO;
+   }
+  }
+
+  default boolean isDebugEnabled() {
+    return getLogLevel().ordinal() >= Level.DEBUG.ordinal();
+  }
+
+  default boolean isInfoEnabled() {
+    return getLogLevel().ordinal() >= Level.INFO.ordinal();
+  }
+    
+  default boolean isWarnEnabled() {
+    return getLogLevel().ordinal() >= Level.WARN.ordinal();
+  }
+
+  default boolean isErrorEnabled() {
+    return getLogLevel().ordinal() >= Level.ERROR.ordinal();
+  }
 
   void debug(String message);
 

--- a/core/src/main/java/io/dekorate/Session.java
+++ b/core/src/main/java/io/dekorate/Session.java
@@ -327,7 +327,7 @@ public class Session {
               imageConfiguration.withName(coords.getName());
             }
             if (Strings.isNullOrEmpty(imageConfiguration.getVersion())) {
-              imageConfiguration.withName(coords.getName());
+              imageConfiguration.withVersion(coords.getVersion());
             }
           }
       });
@@ -339,14 +339,13 @@ public class Session {
           Set<ApplicationConfiguration> matched = configurationRegistry.stream()
               .filter(c -> (c instanceof ApplicationConfiguration) && !(c instanceof ImageConfiguration))
               .map(c -> (ApplicationConfiguration) c)
-              .peek(a -> {LOGGER.info("App config " +a.getClass().getSimpleName()+" part-of:" + a.getPartOf() + " name:" + a.getName() + " version:"+ a.getVersion());})
               .filter(a -> a != null 
                         && ( !Strings.equals(i.getGroup(), a.getPartOf()) 
                              || !Strings.equals(i.getName(), a.getName())
                              || !Strings.equals(i.getVersion(), a.getVersion()))).collect(Collectors.toSet());
 
           if (matched.isEmpty()) {
-            throw new IllegalStateException(String.format("No matching Application configuration found for Image configuration (group=%s,name=%s,version=%s). Please make sure that there is a matching application per image configuration!", i.getGroup(), i.getName(), i.getVersion()));
+            LOGGER.debug(String.format("No matching Application configuration found for Image configuration (group=%s,name=%s,version=%s). This is often leads to confusion!", i.getGroup(), i.getName(), i.getVersion()));
           } 
     });
   }

--- a/core/src/main/java/io/dekorate/logger/AnsiLogger.java
+++ b/core/src/main/java/io/dekorate/logger/AnsiLogger.java
@@ -47,26 +47,34 @@ public class AnsiLogger extends LoggerFactory<PrintStream> implements Logger {
 
   @Override
   public void debug(String message) {
-    check();
-    stream.println(ansi().a("[").fg(CYAN).bold().a(DEBUG).reset().a("] ").a(message));
+    if (isDebugEnabled()) {
+      check();
+      stream.println(ansi().a("[").fg(CYAN).bold().a(Level.DEBUG.name()).reset().a("] ").a(message));
+    }
   }
 
   @Override
   public void info(String message) {
-    check();
-    stream.println(ansi().a("[").fg(BLUE).bold().a(INFO).reset().a("] ").a(message));
+    if (isInfoEnabled()) {
+      check();
+      stream.println(ansi().a("[").fg(BLUE).bold().a(Level.INFO.name()).reset().a("] ").a(message));
+    }
   }
 
   @Override
   public void warning(String message) {
-    check();
-    stream.println(ansi().a("[").fg(MAGENTA).bold().a(WARN).reset().a("] ").a(message));
+    if (isWarnEnabled()) {
+      check();
+      stream.println(ansi().a("[").fg(MAGENTA).bold().a(Level.WARN.name()).reset().a("] ").a(message));
+    }
   }
 
   @Override
   public void error(String message) {
-    check();
-    stream.println(ansi().a("[").fg(RED).bold().a(ERROR).reset().a("] ").a(message));
+    if (isErrorEnabled()) {
+      check();
+      stream.println(ansi().a("[").fg(RED).bold().a(Level.ERROR.name()).reset().a("] ").a(message));
+    }
   }
 
   private void check() {

--- a/core/src/main/java/io/dekorate/logger/AptLogger.java
+++ b/core/src/main/java/io/dekorate/logger/AptLogger.java
@@ -25,6 +25,7 @@ import io.dekorate.LoggerFactory;
 
 public class AptLogger extends LoggerFactory<Messager> implements Logger {
 
+  private final String FORMAT = "[%s] %s";
   private final Messager messager;
 
   public Logger create(Messager messager) {
@@ -43,26 +44,34 @@ public class AptLogger extends LoggerFactory<Messager> implements Logger {
 
   @Override
   public void debug(String message) {
-    check();
-    messager.printMessage(Kind.NOTE, String.format(DEBUG, message));
+    if (isDebugEnabled()) {
+      check();
+      messager.printMessage(Kind.NOTE, String.format(FORMAT, Level.DEBUG.name(), message));
+    }
   }
 
   @Override
   public void info(String message) {
-    check();
-    messager.printMessage(Kind.NOTE, String.format(INFO, message));
+    if (isInfoEnabled()) {
+      check();
+      messager.printMessage(Kind.NOTE, String.format(FORMAT, Level.INFO.name(), message));
+    }
   }
 
   @Override
   public void warning(String message) {
-    check();
-    messager.printMessage(Kind.WARNING, String.format(WARN, message));
+    if (isErrorEnabled()) {
+      check();
+      messager.printMessage(Kind.WARNING, String.format(FORMAT, Level.WARN.name(), message));
+    }
   }
 
   @Override
   public void error(String message) {
-    check();
-    messager.printMessage(Kind.ERROR, String.format(ERROR, message));
+    if (isErrorEnabled()) {
+      check();
+      messager.printMessage(Kind.ERROR, String.format(FORMAT, Level.ERROR.name(), message));
+    }
   }
 
   private void check() {

--- a/core/src/main/java/io/dekorate/utils/Strings.java
+++ b/core/src/main/java/io/dekorate/utils/Strings.java
@@ -144,4 +144,16 @@ public class Strings {
       throw DekorateException.launderThrowable(e);
     }
   }
+
+  public static boolean equals(String left, String right) {
+    if (left == null && right == null) {
+      return true;
+    } else if (left == null) {
+      return false;
+    } else if (right == null) {
+      return false;
+    } else {
+      return left.equals(right);
+    }
+  }
 }

--- a/examples/kubernetes-with-custom-image-name-example/src/main/java/io/dekorate/example/Main.java
+++ b/examples/kubernetes-with-custom-image-name-example/src/main/java/io/dekorate/example/Main.java
@@ -18,7 +18,7 @@ package io.dekorate.example;
 import io.dekorate.docker.annotation.DockerBuild;
 import io.dekorate.kubernetes.annotation.KubernetesApplication;
 
-@KubernetesApplication
+@KubernetesApplication(partOf="mygroup")
 @DockerBuild(image="foo/bar:baz")
 public class Main {
 

--- a/readme.md
+++ b/readme.md
@@ -1907,6 +1907,19 @@ public class Main {
 #### related examples
  - [spring boot with fmp on openshift example](examples/spring-boot-with-fmp-on-kubernetes-example)
 
+
+#### Debugging and Logging
+
+To control how verbose the dekorate output is going to be you can set the log level level threshold, using the `io.dekorate.log.level` system property-drawer.
+
+Allowed values are:
+
+- OFF
+- ERROR
+- WARN
+- INFO (default)
+- DEBUG
+
 #### Explicit configuration of annotation processors
 
 By default, Dekorate doesn't require any specific configuration of its annotation processors. 

--- a/readme.md
+++ b/readme.md
@@ -250,9 +250,50 @@ This module can be added to the project using:
 
 So where did the generated `Deployment` gets its name, docker image etc from?
 
-Everything can be customized via annotation parameters and system properties.
-On top of that, lightweight integration with build tools is provided in order
- to reduce duplication.
+Everything can be customized via annotation parameters, application configuration and system properties.
+On top of that, lightweight integration with build tools is provided in order to reduce duplication.
+
+Note, that part-of, name and version are part of multiple annotations / configuration groups etc.
+
+While, it is valid to use different values for different configuration groups (e.g. differnent names between kubernetes and knative manifests), there should be a match between application configuration and image configuration.
+Specifically, for each image configuration (e.g. docker configuration) found there should be matching application configuration (e.g. kubernetes, knative, openshift). If not, an error will be thrown.
+
+When a single application configuration is found and no explict image configuration value has been used for (group, name & version), values from the application configuration will be used.
+
+For example:
+
+```java
+@KubernetesApplication(name="my-app")
+@EnableDockerBuild(registry="quay.io")
+public class Main {
+}
+```
+
+In the example above, docker is configured with no explicit value on `name`. In this case that name from `@KubernetesApplication(name="my-app")` will be used.
+
+The same applies when property configuratin is used:
+
+```
+io.dekorate.kubernetes.name=my-app
+io.dekorate.docker.registry=quay.io
+```
+
+However, when both application and image configuration has been explicitly configured and are conflicting an error will be thrown. for example:
+
+```
+io.dekorate.kubernetes.name=my-app
+io.dekorate.docker.name=some-app
+io.dekorate.docker.registry=quay.io
+```
+
+Note: Application configuration `part-of` corresponds to image configuration `group`. So the following will also cause an error:
+
+
+```
+io.dekorate.kubernetes.part-of=my-group
+io.dekorate.docker.test=some-group
+io.dekorate.docker.registry=quay.io
+```
 
 ##### Lightweight build tool integration
 

--- a/readme.md
+++ b/readme.md
@@ -255,45 +255,28 @@ On top of that, lightweight integration with build tools is provided in order to
 
 Note, that part-of, name and version are part of multiple annotations / configuration groups etc.
 
-While, it is valid to use different values for different configuration groups (e.g. differnent names between kubernetes and knative manifests), there should be a match between application configuration and image configuration.
-Specifically, for each image configuration (e.g. docker configuration) found there should be matching application configuration (e.g. kubernetes, knative, openshift). If not, an error will be thrown.
-
 When a single application configuration is found and no explict image configuration value has been used for (group, name & version), values from the application configuration will be used.
 
 For example:
 
 ```java
 @KubernetesApplication(name="my-app")
-@EnableDockerBuild(registry="quay.io")
+@DockerBuild(registry="quay.io")
 public class Main {
 }
 ```
 
 In the example above, docker is configured with no explicit value on `name`. In this case that name from `@KubernetesApplication(name="my-app")` will be used.
 
-The same applies when property configuratin is used:
+The same applies when property configuration is used:
 
 ```
 io.dekorate.kubernetes.name=my-app
 io.dekorate.docker.registry=quay.io
 ```
 
-However, when both application and image configuration has been explicitly configured and are conflicting an error will be thrown. for example:
 
-```
-io.dekorate.kubernetes.name=my-app
-io.dekorate.docker.name=some-app
-io.dekorate.docker.registry=quay.io
-```
-
-Note: Application configuration `part-of` corresponds to image configuration `group`. So the following will also cause an error:
-
-
-```
-io.dekorate.kubernetes.part-of=my-group
-io.dekorate.docker.test=some-group
-io.dekorate.docker.registry=quay.io
-```
+Note: Application configuration `part-of` corresponds to image configuration `group`. 
 
 ##### Lightweight build tool integration
 


### PR DESCRIPTION
Resolves: #727

The pull request does the following:

- Separates addition of configurers from configuration (allows keeping track of what explciitly/implictly configured).
- Apply single application configuration to image configuration with missing explicit values for group, name & version.
- Throw error when there are conficting explict values