### PR TITLE
Invalid logger breaks current application flow

### DIFF
--- a/core/src/main/java/io/dekorate/logger/AnsiLogger.java
+++ b/core/src/main/java/io/dekorate/logger/AnsiLogger.java
@@ -20,6 +20,9 @@ package io.dekorate.logger;
 import static org.fusesource.jansi.Ansi.*;
 import static org.fusesource.jansi.Ansi.Color.*;
 
+
+import java.io.FileDescriptor;
+import java.io.FileOutputStream;
 import java.io.PrintStream;
 
 import org.fusesource.jansi.*;
@@ -29,7 +32,7 @@ import io.dekorate.LoggerFactory;
 
 public class AnsiLogger extends LoggerFactory<PrintStream> implements Logger {
 
-  private final PrintStream stream;
+  private PrintStream stream;
 
   public Logger create(PrintStream stream) {
     return new AnsiLogger(stream);
@@ -79,7 +82,9 @@ public class AnsiLogger extends LoggerFactory<PrintStream> implements Logger {
 
   private void check() {
     if (stream == null) {
-      throw new IllegalStateException("AnsiLogger requires a PrintStream instance.");
+      stream = new PrintStream(new FileOutputStream(FileDescriptor.out));
+      stream.println("Invalid AnsiLogger Stream -> Swapping to default sdt out logger.");
     }
   }
+
 }


### PR DESCRIPTION
Instead of throw an `IllegalStateException` exception we could log an `error` msg and swap to std out.

Related issue: https://github.com/quarkusio/quarkus/issues/15953