### PR TITLE
Testing: Docker build should not be used if it's disabled

### DIFF
--- a/annotations/docker-annotations/src/main/java/io/dekorate/docker/buildservice/DockerBuildServiceFactory.java
+++ b/annotations/docker-annotations/src/main/java/io/dekorate/docker/buildservice/DockerBuildServiceFactory.java
@@ -23,6 +23,7 @@ import io.dekorate.BuildService;
 import io.dekorate.BuildServiceApplicablility;
 import io.dekorate.BuildServiceFactory;
 import io.dekorate.config.ConfigurationSupplier;
+import io.dekorate.docker.config.DockerBuildConfig;
 import io.dekorate.kubernetes.config.ImageConfiguration;
 import io.dekorate.project.Project;
 import io.dekorate.utils.Strings;
@@ -56,8 +57,14 @@ public class DockerBuildServiceFactory implements BuildServiceFactory {
 
   @Override
   public BuildServiceApplicablility checkApplicablility(Project project, ImageConfiguration config) {
-    String dockerFile = Strings.isNotNullOrEmpty(config.getDockerFile()) ? config.getDockerFile() : "Dockerfile";
-    boolean applicable = project.getRoot().resolve(dockerFile).toFile().exists();
+    if (!(config instanceof DockerBuildConfig)) {
+      return new BuildServiceApplicablility(false, "Docker build config not found");
+    }
+
+    DockerBuildConfig dockerBuildConfig = (DockerBuildConfig) config;
+    String dockerFile = Strings.isNotNullOrEmpty(dockerBuildConfig.getDockerFile()) ? dockerBuildConfig.getDockerFile()
+        : "Dockerfile";
+    boolean applicable = dockerBuildConfig.isEnabled() && project.getRoot().resolve(dockerFile).toFile().exists();
     String message = applicable
         ? MESSAGE_OK
         : String.format(MESSAGE_NOK, project.getRoot().resolve(dockerFile));

--- a/annotations/jib-annotations/src/main/java/io/dekorate/jib/buildservice/JibBuildServiceFactory.java
+++ b/annotations/jib-annotations/src/main/java/io/dekorate/jib/buildservice/JibBuildServiceFactory.java
@@ -25,6 +25,7 @@ import io.dekorate.BuildService;
 import io.dekorate.BuildServiceApplicablility;
 import io.dekorate.BuildServiceFactory;
 import io.dekorate.config.ConfigurationSupplier;
+import io.dekorate.jib.config.JibBuildConfig;
 import io.dekorate.kubernetes.config.ImageConfiguration;
 import io.dekorate.project.MavenInfoReader;
 import io.dekorate.project.Project;
@@ -47,9 +48,14 @@ public class JibBuildServiceFactory implements BuildServiceFactory {
 
   @Override
   public BuildServiceApplicablility checkApplicablility(Project project, ImageConfiguration config) {
-    boolean supportedTool = SUPPORTED_TOOLS.contains(project.getBuildInfo().getBuildTool());
+    if (!(config instanceof JibBuildConfig)) {
+      return new BuildServiceApplicablility(false, "Jib build config not found");
+    }
 
-    if (!supportedTool) {
+    JibBuildConfig buildConfig = (JibBuildConfig) config;
+    if (!buildConfig.isEnabled()) {
+      return new BuildServiceApplicablility(false, "Project build tool is disabled by Jib");
+    } else if (!SUPPORTED_TOOLS.contains(project.getBuildInfo().getBuildTool())) {
       return new BuildServiceApplicablility(false, "Project build tool no support by Jib");
     } else {
       return new BuildServiceApplicablility(true, "ok");

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/buildservice/S2iBuildServiceFactory.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/buildservice/S2iBuildServiceFactory.java
@@ -57,15 +57,16 @@ public class S2iBuildServiceFactory implements BuildServiceFactory {
 
   @Override
   public BuildServiceApplicablility checkApplicablility(Project project, ImageConfiguration config) {
-    if (config instanceof S2iBuildConfig) {
-      S2iBuildConfig s2iBuildConfig = (S2iBuildConfig) config;
-      if (s2iBuildConfig.isEnabled()) {
-        return new BuildServiceApplicablility(true, MESSAGE_OK);
-      } else {
-        return new BuildServiceApplicablility(false, MESSAGE_DISABLED);
-      }
+    if (!(config instanceof S2iBuildConfig)) {
+      return new BuildServiceApplicablility(false, "S2i build config not found");
     }
-    return new BuildServiceApplicablility(true, MESSAGE_OK);
+
+    S2iBuildConfig s2iBuildConfig = (S2iBuildConfig) config;
+    if (s2iBuildConfig.isEnabled()) {
+      return new BuildServiceApplicablility(true, MESSAGE_OK);
+    } else {
+      return new BuildServiceApplicablility(false, MESSAGE_DISABLED);
+    }
   }
 
   @Override

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/manifest/S2iManifestGenerator.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/manifest/S2iManifestGenerator.java
@@ -91,9 +91,8 @@ public class S2iManifestGenerator implements ManifestGenerator<S2iBuildConfig>, 
       ImageConfiguration imageConfig = configurationRegistry
           .getImageConfig(BuildServiceFactories.supplierMatches(getProject()))
           .orElse(null);
-      String registry = Strings.isNullOrEmpty(imageConfig.getRegistry()) ? "docker.io" : imageConfig.getRegistry();
-
       if (imageConfig != null) {
+        String registry = Strings.isNullOrEmpty(imageConfig.getRegistry()) ? "docker.io" : imageConfig.getRegistry();
         String image = Images.getImage(registry,
             imageConfig.getGroup(), imageConfig.getName(),
             imageConfig.getVersion());

--- a/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/WithOpenshiftConfig.java
+++ b/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/WithOpenshiftConfig.java
@@ -31,6 +31,10 @@ public interface WithOpenshiftConfig {
   String CONFIG_DIR = "config";
   String OPENSHIFT_YML = "openshift.yml";
 
+  default boolean hasOpenshiftConfig(Project project) {
+    return getOpenshiftConfigPath(project).toFile().exists();
+  }
+
   default OpenshiftConfig getOpenshiftConfig(Project project) {
     return getOpenshiftConfig(getOpenshiftConfigPath(project));
   }

--- a/tests/issue-821-docker-build-on-ocp-test/Dockerfile
+++ b/tests/issue-821-docker-build-on-ocp-test/Dockerfile
@@ -1,0 +1,3 @@
+# This file is to reproduce issue 821, we want to force the test to fail is this file is used as we want
+# to disable the Docker build strategy using `dekorate.docker.enabled=false`
+this file should never be used!

--- a/tests/issue-821-docker-build-on-ocp-test/pom.xml
+++ b/tests/issue-821-docker-build-on-ocp-test/pom.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>dekorate-tests</artifactId>
+    <groupId>io.dekorate</groupId>
+    <version>2.7-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>issue-821-docker-build-on-ocp-test</artifactId>
+  <name>Dekorate :: Tests :: Annotations :: Openshift :: Docker build cannot be disabled #821</name>
+  <description>Openshift test should be able to disable docker build to deploy the modules</description>
+
+  <properties>
+    <java.version>1.8</java.version>
+    <version.maven-failsafe-plugin>3.0.0-M3</version.maven-failsafe-plugin>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-junit</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- The following dependency is to reproduce issue 821: -->
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-junit</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${version.spring-boot}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <inherited>true</inherited>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring-boot}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.maven-failsafe-plugin}</version>
+        <configuration>
+          <systemPropertyVariables>
+            <app.name>${project.artifactId}</app.name>
+          </systemPropertyVariables>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/issue-821-docker-build-on-ocp-test/src/main/java/io/dekorate/example/Controller.java
+++ b/tests/issue-821-docker-build-on-ocp-test/src/main/java/io/dekorate/example/Controller.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class Controller {
+
+  @RequestMapping("/")
+  public String hello() {
+    return "Hello world";
+  }
+}

--- a/tests/issue-821-docker-build-on-ocp-test/src/main/java/io/dekorate/example/Main.java
+++ b/tests/issue-821-docker-build-on-ocp-test/src/main/java/io/dekorate/example/Main.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Main.class, args);
+  }
+
+}

--- a/tests/issue-821-docker-build-on-ocp-test/src/main/resources/application.properties
+++ b/tests/issue-821-docker-build-on-ocp-test/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+dekorate.openshift.expose=true
+dekorate.docker.enabled=false

--- a/tests/issue-821-docker-build-on-ocp-test/src/test/java/io/dekorate/example/Issue821IT.java
+++ b/tests/issue-821-docker-build-on-ocp-test/src/test/java/io/dekorate/example/Issue821IT.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dekorate.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.testing.annotation.Inject;
+import io.dekorate.testing.openshift.annotation.OpenshiftIntegrationTest;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+
+@OpenshiftIntegrationTest
+public class Issue821IT {
+
+  @Inject
+  private URL appUrl;
+
+  @Test
+  public void shouldRespondWithHelloWorld() throws Exception {
+    OkHttpClient client = new OkHttpClient();
+    Request request = new Request.Builder().get().url(appUrl).build();
+    Response response = client.newCall(request).execute();
+    assertEquals("Hello world", response.body().string());
+  }
+
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -57,6 +57,7 @@
       <module>issue-775-one-port</module>
       <module>issue-775-sb-server-port</module>
       <module>issue-791-missing-imagestream-with-default-configuration</module>
+      <module>issue-821-docker-build-on-ocp-test</module>
     </modules>
 
 </project>


### PR DESCRIPTION
The property `dekorate.docker.enabled` was being ignored by the test framework.
It also fixes the `jib` build.

Fix https://github.com/dekorateio/dekorate/issues/821