### PR TITLE
Configuration for primitives is not taken into account, default value has higher priority

### DIFF
--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/annotation/KubernetesApplication.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/annotation/KubernetesApplication.java
@@ -119,7 +119,7 @@ public @interface KubernetesApplication {
    * 
    * @return The number of replicas.
    */
-  int replicas() ;
+  int replicas() default 1;
 
   /**
    * Specifies the deployment strategy.

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/annotation/KubernetesApplication.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/annotation/KubernetesApplication.java
@@ -119,7 +119,7 @@ public @interface KubernetesApplication {
    * 
    * @return The number of replicas.
    */
-  int replicas() default 1;
+  int replicas() ;
 
   /**
    * Specifies the deployment strategy.

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/manifest/KubernetesManifestGenerator.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/manifest/KubernetesManifestGenerator.java
@@ -190,7 +190,7 @@ public class KubernetesManifestGenerator extends AbstractKubernetesManifestGener
         .withName(appConfig.getName())
         .endMetadata()
         .withNewSpec()
-        .withReplicas(1)
+        .withReplicas(appConfig.getReplicas())
         .withNewSelector() //We need to have at least an empty selector so that the decorator can work with it.
         .withMatchLabels(new HashMap<String, String>())
         .endSelector()

--- a/tests/issue-331-annotation-combined-with-properties/src/main/java/io/dekorate/annotationless/DemoApplication.java
+++ b/tests/issue-331-annotation-combined-with-properties/src/main/java/io/dekorate/annotationless/DemoApplication.java
@@ -23,7 +23,7 @@ import io.dekorate.kubernetes.annotation.KubernetesApplication;
 import io.dekorate.kubernetes.annotation.Port;
 
 @SpringBootApplication
-@KubernetesApplication(replicas = 3, serviceType = ServiceType.NodePort, serviceAccount = "test", ports = {
+@KubernetesApplication(replicas = 3, serviceAccount = "test", ports = {
     @Port(name = "http", containerPort = 8080),
     @Port(name = "admin-console", containerPort = 9090) })
 public class DemoApplication {

--- a/tests/issue-331-annotation-combined-with-properties/src/main/java/io/dekorate/annotationless/DemoApplication.java
+++ b/tests/issue-331-annotation-combined-with-properties/src/main/java/io/dekorate/annotationless/DemoApplication.java
@@ -15,6 +15,7 @@
  */
 package io.dekorate.annotationless;
 
+import io.dekorate.kubernetes.annotation.ServiceType;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -22,7 +23,7 @@ import io.dekorate.kubernetes.annotation.KubernetesApplication;
 import io.dekorate.kubernetes.annotation.Port;
 
 @SpringBootApplication
-@KubernetesApplication(replicas = 3, serviceAccount = "test", ports = {
+@KubernetesApplication(replicas = 3, serviceType = ServiceType.NodePort, serviceAccount = "test", ports = {
     @Port(name = "http", containerPort = 8080),
     @Port(name = "admin-console", containerPort = 9090) })
 public class DemoApplication {

--- a/tests/issue-331-annotation-combined-with-properties/src/main/resources/application.properties
+++ b/tests/issue-331-annotation-combined-with-properties/src/main/resources/application.properties
@@ -4,5 +4,5 @@ dekorate.kubernetes.labels[0].value=bar
 dekorate.kubernetes.labels[1].key=food
 dekorate.kubernetes.labels[1].value=baz
 dekorate.kubernetes.ports[0].name=http
-dekorate.kubernetes.ports[0].containerPort=8080
+dekorate.kubernetes.ports[0].containerPort=8081
 dekorate.kubernetes.serviceType=LoadBalancer

--- a/tests/issue-331-annotation-combined-with-properties/src/test/java/io/dekorate/annotationless/Issue331Test.java
+++ b/tests/issue-331-annotation-combined-with-properties/src/test/java/io/dekorate/annotationless/Issue331Test.java
@@ -18,8 +18,10 @@ package io.dekorate.annotationless;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Map;
 import java.util.Optional;
 
+import io.fabric8.kubernetes.api.model.*;
 import org.junit.jupiter.api.Test;
 
 import io.dekorate.utils.Serialization;
@@ -38,13 +40,32 @@ public class Issue331Test {
     assertNotNull(list);
     Deployment d = findFirst(list, Deployment.class).orElseThrow(() -> new IllegalStateException());
     assertNotNull(d);
-    assertEquals(3, d.getSpec().getReplicas());
+    final Map<String, String> labels = d.getMetadata().getLabels();
+    assertEquals("bar", labels.get("foo"));
+    assertEquals("baz", labels.get("food"));
     PodSpec podSpec = d.getSpec().getTemplate().getSpec();
     Container container = podSpec.getContainers().get(0);
     assertNotNull(container);
     assertEquals("test", podSpec.getServiceAccount());
-    assertTrue(container.getPorts().stream().filter(p -> p.getName().equals("http") && p.getContainerPort() == 8080)
-        .findAny().isPresent());
+    Optional<ContainerPort> httpPort = container.getPorts().stream().filter(p -> p.getName().equals("http") && p.getContainerPort()==8081).findAny();
+    assertTrue(httpPort.isPresent());
+    assertTrue(container.getPorts().stream().filter(p -> p.getName().equals("admin-console") && p.getContainerPort() == 9090)
+      .findAny().isPresent());
+    assertEquals(3, d.getSpec().getReplicas());
+
+
+  }
+
+  @Test
+  public void shouldContainService() {
+    KubernetesList list = Serialization
+      .unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/kubernetes.yml"));
+    assertNotNull(list);
+    Service service = findFirst(list, Service.class).orElseThrow(IllegalStateException::new);
+    assertNotNull(service);
+    assertEquals(1, list.getItems().stream().filter(i -> Service.class.isInstance(i)).count());
+    assertTrue(service.getSpec().getPorts().stream().filter(p -> p.getName().equals("http")&&p.getTargetPort().getIntVal()==8081).findAny().isPresent());
+    assertTrue(service.getSpec().getType().equals("LoadBalancer"));
   }
 
   <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {


### PR DESCRIPTION
Related to #706 
This is not completely fixed but contains some needed code. This PR fixes the hard code for replicas, improve the test and remove default value for replicas in k8s application config