### PR TITLE
Testing: Allow to deploy multiple projects

### DIFF
--- a/examples/multimodule-projects-on-kubernetes-example/multimodule-project-a-on-kubernetes-example/Dockerfile
+++ b/examples/multimodule-projects-on-kubernetes-example/multimodule-project-a-on-kubernetes-example/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:8u171-alpine3.7
+RUN apk --no-cache add curl
+COPY target/*.jar multimodule-project-a-on-kubernetes-example.jar
+CMD java ${JAVA_OPTS} -jar multimodule-project-a-on-kubernetes-example.jar

--- a/examples/multimodule-projects-on-kubernetes-example/multimodule-project-a-on-kubernetes-example/pom.xml
+++ b/examples/multimodule-projects-on-kubernetes-example/multimodule-project-a-on-kubernetes-example/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>multimodule-project-a-on-kubernetes-example</artifactId>
+  <version>2.6-SNAPSHOT</version>
+  <name>Dekorate :: Examples :: Multi Module Project on Kubernetes :: Project A</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+
+    <version.spring-boot>2.4.5</version.spring-boot>
+    <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
+
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>docker-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring-boot}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/examples/multimodule-projects-on-kubernetes-example/multimodule-project-a-on-kubernetes-example/src/main/java/io/dekorate/example/Controller.java
+++ b/examples/multimodule-projects-on-kubernetes-example/multimodule-project-a-on-kubernetes-example/src/main/java/io/dekorate/example/Controller.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2021 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class Controller {
+
+  @RequestMapping("/")
+  public String hello() {
+    return "Hello world";
+  }
+}

--- a/examples/multimodule-projects-on-kubernetes-example/multimodule-project-a-on-kubernetes-example/src/main/java/io/dekorate/example/Main.java
+++ b/examples/multimodule-projects-on-kubernetes-example/multimodule-project-a-on-kubernetes-example/src/main/java/io/dekorate/example/Main.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2021 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Main.class, args);
+  }
+
+}

--- a/examples/multimodule-projects-on-kubernetes-example/multimodule-project-a-on-kubernetes-example/src/main/resources/application.properties
+++ b/examples/multimodule-projects-on-kubernetes-example/multimodule-project-a-on-kubernetes-example/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+dekorate.docker.group=testme
+dekorate.kubernetes.replicas=1

--- a/examples/multimodule-projects-on-kubernetes-example/multimodule-project-b-on-kubernetes-example/Dockerfile
+++ b/examples/multimodule-projects-on-kubernetes-example/multimodule-project-b-on-kubernetes-example/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:8u171-alpine3.7
+RUN apk --no-cache add curl
+COPY target/*.jar multimodule-project-b-on-kubernetes-example.jar
+CMD java ${JAVA_OPTS} -jar multimodule-project-b-on-kubernetes-example.jar

--- a/examples/multimodule-projects-on-kubernetes-example/multimodule-project-b-on-kubernetes-example/pom.xml
+++ b/examples/multimodule-projects-on-kubernetes-example/multimodule-project-b-on-kubernetes-example/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>multimodule-project-b-on-kubernetes-example</artifactId>
+  <version>2.6-SNAPSHOT</version>
+  <name>Dekorate :: Examples :: Multi Module Project on Kubernetes :: Project B</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+
+    <version.spring-boot>2.4.5</version.spring-boot>
+    <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
+
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>docker-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring-boot}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/examples/multimodule-projects-on-kubernetes-example/multimodule-project-b-on-kubernetes-example/src/main/java/io/dekorate/example/Controller.java
+++ b/examples/multimodule-projects-on-kubernetes-example/multimodule-project-b-on-kubernetes-example/src/main/java/io/dekorate/example/Controller.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2021 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class Controller {
+
+  @RequestMapping("/")
+  public String hello() {
+    return "Hello world";
+  }
+}

--- a/examples/multimodule-projects-on-kubernetes-example/multimodule-project-b-on-kubernetes-example/src/main/java/io/dekorate/example/Main.java
+++ b/examples/multimodule-projects-on-kubernetes-example/multimodule-project-b-on-kubernetes-example/src/main/java/io/dekorate/example/Main.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2021 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Main.class, args);
+  }
+
+}

--- a/examples/multimodule-projects-on-kubernetes-example/multimodule-project-b-on-kubernetes-example/src/main/resources/application.properties
+++ b/examples/multimodule-projects-on-kubernetes-example/multimodule-project-b-on-kubernetes-example/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+dekorate.docker.group=testme
+dekorate.kubernetes.replicas=1

--- a/examples/multimodule-projects-on-kubernetes-example/multimodule-project-tests-on-kubernetes-example/pom.xml
+++ b/examples/multimodule-projects-on-kubernetes-example/multimodule-project-tests-on-kubernetes-example/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>multimodule-project-tests-on-kubernetes-example</artifactId>
+  <version>2.6-SNAPSHOT</version>
+  <name>Dekorate :: Examples :: Multi Module Project on Kubernetes :: Project Tests</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+
+    <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
+    <version.maven-failsafe-plugin>3.0.0-M3</version.maven-failsafe-plugin>
+
+  </properties>
+
+  <dependencies>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-junit-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.maven-failsafe-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <includes>
+                <include>**/*IT.class</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/examples/multimodule-projects-on-kubernetes-example/multimodule-project-tests-on-kubernetes-example/src/test/java/io/dekorate/example/SpringBootForMultiModuleAppsOnKubernetesIT.java
+++ b/examples/multimodule-projects-on-kubernetes-example/multimodule-project-tests-on-kubernetes-example/src/test/java/io/dekorate/example/SpringBootForMultiModuleAppsOnKubernetesIT.java
@@ -1,0 +1,83 @@
+/**
+ * Copyright 2021 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import io.dekorate.testing.annotation.KubernetesIntegrationTest;
+import io.dekorate.testing.annotation.Named;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.LocalPortForward;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import io.dekorate.testing.annotation.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@KubernetesIntegrationTest(additionalModules = { "../multimodule-project-a-on-kubernetes-example", "../multimodule-project-b-on-kubernetes-example" })
+class SpringBootForMultiModuleAppsOnKubernetesIT {
+
+  @Inject
+  private KubernetesClient client;
+
+  @Inject
+  private KubernetesList allResources;
+
+  @Inject
+  @Named("multimodule-project-a-on-kubernetes-example")
+  Pod podForProjectA;
+
+  @Inject
+  @Named("multimodule-project-b-on-kubernetes-example")
+  Pod podForProjectB;
+
+  @Test
+  public void shouldInjectAllInstances() {
+    assertNotNull(client);
+    assertNotNull(allResources);
+
+    // project a
+    assertNotNull(podForProjectA);
+
+    // project b
+    assertNotNull(podForProjectB);
+  }
+
+  @Test
+  public void shouldRespondWithHelloWorld() throws Exception {
+    assertHelloWorld(podForProjectA);
+    assertHelloWorld(podForProjectB);
+  }
+
+  private void assertHelloWorld(Pod pod) throws IOException {
+    try (LocalPortForward p = client.pods().withName(pod.getMetadata().getName()).portForward(9090)) {
+      assertTrue(p.isAlive());
+      URL url = new URL("http://localhost:"+p.getLocalPort()+"/");
+
+      OkHttpClient client = new OkHttpClient();
+      Request request = new Request.Builder().get().url(url).build();
+      Response response = client.newCall(request).execute();
+      assertEquals(response.body().string(), "Hello world");
+    }
+  }
+
+}

--- a/examples/multimodule-projects-on-kubernetes-example/pom.xml
+++ b/examples/multimodule-projects-on-kubernetes-example/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>multimodule-project-parent-on-kubernetes-example</artifactId>
+  <version>2.6-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>Dekorate :: Examples :: Multi Module Project on Kubernetes :: Parent</name>
+
+  <modules>
+    <module>multimodule-project-a-on-kubernetes-example</module>
+    <module>multimodule-project-b-on-kubernetes-example</module>
+    <module>multimodule-project-tests-on-kubernetes-example</module>
+  </modules>
+
+</project>

--- a/examples/multimodule-projects-on-openshift-example/multimodule-project-a-on-openshift-example/pom.xml
+++ b/examples/multimodule-projects-on-openshift-example/multimodule-project-a-on-openshift-example/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>multimodule-project-a-on-openshift-example</artifactId>
+  <version>2.6-SNAPSHOT</version>
+  <name>Dekorate :: Examples :: Multi Module Project on Openshift :: Project A</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+
+    <version.spring-boot>2.4.5</version.spring-boot>
+    <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
+
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>docker-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring-boot}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/examples/multimodule-projects-on-openshift-example/multimodule-project-a-on-openshift-example/src/main/java/io/dekorate/example/Controller.java
+++ b/examples/multimodule-projects-on-openshift-example/multimodule-project-a-on-openshift-example/src/main/java/io/dekorate/example/Controller.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2021 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class Controller {
+
+  @RequestMapping("/")
+  public String hello() {
+    return "Hello world";
+  }
+}

--- a/examples/multimodule-projects-on-openshift-example/multimodule-project-a-on-openshift-example/src/main/java/io/dekorate/example/Main.java
+++ b/examples/multimodule-projects-on-openshift-example/multimodule-project-a-on-openshift-example/src/main/java/io/dekorate/example/Main.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2021 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Main.class, args);
+  }
+
+}

--- a/examples/multimodule-projects-on-openshift-example/multimodule-project-a-on-openshift-example/src/main/resources/application.properties
+++ b/examples/multimodule-projects-on-openshift-example/multimodule-project-a-on-openshift-example/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+dekorate.openshift.expose=true

--- a/examples/multimodule-projects-on-openshift-example/multimodule-project-b-on-openshift-example/pom.xml
+++ b/examples/multimodule-projects-on-openshift-example/multimodule-project-b-on-openshift-example/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>multimodule-project-b-on-openshift-example</artifactId>
+  <version>2.6-SNAPSHOT</version>
+  <name>Dekorate :: Examples :: Multi Module Project on Openshift :: Project B</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+
+    <version.spring-boot>2.4.5</version.spring-boot>
+    <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
+
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>docker-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring-boot}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/examples/multimodule-projects-on-openshift-example/multimodule-project-b-on-openshift-example/src/main/java/io/dekorate/example/Controller.java
+++ b/examples/multimodule-projects-on-openshift-example/multimodule-project-b-on-openshift-example/src/main/java/io/dekorate/example/Controller.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2021 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class Controller {
+
+  @RequestMapping("/")
+  public String hello() {
+    return "Hello world";
+  }
+}

--- a/examples/multimodule-projects-on-openshift-example/multimodule-project-b-on-openshift-example/src/main/java/io/dekorate/example/Main.java
+++ b/examples/multimodule-projects-on-openshift-example/multimodule-project-b-on-openshift-example/src/main/java/io/dekorate/example/Main.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2021 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Main.class, args);
+  }
+
+}

--- a/examples/multimodule-projects-on-openshift-example/multimodule-project-b-on-openshift-example/src/main/resources/application.properties
+++ b/examples/multimodule-projects-on-openshift-example/multimodule-project-b-on-openshift-example/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+dekorate.openshift.expose=true

--- a/examples/multimodule-projects-on-openshift-example/multimodule-project-tests-on-openshift-example/pom.xml
+++ b/examples/multimodule-projects-on-openshift-example/multimodule-project-tests-on-openshift-example/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>multimodule-project-tests-on-openshift-example</artifactId>
+  <version>2.6-SNAPSHOT</version>
+  <name>Dekorate :: Examples :: Multi Module Project on Openshift :: Project Tests</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+
+    <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
+    <version.maven-failsafe-plugin>3.0.0-M3</version.maven-failsafe-plugin>
+
+  </properties>
+
+  <dependencies>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-junit-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.maven-failsafe-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <includes>
+                <include>**/*IT.class</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/examples/multimodule-projects-on-openshift-example/multimodule-project-tests-on-openshift-example/src/test/java/io/dekorate/example/SpringBootForMultiModuleAppsOnOpenshiftIT.java
+++ b/examples/multimodule-projects-on-openshift-example/multimodule-project-tests-on-openshift-example/src/test/java/io/dekorate/example/SpringBootForMultiModuleAppsOnOpenshiftIT.java
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2021 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import io.dekorate.testing.annotation.Named;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.api.model.Route;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import io.dekorate.testing.annotation.Inject;
+import io.dekorate.testing.openshift.annotation.OpenshiftIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@OpenshiftIntegrationTest(additionalModules = { "../multimodule-project-a-on-openshift-example", "../multimodule-project-b-on-openshift-example" })
+class SpringBootForMultiModuleAppsOnOpenshiftIT {
+
+  @Inject
+  private KubernetesClient client;
+
+  @Inject
+  private KubernetesList allResources;
+
+  @Inject
+  @Named("multimodule-project-a-on-openshift-example")
+  Pod podForProjectA;
+
+  @Inject
+  @Named("multimodule-project-a-on-openshift-example")
+  private Route routeForProjectA;
+
+  @Inject
+  @Named("multimodule-project-a-on-openshift-example")
+  private URL appUrlForProjectA;
+
+  @Inject
+  @Named("multimodule-project-b-on-openshift-example")
+  Pod podForProjectB;
+
+  @Inject
+  @Named("multimodule-project-b-on-openshift-example")
+  private Route routeForProjectB;
+
+  @Inject
+  @Named("multimodule-project-b-on-openshift-example")
+  private URL appUrlForProjectB;
+
+  @Test
+  public void shouldInjectAllInstances() {
+    assertNotNull(client);
+    assertNotNull(allResources);
+
+    // project a
+    assertNotNull(podForProjectA);
+    assertNotNull(routeForProjectA);
+    assertNotNull(appUrlForProjectA);
+
+    // project b
+    assertNotNull(podForProjectB);
+    assertNotNull(routeForProjectB);
+    assertNotNull(appUrlForProjectB);
+  }
+
+  @Test
+  public void shouldRespondWithHelloWorld() throws Exception {
+    assertHelloWorld(appUrlForProjectA);
+    assertHelloWorld(appUrlForProjectB);
+  }
+
+  private void assertHelloWorld(URL appUrl) throws IOException {
+    OkHttpClient client = new OkHttpClient();
+    Request request = new Request.Builder().get().url(appUrl).build();
+    Response response = client.newCall(request).execute();
+    assertEquals(response.body().string(), "Hello world");
+  }
+
+}

--- a/examples/multimodule-projects-on-openshift-example/pom.xml
+++ b/examples/multimodule-projects-on-openshift-example/pom.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>multimodule-project-parent-on-openshift-example</artifactId>
+  <version>2.6-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  <name>Dekorate :: Examples :: Multi Module Project on Openshift :: Parent</name>
+
+  <modules>
+    <module>multimodule-project-a-on-openshift-example</module>
+    <module>multimodule-project-b-on-openshift-example</module>
+    <module>multimodule-project-tests-on-openshift-example</module>
+  </modules>
+
+</project>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -36,6 +36,8 @@
     <module>thorntail-on-openshift-example</module>
     <module>vertx-on-kubernetes-example</module>
     <module>vertx-on-openshift-example</module>
+    <module>multimodule-projects-on-kubernetes-example</module>
+    <module>multimodule-projects-on-openshift-example</module>
   </modules>
 
   <profiles>

--- a/testing/core-junit/src/main/java/io/dekorate/testing/WithImageConfig.java
+++ b/testing/core-junit/src/main/java/io/dekorate/testing/WithImageConfig.java
@@ -31,8 +31,7 @@ public interface WithImageConfig extends WithProject {
   String CONFIG_YML = "%s.yml";
   String CONFIG_DIR = "config";
 
-  default <C extends ImageConfiguration> Stream<C> stream(Class<C> type) {
-    final Project project = getProject();
+  default <C extends ImageConfiguration> Stream<C> stream(Class<C> type, Project project) {
     final Path configDir = project.getBuildInfo().getClassOutputDir().resolve(project.getDekorateMetaDir())
         .resolve(CONFIG_DIR);
 
@@ -42,17 +41,17 @@ public interface WithImageConfig extends WithProject {
         .map(s -> configDir.resolve(s))
         .filter(p -> p.toFile().exists())
         .map(p -> Serialization.unmarshal(p.toFile(), ImageConfiguration.class))
-        .filter(BuildServiceFactories.configMatches(getProject()))
+        .filter(BuildServiceFactories.configMatches(project))
         .filter(i -> type.isInstance(i))
         .map(i -> (C) i);
   }
 
-  default boolean hasImageConfig() {
-    return stream(ImageConfiguration.class).findAny().isPresent();
+  default boolean hasImageConfig(Project project) {
+    return stream(ImageConfiguration.class, project).findAny().isPresent();
   }
 
-  default Optional<ImageConfiguration> getImageConfig() {
-    return stream(ImageConfiguration.class).findFirst();
+  default Optional<ImageConfiguration> getImageConfig(Project project) {
+    return stream(ImageConfiguration.class, project).findFirst();
   }
 
 }

--- a/testing/core-junit/src/main/java/io/dekorate/testing/WithPod.java
+++ b/testing/core-junit/src/main/java/io/dekorate/testing/WithPod.java
@@ -62,7 +62,8 @@ public interface WithPod
       return;
     }
 
-    String name = namedAnnotation(field).orElseGet(() -> getName());
+    String name = namedAnnotation(field).orElseGet(() -> getName(context));
+
     field.setAccessible(true);
     try {
       field.set(testInstance, podForName(context, name));
@@ -93,7 +94,7 @@ public interface WithPod
 
   /**
    * Returns the value of the {@link Named} annotation.
-   * 
+   *
    * @param field The target field.
    * @return An optional string with the name if the field is annotated or empty otherwise.
    */
@@ -105,8 +106,9 @@ public interface WithPod
   }
 
   /**
+   * @param context The execution context.
    * @return the resource name.
    */
-  String getName();
+  String getName(ExtensionContext context);
 
 }

--- a/testing/core-junit/src/main/java/io/dekorate/testing/WithProject.java
+++ b/testing/core-junit/src/main/java/io/dekorate/testing/WithProject.java
@@ -19,6 +19,14 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 import io.dekorate.DekorateException;
 import io.dekorate.project.FileProjectFactory;
@@ -29,20 +37,40 @@ public interface WithProject {
 
   String PROJECT_YML = ".project.yml";
 
-  default Project getProject() {
-    Project p = new FileProjectFactory().create(new File("."));
-    return getProject(p.getBuildInfo().getClassOutputDir().resolve(p.getDekorateMetaDir()).resolve(PROJECT_YML)
-        .toAbsolutePath().toString());
-  }
+  String[] getAdditionalModules(ExtensionContext context);
 
-  default Project getProject(String projectDescriptorPath) {
-    if (projectDescriptorPath != null) {
-      try (InputStream is = new FileInputStream(new File(projectDescriptorPath))) {
-        return Serialization.unmarshal(is, Project.class);
-      } catch (IOException e) {
-        throw DekorateException.launderThrowable(e);
+  default List<Project> getProjects(ExtensionContext context) {
+    try {
+      List<String> projectsLocations = new ArrayList<>();
+      // Current project
+      projectsLocations.add(".");
+      // Additional modules
+      projectsLocations.addAll(Arrays.asList(getAdditionalModules(context)));
+
+      List<Project> projects = new ArrayList<>();
+
+      for (String projectLocation : projectsLocations) {
+        // Get project to get the build info
+        Project projectInfo = new FileProjectFactory().create(new File(projectLocation));
+        // Class output dir might be either `target/classes` if Maven or `build/classes` for gradle,
+        // but the .project yaml files are located at `target/.dekorate/` or `build/.dekorate/`, so we need the parent of the
+        // class output dir:
+        Path outputPath = Paths.get(projectLocation).resolve(projectInfo.getBuildInfo().getClassOutputDir().getParent());
+        Files.walk(outputPath)
+            .filter(path -> path.getFileName().toString().endsWith(PROJECT_YML))
+            .map(path -> {
+              try (InputStream is = new FileInputStream(path.toFile())) {
+                return Serialization.unmarshal(is, Project.class);
+              } catch (IOException e) {
+                throw DekorateException.launderThrowable(e);
+              }
+            })
+            .forEach(projects::add);
       }
+
+      return projects;
+    } catch (IOException e) {
+      throw DekorateException.launderThrowable(e);
     }
-    throw new IllegalStateException("Expected to find manifest at: " + projectDescriptorPath + "!");
   }
 }

--- a/testing/kubernetes-junit/src/main/java/io/dekorate/testing/annotation/KubernetesIntegrationTest.java
+++ b/testing/kubernetes-junit/src/main/java/io/dekorate/testing/annotation/KubernetesIntegrationTest.java
@@ -59,4 +59,11 @@ public @interface KubernetesIntegrationTest {
    * @return The max amount in milliseconds.
    */
   long readinessTimeout() default 300000;
+
+  /**
+   * List of additional modules to be loaded by the test framework.
+   *
+   * @return The list of additional modules to be loaded.
+   */
+  String[] additionalModules() default {};
 }

--- a/testing/kubernetes-junit/src/main/java/io/dekorate/testing/kubernetes/WithKubernetesConfig.java
+++ b/testing/kubernetes-junit/src/main/java/io/dekorate/testing/kubernetes/WithKubernetesConfig.java
@@ -24,7 +24,6 @@ import java.nio.file.Path;
 
 import io.dekorate.DekorateException;
 import io.dekorate.kubernetes.config.KubernetesConfig;
-import io.dekorate.project.FileProjectFactory;
 import io.dekorate.project.Project;
 import io.dekorate.utils.Serialization;
 
@@ -33,17 +32,17 @@ public interface WithKubernetesConfig {
   String CONFIG_DIR = "config";
   String KUBERNETES_YML = "kubernetes.yml";
 
-  default boolean hasKubernetesConfig() {
-    return getKubernetesConfigPath().toFile().exists();
+  default boolean hasKubernetesConfig(Project project) {
+    return getKubernetesConfigPath(project).toFile().exists();
   }
 
-  default KubernetesConfig getKubernetesConfig() {
-    return getKubernetesConfig(getKubernetesConfigPath());
+  default KubernetesConfig getKubernetesConfig(Project project) {
+    return getKubernetesConfig(getKubernetesConfigPath(project));
   }
 
-  default Path getKubernetesConfigPath() {
-    Project p = new FileProjectFactory().create(new File("."));
-    return p.getBuildInfo().getClassOutputDir().resolve(p.getDekorateMetaDir()).resolve(CONFIG_DIR).resolve(KUBERNETES_YML);
+  default Path getKubernetesConfigPath(Project project) {
+    return project.getBuildInfo().getClassOutputDir().resolve(project.getDekorateMetaDir()).resolve(CONFIG_DIR)
+        .resolve(KUBERNETES_YML);
   }
 
   default KubernetesConfig getKubernetesConfig(Path path) {

--- a/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/WithOpenshiftConfig.java
+++ b/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/WithOpenshiftConfig.java
@@ -23,7 +23,6 @@ import java.nio.file.Path;
 
 import io.dekorate.DekorateException;
 import io.dekorate.openshift.config.OpenshiftConfig;
-import io.dekorate.project.FileProjectFactory;
 import io.dekorate.project.Project;
 import io.dekorate.utils.Serialization;
 
@@ -32,13 +31,13 @@ public interface WithOpenshiftConfig {
   String CONFIG_DIR = "config";
   String OPENSHIFT_YML = "openshift.yml";
 
-  default OpenshiftConfig getOpenshiftConfig() {
-    return getOpenshiftConfig(getOpenshiftConfigPath());
+  default OpenshiftConfig getOpenshiftConfig(Project project) {
+    return getOpenshiftConfig(getOpenshiftConfigPath(project));
   }
 
-  default Path getOpenshiftConfigPath() {
-    Project p = new FileProjectFactory().create(new File("."));
-    return p.getBuildInfo().getClassOutputDir().resolve(p.getDekorateMetaDir()).resolve(CONFIG_DIR).resolve(OPENSHIFT_YML);
+  default Path getOpenshiftConfigPath(Project project) {
+    return project.getBuildInfo().getClassOutputDir().resolve(project.getDekorateMetaDir()).resolve(CONFIG_DIR)
+        .resolve(OPENSHIFT_YML);
   }
 
   default OpenshiftConfig getOpenshiftConfig(Path path) {

--- a/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/WithRoute.java
+++ b/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/WithRoute.java
@@ -64,7 +64,7 @@ public interface WithRoute
       return;
     }
 
-    String name = namedAnnotationForRoute(field).orElseGet(this::getName);
+    String name = namedAnnotationForRoute(field).orElseGet(() -> getName(context));
     Route route = routeForName(context, name);
     field.setAccessible(true);
     try {
@@ -101,8 +101,9 @@ public interface WithRoute
   }
 
   /**
+   * @param context The execution context.
    * @return the resource name.
    */
-  String getName();
+  String getName(ExtensionContext context);
 
 }

--- a/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/annotation/OpenshiftIntegrationTest.java
+++ b/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/annotation/OpenshiftIntegrationTest.java
@@ -73,4 +73,11 @@ public @interface OpenshiftIntegrationTest {
    * @return The max amount in milliseconds.
    */
   long readinessTimeout() default 300000;
+
+  /**
+   * List of additional modules to be loaded by the test framework.
+   *
+   * @return The list of additional modules to be loaded.
+   */
+  String[] additionalModules() default {};
 }


### PR DESCRIPTION
Before this change, the OpenShift / Kubernetes JUnit extensions in Dekorate were only able to deploy the projects from the current classpath. 

Now, we can load additional modules as:

```java
@OpenshiftIntegrationTest(additionalModules = { "../multimodule-project-a-on-openshift-example", "../multimodule-project-b-on-openshift-example" })
class SpringBootForMultipleAppsOnOpenshiftIT {

  @Inject
  private KubernetesClient client;

  @Inject
  @Named("project-a-on-openshift-example")
  private KubernetesList resourcesForProjectA;

  @Inject
  @Named("multiple-project-a-on-openshift-example")
  Pod podForProjectA;

  @Inject
  @Named("multiple-project-a-on-openshift-example")
  private Route routeForProjectA;

  @Inject
  @Named("multiple-project-a-on-openshift-example")
  private URL appUrlForProjectA;

  @Inject
  @Named("project-b-on-openshift-example")
  private KubernetesList resourcesForProjectB;

  @Inject
  @Named("multiple-project-b-on-openshift-example")
  Pod podForProjectB;

  @Inject
  @Named("multiple-project-b-on-openshift-example")
  private Route routeForProjectB;

  @Inject
  @Named("multiple-project-b-on-openshift-example")
  private URL appUrlForProjectB;

  // ...
}
```

Note that as multiple projects are loaded, we need to use the `@Named` annotation to find the right resource to instantiate. 

**In case of you're not using a Multi Module project, you don't need to do anything to continue working as previously.**


Fix https://github.com/dekorateio/dekorate/issues/805
Fix https://github.com/dekorateio/dekorate/issues/806