### PR TITLE
Testing: Don't delete resources if deploy was disabled

### DIFF
--- a/testing/kubernetes-junit/src/main/java/io/dekorate/testing/kubernetes/KubernetesExtension.java
+++ b/testing/kubernetes-junit/src/main/java/io/dekorate/testing/kubernetes/KubernetesExtension.java
@@ -154,16 +154,20 @@ public class KubernetesExtension implements ExecutionCondition, BeforeAllCallbac
 
   @Override
   public void afterAll(ExtensionContext context) {
+    KubernetesIntegrationTestConfig config = getKubernetesIntegrationTestConfig(context);
+
     try {
       LOGGER.info("Cleaning up...");
       if (shouldDisplayDiagnostics(context)) {
         displayDiagnostics(context);
       }
 
-      getKubernetesResources(context).getItems().stream().forEach(r -> {
-        LOGGER.info("Deleting: " + r.getKind() + " name:" + r.getMetadata().getName() + ". Deleted:"
+      if (config.isDeployEnabled()) {
+        getKubernetesResources(context).getItems().stream().forEach(r -> {
+          LOGGER.info("Deleting: " + r.getKind() + " name:" + r.getMetadata().getName() + ". Deleted:"
             + getKubernetesClient(context).resource(r).cascading(true).delete());
-      });
+        });
+      }
     } finally {
       closeKubernetesClient(context);
     }


### PR DESCRIPTION
When using `@KubernetesIntegrationTest(deployEnabled = false)` or `@OpenShiftIntegrationTest(deployEnabled = false)` means that the test framework did not deploy the resources, but they were deployed before running the test. 

The problem is that regardless if the testing deployed the application or not, it's always deleting the resources.

With these changes, the test framework will only delete the resources if and only if the test framework deployed them.