### PR TITLE
Issue 775. Port numbers generated are not unique for the Kubernetes service

### DIFF
--- a/core/src/main/java/io/dekorate/kubernetes/configurator/ApplyPort.java
+++ b/core/src/main/java/io/dekorate/kubernetes/configurator/ApplyPort.java
@@ -25,7 +25,6 @@ import io.dekorate.kubernetes.config.BaseConfigFluent;
 import io.dekorate.kubernetes.config.Configurator;
 import io.dekorate.kubernetes.config.Port;
 import io.dekorate.kubernetes.config.PortBuilder;
-import io.dekorate.utils.Ports;
 import io.dekorate.utils.Strings;
 
 public class ApplyPort extends Configurator<BaseConfigFluent<?>> {
@@ -63,11 +62,14 @@ public class ApplyPort extends Configurator<BaseConfigFluent<?>> {
         config.editMatchingPort(predicate)
             .withHostPort(port.getHostPort())
             .endPort();
-      } else if (Ports.isWebPort(port)) {
-        config.editMatchingPort(predicate)
-            .withHostPort(80)
-            .endPort();
-      }
+      } /*
+         * Delete to AddServiceResourceDecorator the role to define it
+         * else if (Ports.isWebPort(port)) {
+         * config.editMatchingPort(predicate)
+         * .withHostPort(80)
+         * .endPort();
+         * }
+         */
     } else {
       String name = names.size() > 0 ? names.get(0) : FALLBACK_PORT_NAME;
       config.addNewPortLike(port)

--- a/core/src/main/java/io/dekorate/kubernetes/configurator/ApplyPort.java
+++ b/core/src/main/java/io/dekorate/kubernetes/configurator/ApplyPort.java
@@ -25,6 +25,7 @@ import io.dekorate.kubernetes.config.BaseConfigFluent;
 import io.dekorate.kubernetes.config.Configurator;
 import io.dekorate.kubernetes.config.Port;
 import io.dekorate.kubernetes.config.PortBuilder;
+import io.dekorate.utils.Ports;
 import io.dekorate.utils.Strings;
 
 public class ApplyPort extends Configurator<BaseConfigFluent<?>> {
@@ -62,14 +63,11 @@ public class ApplyPort extends Configurator<BaseConfigFluent<?>> {
         config.editMatchingPort(predicate)
             .withHostPort(port.getHostPort())
             .endPort();
-      } /*
-         * Delete to AddServiceResourceDecorator the role to define it
-         * else if (Ports.isWebPort(port)) {
-         * config.editMatchingPort(predicate)
-         * .withHostPort(80)
-         * .endPort();
-         * }
-         */
+      } else if (Ports.isWebPort(port)) {
+        config.editMatchingPort(predicate)
+            .withHostPort(80)
+            .endPort();
+      }
     } else {
       String name = names.size() > 0 ? names.get(0) : FALLBACK_PORT_NAME;
       config.addNewPortLike(port)

--- a/core/src/main/java/io/dekorate/kubernetes/configurator/ApplyPort.java
+++ b/core/src/main/java/io/dekorate/kubernetes/configurator/ApplyPort.java
@@ -63,7 +63,7 @@ public class ApplyPort extends Configurator<BaseConfigFluent<?>> {
             .withHostPort(port.getHostPort())
             .endPort();
       } /*
-         * Delete to AddServiceResourceDecorator the role to define it
+         * Delegate to AddServiceResourceDecorator the role to define the hostPort as it is only needed by the Kubernetes service
          * else if (Ports.isWebPort(port)) {
          * config.editMatchingPort(predicate)
          * .withHostPort(80)

--- a/core/src/main/java/io/dekorate/kubernetes/configurator/PopulateWebPort.java
+++ b/core/src/main/java/io/dekorate/kubernetes/configurator/PopulateWebPort.java
@@ -36,7 +36,11 @@ public class PopulateWebPort extends Configurator<BaseConfigFluent<?>> {
     if (!Ports.isWebPort(port)) {
       return port;
     }
-    return new PortBuilder(port).withHostPort(80).build();
+    /*
+     * Delete to AddServiceResourceDecorator the role to define it
+     * return new PortBuilder(port).withHostPort(80).build();
+     */
+    return new PortBuilder(port).build();
   }
 
   @Override

--- a/core/src/main/java/io/dekorate/kubernetes/configurator/PopulateWebPort.java
+++ b/core/src/main/java/io/dekorate/kubernetes/configurator/PopulateWebPort.java
@@ -36,11 +36,7 @@ public class PopulateWebPort extends Configurator<BaseConfigFluent<?>> {
     if (!Ports.isWebPort(port)) {
       return port;
     }
-    /*
-     * Delete to AddServiceResourceDecorator the role to define it
-     * return new PortBuilder(port).withHostPort(80).build();
-     */
-    return new PortBuilder(port).build();
+    return new PortBuilder(port).withHostPort(80).build();
   }
 
   @Override

--- a/core/src/main/java/io/dekorate/kubernetes/configurator/PopulateWebPort.java
+++ b/core/src/main/java/io/dekorate/kubernetes/configurator/PopulateWebPort.java
@@ -37,7 +37,7 @@ public class PopulateWebPort extends Configurator<BaseConfigFluent<?>> {
       return port;
     }
     /*
-     * Delete to AddServiceResourceDecorator the role to define it
+     * Delegate to AddServiceResourceDecorator the role to define the hostPort as it is only needed by the Kubernetes service
      * return new PortBuilder(port).withHostPort(80).build();
      */
     return new PortBuilder(port).build();

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddServiceResourceDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddServiceResourceDecorator.java
@@ -29,6 +29,7 @@ import io.dekorate.doc.Description;
 import io.dekorate.kubernetes.config.BaseConfig;
 import io.dekorate.kubernetes.config.Port;
 import io.dekorate.utils.Labels;
+import io.dekorate.utils.Ports;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
@@ -68,21 +69,9 @@ public class AddServiceResourceDecorator extends ResourceProvidingDecorator<Kube
     return new ServicePortBuilder()
         .withName(port.getName())
         .withNewTargetPort(port.getContainerPort())
-        .withPort(calculateHostPort(port))
+        .withPort(port.getHostPort() != null && port.getHostPort() > 0 ? port.getHostPort()
+            : (Ports.isWebPort(port) ? 80 : port.getContainerPort()))
         .build();
-  }
-
-  public static Integer calculateHostPort(Port port) {
-    // Check if ingress is enabled
-    // TODO : Add ingress property to the Kubernetes config
-
-    // If a HostPort has been defined by the user, then we use it
-    if (port.getHostPort() != null && port.getHostPort() > 0) {
-      return port.getHostPort();
-    }
-    // If not hostPort exists, then we will return the containerPort to follow
-    // the same convention as kubernetes suggests
-    return port.getContainerPort();
   }
 
   public static <T> Predicate<T> distinct(Function<? super T, Object> keyExtractor) {

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddServiceResourceDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddServiceResourceDecorator.java
@@ -29,7 +29,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.kubernetes.config.BaseConfig;
 import io.dekorate.kubernetes.config.Port;
 import io.dekorate.utils.Labels;
-import io.dekorate.utils.Ports;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
@@ -69,9 +68,21 @@ public class AddServiceResourceDecorator extends ResourceProvidingDecorator<Kube
     return new ServicePortBuilder()
         .withName(port.getName())
         .withNewTargetPort(port.getContainerPort())
-        .withPort(port.getHostPort() != null && port.getHostPort() > 0 ? port.getHostPort()
-            : (Ports.isWebPort(port) ? 80 : port.getContainerPort()))
+        .withPort(calculateHostPort(port))
         .build();
+  }
+
+  public static Integer calculateHostPort(Port port) {
+    // Check if ingress is enabled
+    // TODO : Add ingress property to the Kubernetes config
+
+    // If a HostPort has been defined by the user, then we use it
+    if (port.getHostPort() != null && port.getHostPort() > 0) {
+      return port.getHostPort();
+    }
+    // If not hostPort exists, then we will return the containerPort to follow
+    // the same convention as kubernetes suggests
+    return port.getContainerPort();
   }
 
   public static <T> Predicate<T> distinct(Function<? super T, Object> keyExtractor) {

--- a/core/src/main/java/io/dekorate/utils/Ports.java
+++ b/core/src/main/java/io/dekorate/utils/Ports.java
@@ -33,7 +33,7 @@ import io.fabric8.kubernetes.api.model.ContainerPort;
 
 public class Ports {
 
-  private static final List<String> HTTP_PORT_NAMES = Arrays.asList(new String[] { "http", "web" });
+  private static final List<String> HTTP_PORT_NAMES = Arrays.asList(new String[] { "http", "web", "http1", "h2c" });
   private static final List<String> HTTPS_PORT_NAMES = Arrays.asList(new String[] { "https" });
 
   private static final List<Integer> HTTP_PORT_NUMBERS = Arrays.asList(new Integer[] { 80, 8080 });

--- a/core/src/main/java/io/dekorate/utils/Ports.java
+++ b/core/src/main/java/io/dekorate/utils/Ports.java
@@ -33,7 +33,7 @@ import io.fabric8.kubernetes.api.model.ContainerPort;
 
 public class Ports {
 
-  private static final List<String> HTTP_PORT_NAMES = Arrays.asList(new String[] { "http", "web", "http1", "h2c" });
+  private static final List<String> HTTP_PORT_NAMES = Arrays.asList(new String[] { "http", "web" });
   private static final List<String> HTTPS_PORT_NAMES = Arrays.asList(new String[] { "https" });
 
   private static final List<Integer> HTTP_PORT_NUMBERS = Arrays.asList(new Integer[] { 80, 8080 });

--- a/frameworks/spring-boot/src/main/java/io/dekorate/spring/generator/SpringBootWebAnnotationGenerator.java
+++ b/frameworks/spring-boot/src/main/java/io/dekorate/spring/generator/SpringBootWebAnnotationGenerator.java
@@ -51,9 +51,7 @@ public interface SpringBootWebAnnotationGenerator extends ConfigurationGenerator
   default Port detectHttpPort(Map map) {
     return new PortBuilder()
         .withName("http")
-        // Don't decide here to apply a fixed hostPort as several ports (HTTP, HTTPS, ...) could be generated for a K8s Service
-        // The AddServiceResourceDecorator will take care to assign it
-        //.withHostPort()
+        .withHostPort(80)
         .withContainerPort(extractPortFromProperties())
         .withPath(String.valueOf(map.getOrDefault(DEKORATE_SPRING_WEB_PATH, Ports.DEFAULT_HTTP_PORT_PATH)))
         .build();

--- a/frameworks/spring-boot/src/main/java/io/dekorate/spring/generator/SpringBootWebAnnotationGenerator.java
+++ b/frameworks/spring-boot/src/main/java/io/dekorate/spring/generator/SpringBootWebAnnotationGenerator.java
@@ -51,7 +51,9 @@ public interface SpringBootWebAnnotationGenerator extends ConfigurationGenerator
   default Port detectHttpPort(Map map) {
     return new PortBuilder()
         .withName("http")
-        .withHostPort(80)
+        // Don't decide here to apply a fixed hostPort as several ports (HTTP, HTTPS, ...) could be generated for a K8s Service
+        // The AddServiceResourceDecorator will take care to assign it
+        //.withHostPort()
         .withContainerPort(extractPortFromProperties())
         .withPath(String.valueOf(map.getOrDefault(DEKORATE_SPRING_WEB_PATH, Ports.DEFAULT_HTTP_PORT_PATH)))
         .build();

--- a/tests/issue-775-duplicate-service-port/pom.xml
+++ b/tests/issue-775-duplicate-service-port/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <artifactId>dekorate-tests</artifactId>
+    <groupId>io.dekorate</groupId>
+    <version>2.3-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>issue-775-duplicate-service-port</artifactId>
+  <name>Dekorate :: Tests :: Annotations :: Kubernetes :: Duplicate Service port #775</name>
+  <description>Kubernetes service should have unique port number</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <inherited>true</inherited>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring-boot}</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/issue-775-duplicate-service-port/src/main/java/io/dekorate/annotationless/DemoApplication.java
+++ b/tests/issue-775-duplicate-service-port/src/main/java/io/dekorate/annotationless/DemoApplication.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.annotationless;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(DemoApplication.class, args);
+  }
+
+}

--- a/tests/issue-775-duplicate-service-port/src/main/java/io/dekorate/annotationless/HelloController.java
+++ b/tests/issue-775-duplicate-service-port/src/main/java/io/dekorate/annotationless/HelloController.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate.annotationless;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+  private static final String HELLO = "hello world!";
+
+  @RequestMapping("/")
+  public String hello() {
+    return HELLO;
+  }
+}

--- a/tests/issue-775-duplicate-service-port/src/main/resources/application.properties
+++ b/tests/issue-775-duplicate-service-port/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+dekorate.kubernetes.expose=true
+dekorate.kubernetes.ports[0].name=http
+dekorate.kubernetes.ports[0].containerPort=8080
+dekorate.kubernetes.ports[1].name=https
+dekorate.kubernetes.ports[1].containerPort=8443

--- a/tests/issue-775-duplicate-service-port/src/main/resources/application.properties
+++ b/tests/issue-775-duplicate-service-port/src/main/resources/application.properties
@@ -1,5 +1,8 @@
 dekorate.kubernetes.expose=true
 dekorate.kubernetes.ports[0].name=http
 dekorate.kubernetes.ports[0].containerPort=8080
+dekorate.kubernetes.ports[0].path=/
+
 dekorate.kubernetes.ports[1].name=https
 dekorate.kubernetes.ports[1].containerPort=8443
+dekorate.kubernetes.ports[1].path=/

--- a/tests/issue-775-duplicate-service-port/src/main/resources/application.properties
+++ b/tests/issue-775-duplicate-service-port/src/main/resources/application.properties
@@ -1,8 +1,5 @@
 dekorate.kubernetes.expose=true
 dekorate.kubernetes.ports[0].name=http
 dekorate.kubernetes.ports[0].containerPort=8080
-dekorate.kubernetes.ports[0].path=/
-
 dekorate.kubernetes.ports[1].name=https
 dekorate.kubernetes.ports[1].containerPort=8443
-dekorate.kubernetes.ports[1].path=/

--- a/tests/issue-775-duplicate-service-port/src/test/java/io/dekorate/annotationless/Issue775Test.java
+++ b/tests/issue-775-duplicate-service-port/src/test/java/io/dekorate/annotationless/Issue775Test.java
@@ -42,12 +42,14 @@ public class Issue775Test {
 
     ServicePort servicePort1 = p.get(0);
     assertEquals("http", servicePort1.getName());
-    assertEquals(8080, servicePort1.getPort());
+    assertEquals(80, servicePort1.getPort());
     assertEquals(8080, servicePort1.getTargetPort().getIntVal());
 
     ServicePort servicePort2 = p.get(1);
     assertEquals("https", servicePort2.getName());
-    assertEquals(8443, servicePort2.getPort());
+    // Fail due to wrong logic implemented
+    //assertEquals(8443, servicePort2.getPort());
+    assertEquals(80, servicePort2.getPort());
     assertEquals(8443, servicePort2.getTargetPort().getIntVal());
   }
 

--- a/tests/issue-775-duplicate-service-port/src/test/java/io/dekorate/annotationless/Issue775Test.java
+++ b/tests/issue-775-duplicate-service-port/src/test/java/io/dekorate/annotationless/Issue775Test.java
@@ -47,8 +47,6 @@ public class Issue775Test {
 
     ServicePort servicePort2 = p.get(1);
     assertEquals("https", servicePort2.getName());
-    // Fail due to wrong logic implemented
-    //assertEquals(8443, servicePort2.getPort());
     assertEquals(80, servicePort2.getPort());
     assertEquals(8443, servicePort2.getTargetPort().getIntVal());
   }

--- a/tests/issue-775-duplicate-service-port/src/test/java/io/dekorate/annotationless/Issue775Test.java
+++ b/tests/issue-775-duplicate-service-port/src/test/java/io/dekorate/annotationless/Issue775Test.java
@@ -42,14 +42,12 @@ public class Issue775Test {
 
     ServicePort servicePort1 = p.get(0);
     assertEquals("http", servicePort1.getName());
-    assertEquals(80, servicePort1.getPort());
+    assertEquals(8080, servicePort1.getPort());
     assertEquals(8080, servicePort1.getTargetPort().getIntVal());
 
     ServicePort servicePort2 = p.get(1);
     assertEquals("https", servicePort2.getName());
-    // Fail due to wrong logic implemented
-    //assertEquals(8443, servicePort2.getPort());
-    assertEquals(80, servicePort2.getPort());
+    assertEquals(8443, servicePort2.getPort());
     assertEquals(8443, servicePort2.getTargetPort().getIntVal());
   }
 

--- a/tests/issue-775-duplicate-service-port/src/test/java/io/dekorate/annotationless/Issue775Test.java
+++ b/tests/issue-775-duplicate-service-port/src/test/java/io/dekorate/annotationless/Issue775Test.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dekorate.annotationless;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.utils.Serialization;
+import io.fabric8.kubernetes.api.model.*;
+
+public class Issue775Test {
+
+  @Test
+  public void shouldHaveUniquePortNumber() {
+    KubernetesList list = Serialization
+        .unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/kubernetes.yml"));
+    assertNotNull(list);
+    Service s = findFirst(list, Service.class).orElseThrow(() -> new IllegalStateException());
+    assertNotNull(s);
+
+    List<ServicePort> p = s.getSpec().getPorts();
+    assertEquals(2, p.size());
+
+    ServicePort servicePort1 = p.get(0);
+    assertEquals("http", servicePort1.getName());
+    assertEquals(80, servicePort1.getPort());
+    assertEquals(8080, servicePort1.getTargetPort().getIntVal());
+
+    ServicePort servicePort2 = p.get(1);
+    assertEquals("https", servicePort2.getName());
+    // Fail due to wrong logic implemented
+    //assertEquals(8443, servicePort2.getPort());
+    assertEquals(80, servicePort2.getPort());
+    assertEquals(8443, servicePort2.getTargetPort().getIntVal());
+  }
+
+  <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {
+    return (Optional<T>) list.getItems().stream()
+        .filter(i -> t.isInstance(i))
+        .findFirst();
+  }
+
+}

--- a/tests/issue-775-duplicate-service-port/src/test/java/io/dekorate/annotationless/Issue775Test.java
+++ b/tests/issue-775-duplicate-service-port/src/test/java/io/dekorate/annotationless/Issue775Test.java
@@ -42,12 +42,12 @@ public class Issue775Test {
 
     ServicePort servicePort1 = p.get(0);
     assertEquals("http", servicePort1.getName());
-    assertEquals(80, servicePort1.getPort());
+    assertEquals(8080, servicePort1.getPort());
     assertEquals(8080, servicePort1.getTargetPort().getIntVal());
 
     ServicePort servicePort2 = p.get(1);
     assertEquals("https", servicePort2.getName());
-    assertEquals(80, servicePort2.getPort());
+    assertEquals(8443, servicePort2.getPort());
     assertEquals(8443, servicePort2.getTargetPort().getIntVal());
   }
 

--- a/tests/issue-775-duplicate-service-port/src/test/java/io/dekorate/annotationless/Issue775TwoPortsTest.java
+++ b/tests/issue-775-duplicate-service-port/src/test/java/io/dekorate/annotationless/Issue775TwoPortsTest.java
@@ -23,14 +23,16 @@ import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.TestPropertySource;
 
 import io.dekorate.utils.Serialization;
 import io.fabric8.kubernetes.api.model.*;
 
-public class Issue775Test {
+@TestPropertySource(locations = "./application2.properties")
+public class Issue775TwoPortsTest {
 
   @Test
-  public void shouldHaveUniquePortNumber() {
+  public void shouldHaveUniquePortNumberForTwoPorts() {
     KubernetesList list = Serialization
         .unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/kubernetes.yml"));
     assertNotNull(list);

--- a/tests/issue-775-one-port/pom.xml
+++ b/tests/issue-775-one-port/pom.xml
@@ -11,9 +11,9 @@
   </parent>
 
   <groupId>io.dekorate</groupId>
-  <artifactId>issue-775-duplicate-service-port</artifactId>
-  <name>Dekorate :: Tests :: Annotations :: Kubernetes :: Duplicate Service port #775</name>
-  <description>Kubernetes service should have HTTP - 8080 and HTTPS - 8443 ports</description>
+  <artifactId>issue-775-one-port</artifactId>
+  <name>Dekorate :: Tests :: Annotations :: Kubernetes :: Should have one service port - 8080 #775</name>
+  <description>Kubernetes service should have one HTTP - 8080 port</description>
 
   <dependencies>
     <dependency>

--- a/tests/issue-775-one-port/src/main/java/io/dekorate/annotationless/DemoApplication.java
+++ b/tests/issue-775-one-port/src/main/java/io/dekorate/annotationless/DemoApplication.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.annotationless;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(DemoApplication.class, args);
+  }
+
+}

--- a/tests/issue-775-one-port/src/main/java/io/dekorate/annotationless/HelloController.java
+++ b/tests/issue-775-one-port/src/main/java/io/dekorate/annotationless/HelloController.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate.annotationless;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+  private static final String HELLO = "hello world!";
+
+  @RequestMapping("/")
+  public String hello() {
+    return HELLO;
+  }
+}

--- a/tests/issue-775-one-port/src/main/resources/application.properties
+++ b/tests/issue-775-one-port/src/main/resources/application.properties
@@ -1,0 +1,4 @@
+dekorate.kubernetes.expose=true
+dekorate.kubernetes.ports[0].name=http
+dekorate.kubernetes.ports[0].containerPort=8080
+dekorate.kubernetes.ports[0].path=/

--- a/tests/issue-775-one-port/src/test/java/io/dekorate/annotationless/Issue775OnePortTest.java
+++ b/tests/issue-775-one-port/src/test/java/io/dekorate/annotationless/Issue775OnePortTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dekorate.annotationless;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.utils.Serialization;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+
+public class Issue775OnePortTest {
+
+  @Test
+  public void shouldHaveOnePort() {
+    KubernetesList list = Serialization
+        .unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/kubernetes.yml"));
+    assertNotNull(list);
+    Service s = findFirst(list, Service.class).orElseThrow(() -> new IllegalStateException());
+    assertNotNull(s);
+
+    List<ServicePort> p = s.getSpec().getPorts();
+    assertEquals(1, p.size());
+
+    ServicePort servicePort1 = p.get(0);
+    assertEquals("http", servicePort1.getName());
+    assertEquals(8080, servicePort1.getPort());
+    assertEquals(8080, servicePort1.getTargetPort().getIntVal());
+  }
+
+  <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {
+    return (Optional<T>) list.getItems().stream()
+        .filter(i -> t.isInstance(i))
+        .findFirst();
+  }
+
+}

--- a/tests/issue-775-sb-server-port/pom.xml
+++ b/tests/issue-775-sb-server-port/pom.xml
@@ -11,9 +11,9 @@
   </parent>
 
   <groupId>io.dekorate</groupId>
-  <artifactId>issue-775-duplicate-service-port</artifactId>
-  <name>Dekorate :: Tests :: Annotations :: Kubernetes :: Duplicate Service port #775</name>
-  <description>Kubernetes service should have HTTP - 8080 and HTTPS - 8443 ports</description>
+  <artifactId>issue-775-sb-server-port</artifactId>
+  <name>Dekorate :: Tests :: Annotations :: Kubernetes :: Spring Boot server port #775</name>
+  <description>Kubernetes service should have one HTTP - 8090 port as defined by Spring Boot</description>
 
   <dependencies>
     <dependency>

--- a/tests/issue-775-sb-server-port/src/main/java/io/dekorate/annotationless/DemoApplication.java
+++ b/tests/issue-775-sb-server-port/src/main/java/io/dekorate/annotationless/DemoApplication.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.annotationless;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(DemoApplication.class, args);
+  }
+
+}

--- a/tests/issue-775-sb-server-port/src/main/java/io/dekorate/annotationless/HelloController.java
+++ b/tests/issue-775-sb-server-port/src/main/java/io/dekorate/annotationless/HelloController.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate.annotationless;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+  private static final String HELLO = "hello world!";
+
+  @RequestMapping("/")
+  public String hello() {
+    return HELLO;
+  }
+}

--- a/tests/issue-775-sb-server-port/src/main/resources/application.properties
+++ b/tests/issue-775-sb-server-port/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=8090
+dekorate.kubernetes.expose=true

--- a/tests/issue-775-sb-server-port/src/test/java/io/dekorate/annotationless/Issue775SpringBootServerTest.java
+++ b/tests/issue-775-sb-server-port/src/test/java/io/dekorate/annotationless/Issue775SpringBootServerTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dekorate.annotationless;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.utils.Serialization;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.ServicePort;
+
+public class Issue775SpringBootServerTest {
+
+  @Test
+  public void shouldHaveSpringBootServerPort() {
+    KubernetesList list = Serialization
+        .unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/kubernetes.yml"));
+    assertNotNull(list);
+    Service s = findFirst(list, Service.class).orElseThrow(() -> new IllegalStateException());
+    assertNotNull(s);
+
+    List<ServicePort> p = s.getSpec().getPorts();
+    assertEquals(1, p.size());
+
+    ServicePort servicePort1 = p.get(0);
+    assertEquals("http", servicePort1.getName());
+    assertEquals(8090, servicePort1.getPort());
+    assertEquals(8090, servicePort1.getTargetPort().getIntVal());
+  }
+
+  <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {
+    return (Optional<T>) list.getItems().stream()
+        .filter(i -> t.isInstance(i))
+        .findFirst();
+  }
+
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -54,6 +54,8 @@
       <module>issue-687-knative-volumes</module>
       <module>issue-769-old-jackson-version</module>
       <module>issue-775-duplicate-service-port</module>
+      <module>issue-775-one-port</module>
+      <module>issue-775-sb-server-port</module>
     </modules>
 
 </project>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -53,6 +53,7 @@
       <module>issue-667-init-container-probes</module>
       <module>issue-687-knative-volumes</module>
       <module>issue-769-old-jackson-version</module>
+      <module>issue-775-duplicate-service-port</module>
     </modules>
 
 </project>


### PR DESCRIPTION
- Add test case to reproduce the error. See lines 51-52 of the code
- Implement a first version of the new logic as defined within the ticket
- Ingress code is still not implemented as there is not Kubernetes Config property like `service.expose` to check if it has been enabled.

Fixes #775 