### PR TITLE
Support of additional test resources for K8s and OCP deployments

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -25,6 +25,7 @@
     <module>spring-boot-on-openshift-example</module>
     <module>spring-boot-on-openshift-with-docker-example</module>
     <module>spring-boot-on-openshift-with-jib-custom-registry-example</module>
+    <module>spring-boot-with-database-on-openshift-example</module>
     <module>spring-boot-with-groovy-on-openshift-example</module>
     <module>spring-boot-with-existing-manifests-on-kubernetes-example</module>
     <module>spring-boot-with-fmp-on-kubernetes-example</module>

--- a/examples/spring-boot-with-database-on-openshift-example/pom.xml
+++ b/examples/spring-boot-with-database-on-openshift-example/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>spring-boot-with-database-on-openshift-example</artifactId>
+  <version>2.6-SNAPSHOT</version>
+  <name>Dekorate :: Examples :: Spring Boot with Database on Openshift</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+
+    <version.postgresql>42.3.1</version.postgresql>
+    <version.rest-assured>4.4.0</version.rest-assured>
+    <version.spring-boot>2.4.5</version.spring-boot>
+
+    <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
+    <version.maven-failsafe-plugin>3.0.0-M3</version.maven-failsafe-plugin>
+    <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${version.postgresql}</version>
+      <scope>runtime</scope>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-junit-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <version>${version.rest-assured}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring-boot}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.maven-surefire-plugin}</version>
+        <inherited>true</inherited>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.maven-failsafe-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <includes>
+                <include>**/*IT.class</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/examples/spring-boot-with-database-on-openshift-example/src/main/java/io/dekorate/example/Application.java
+++ b/examples/spring-boot-with-database-on-openshift-example/src/main/java/io/dekorate/example/Application.java
@@ -1,0 +1,13 @@
+package io.dekorate.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/examples/spring-boot-with-database-on-openshift-example/src/main/java/io/dekorate/example/service/Fruit.java
+++ b/examples/spring-boot-with-database-on-openshift-example/src/main/java/io/dekorate/example/service/Fruit.java
@@ -1,0 +1,39 @@
+package io.dekorate.example.service;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class Fruit {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    private String name;
+
+    public Fruit() {
+    }
+
+    public Fruit(String type) {
+        this.name = type;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/examples/spring-boot-with-database-on-openshift-example/src/main/java/io/dekorate/example/service/FruitController.java
+++ b/examples/spring-boot-with-database-on-openshift-example/src/main/java/io/dekorate/example/service/FruitController.java
@@ -1,0 +1,63 @@
+package io.dekorate.example.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Spliterator;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+@RestController
+@RequestMapping(value = "/api/fruits")
+public class FruitController {
+
+    private final FruitRepository repository;
+
+    public FruitController(FruitRepository repository) {
+        this.repository = repository;
+    }
+
+    @GetMapping("/{id}")
+    public Fruit get(@PathVariable("id") Integer id) {
+        return repository.findById(id).orElseThrow(NotFoundException::new);
+    }
+
+    @GetMapping
+    public List<Fruit> getAll() {
+        Spliterator<Fruit> fruits = repository.findAll()
+                .spliterator();
+
+        return StreamSupport
+                .stream(fruits, false)
+                .collect(Collectors.toList());
+    }
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public Fruit post(@RequestBody(required = false) Fruit fruit) {
+        return repository.save(fruit);
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @PutMapping("/{id}")
+    public Fruit put(@PathVariable("id") Integer id, @RequestBody(required = false) Fruit fruit) {
+        fruit.setId(id);
+        return repository.save(fruit);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable("id") Integer id) {
+        repository.deleteById(id);
+    }
+
+}

--- a/examples/spring-boot-with-database-on-openshift-example/src/main/java/io/dekorate/example/service/FruitRepository.java
+++ b/examples/spring-boot-with-database-on-openshift-example/src/main/java/io/dekorate/example/service/FruitRepository.java
@@ -1,0 +1,6 @@
+package io.dekorate.example.service;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface FruitRepository extends CrudRepository<Fruit, Integer> {
+}

--- a/examples/spring-boot-with-database-on-openshift-example/src/main/java/io/dekorate/example/service/NotFoundException.java
+++ b/examples/spring-boot-with-database-on-openshift-example/src/main/java/io/dekorate/example/service/NotFoundException.java
@@ -1,0 +1,9 @@
+package io.dekorate.example.service;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException {
+
+}

--- a/examples/spring-boot-with-database-on-openshift-example/src/main/resources/application.properties
+++ b/examples/spring-boot-with-database-on-openshift-example/src/main/resources/application.properties
@@ -1,0 +1,12 @@
+# OpenShift properties
+## Values from `database.yml` resource
+dekorate.openshift.env-vars[0].name=spring.datasource.url
+dekorate.openshift.env-vars[0].value=jdbc:postgresql://my-database:5432/my_data
+dekorate.openshift.env-vars[1].name=spring.datasource.username
+dekorate.openshift.env-vars[1].value=luke
+dekorate.openshift.env-vars[2].name=spring.datasource.password
+dekorate.openshift.env-vars[2].value=secret
+dekorate.openshift.env-vars[3].name=spring.datasource.driver-class-name
+dekorate.openshift.env-vars[3].value=org.postgresql.Driver
+dekorate.openshift.env-vars[4].name=spring.jpa.hibernate.ddl-auto
+dekorate.openshift.env-vars[4].value=create

--- a/examples/spring-boot-with-database-on-openshift-example/src/test/java/io/dekorate/example/SpringBootOnOpenShiftIT.java
+++ b/examples/spring-boot-with-database-on-openshift-example/src/test/java/io/dekorate/example/SpringBootOnOpenShiftIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016-2017 Red Hat, Inc, and individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dekorate.example;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.isEmptyString;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.testing.annotation.Inject;
+import io.dekorate.testing.openshift.annotation.OpenshiftIntegrationTest;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.LocalPortForward;
+import io.restassured.http.ContentType;
+
+@OpenshiftIntegrationTest(additionalResources = "src/test/resources/database.yml")
+public class SpringBootOnOpenShiftIT {
+
+    private static final String FRUITS_PATH = "api/fruits";
+
+    @Inject
+    KubernetesClient client;
+
+    @Inject
+    Pod pod;
+
+    @Test
+    public void testPostGetAndDelete() throws IOException {
+        try (LocalPortForward p = client.pods().withName(pod.getMetadata().getName()).portForward(8080)) {
+            String url = "http://localhost:" + p.getLocalPort() + "/";
+            Integer id = given()
+                    .baseUri(url)
+                    .contentType(ContentType.JSON)
+                    .body(Collections.singletonMap("name", "Lemon"))
+                    .post(FRUITS_PATH)
+                    .then()
+                    .statusCode(201)
+                    .body("id", not(isEmptyString()))
+                    .body("name", is("Lemon"))
+                    .extract()
+                    .response()
+                    .path("id");
+
+            given()
+                    .baseUri(url)
+                    .get(String.format("%s/%d", FRUITS_PATH, id))
+                    .then()
+                    .statusCode(200)
+                    .body("id", is(id))
+                    .body("name", is("Lemon"));
+
+            given()
+                    .baseUri(url)
+                    .delete(String.format("%s/%d", FRUITS_PATH, id))
+                    .then()
+                    .statusCode(204);
+        }
+
+    }
+
+}
+

--- a/examples/spring-boot-with-database-on-openshift-example/src/test/resources/database.yml
+++ b/examples/spring-boot-with-database-on-openshift-example/src/test/resources/database.yml
@@ -1,0 +1,112 @@
+apiVersion: v1
+items:
+- apiVersion: v1
+  kind: ImageStream
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: my-database
+    name: my-database
+  spec:
+    lookupPolicy:
+      local: false
+    tags:
+    - annotations:
+        openshift.io/imported-from: quay.io/bitnami/postgresql
+      from:
+        kind: DockerImage
+        name: quay.io/bitnami/postgresql:13.4.0
+      generation: null
+      importPolicy: {}
+      name: latest
+      referencePolicy:
+        type: ""
+  status:
+    dockerImageRepository: ""
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: my-database
+    name: my-database
+  spec:
+    replicas: 1
+    selector:
+      app: my-database
+      deploymentconfig: my-database
+    strategy:
+      resources: {}
+    template:
+      metadata:
+        annotations:
+          openshift.io/generated-by: OpenShiftNewApp
+        creationTimestamp: null
+        labels:
+          app: my-database
+          deploymentconfig: my-database
+      spec:
+        containers:
+        - env:
+          - name: POSTGRESQL_DATABASE
+            value: my_data
+          - name: POSTGRESQL_PASSWORD
+            value: secret
+          - name: POSTGRESQL_USER
+            value: luke
+          image: quay.io/bitnami/postgresql:13.4.0
+          name: my-database
+          ports:
+          - containerPort: 5432
+            protocol: TCP
+          resources: {}
+          volumeMounts:
+          - mountPath: /var/lib/pgsql/data
+            name: my-database-volume-1
+        volumes:
+        - emptyDir: {}
+          name: my-database-volume-1
+    test: false
+    triggers:
+    - type: ConfigChange
+    - imageChangeParams:
+        automatic: true
+        containerNames:
+        - my-database
+        from:
+          kind: ImageStreamTag
+          name: my-database:latest
+      type: ImageChange
+  status:
+    availableReplicas: 0
+    latestVersion: 0
+    observedGeneration: 0
+    replicas: 0
+    unavailableReplicas: 0
+    updatedReplicas: 0
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: my-database
+    name: my-database
+  spec:
+    ports:
+    - name: 5432-tcp
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+    selector:
+      app: my-database
+      deploymentconfig: my-database
+  status:
+    loadBalancer: {}
+kind: List
+metadata: {}

--- a/testing/core-junit/src/main/java/io/dekorate/testing/WithAdditionalResources.java
+++ b/testing/core-junit/src/main/java/io/dekorate/testing/WithAdditionalResources.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2021 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.testing;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import io.dekorate.DekorateException;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.dsl.Waitable;
+
+/**
+ * Mixin for deploying / deleting additional resources.
+ */
+public interface WithAdditionalResources extends WithKubernetesClient {
+  default void loadAdditionalResources(ExtensionContext context, String[] additionalResources,
+      long additionalResourcesTimeout) {
+
+    KubernetesClient client = getKubernetesClient(context);
+
+    for (String additionalResource : additionalResources) {
+      try (FileInputStream is = new FileInputStream(additionalResource)) {
+        client.resourceList(client.load(is).get()).createOrReplace().stream()
+            .filter(item -> item instanceof Waitable)
+            .forEach(item -> ((Waitable) item).waitUntilReady(additionalResourcesTimeout, TimeUnit.MILLISECONDS));
+
+      } catch (IOException e) {
+        throw DekorateException.launderThrowable("Failed to load resource: " + additionalResource, e);
+      }
+    }
+  }
+
+  default void deleteAdditionalResources(ExtensionContext context, String[] additionalResources) {
+    KubernetesClient client = getKubernetesClient(context);
+    for (String additionalResource : additionalResources) {
+      try (FileInputStream is = new FileInputStream(additionalResource)) {
+        List<HasMetadata> items = client.load(is).get();
+        items.forEach(r -> deleteResource(client, r));
+      } catch (IOException ignored) {
+      }
+    }
+  }
+
+  void deleteResource(KubernetesClient client, HasMetadata resource);
+}

--- a/testing/kubernetes-junit/src/main/java/io/dekorate/testing/annotation/KubernetesIntegrationTest.java
+++ b/testing/kubernetes-junit/src/main/java/io/dekorate/testing/annotation/KubernetesIntegrationTest.java
@@ -59,4 +59,18 @@ public @interface KubernetesIntegrationTest {
    * @return The max amount in milliseconds.
    */
   long readinessTimeout() default 300000;
+
+  /**
+   * Additional resources to be deployed before the application.
+   *
+   * @return list of resources to be deployed before the application deployment.
+   */
+  String[] additionalResources() default {};
+
+  /**
+   * The amount of time in milliseconds to wait for additional resources to become ready.
+   *
+   * @return The max amount in milliseconds.
+   */
+  long additionalResourcesTimeout() default 120000;
 }

--- a/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/annotation/OpenshiftIntegrationTest.java
+++ b/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/annotation/OpenshiftIntegrationTest.java
@@ -73,4 +73,18 @@ public @interface OpenshiftIntegrationTest {
    * @return The max amount in milliseconds.
    */
   long readinessTimeout() default 300000;
+
+  /**
+   * Additional resources to be deployed before the application.
+   *
+   * @return list of resources to be deployed before the application deployment.
+   */
+  String[] additionalResources() default {};
+
+  /**
+   * The amount of time in milliseconds to wait for additional resources to become ready.
+   *
+   * @return The max amount in milliseconds.
+   */
+  long additionalResourcesTimeout() default 120000;
 }


### PR DESCRIPTION
Description:
This could be handy for writing tests for applications that depend on third parties like database to work.

Usage:

```java
@OpenshiftIntegrationTest(additionalResources = "src/test/resources/database.yml")
public class OpenShiftIT {
// ...
}
```