### PR TITLE
Support configuration based on spring/dekorate profiles, and components

### DIFF
--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/config/KnativeAdditionalResourcesProvider.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/config/KnativeAdditionalResourcesProvider.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+package io.dekorate.knative.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.dekorate.config.AdditionalResourcesProvider;
+
+public class KnativeAdditionalResourcesProvider implements AdditionalResourcesProvider {
+
+  @Override
+  public int order() {
+    return 4;
+  }
+
+  /**
+   * @return resource names for Knative annotations.
+   */
+  @Override
+  public List<String> getResourceNames() {
+    return Arrays.asList("application-knative.properties",
+        "application-knative.yaml",
+        "application-knative.yml");
+  }
+}

--- a/annotations/knative-annotations/src/main/resources/META-INF/services/io.dekorate.config.AdditionalResourcesProvider
+++ b/annotations/knative-annotations/src/main/resources/META-INF/services/io.dekorate.config.AdditionalResourcesProvider
@@ -1,0 +1,1 @@
+io.dekorate.knative.config.KnativeAdditionalResourcesProvider

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/config/KubernetesAdditionalResourcesProvider.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/config/KubernetesAdditionalResourcesProvider.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+package io.dekorate.kubernetes.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.dekorate.config.AdditionalResourcesProvider;
+
+public class KubernetesAdditionalResourcesProvider implements AdditionalResourcesProvider {
+
+  @Override
+  public int order() {
+    return 3;
+  }
+
+  /**
+   * @return resource names for Kubernetes annotations.
+   */
+  @Override
+  public List<String> getResourceNames() {
+    return Arrays.asList("application-kubernetes.properties",
+        "application-kubernetes.yaml",
+        "application-kubernetes.yml");
+  }
+}

--- a/annotations/kubernetes-annotations/src/main/resources/META-INF/services/io.dekorate.config.AdditionalResourcesProvider
+++ b/annotations/kubernetes-annotations/src/main/resources/META-INF/services/io.dekorate.config.AdditionalResourcesProvider
@@ -1,0 +1,1 @@
+io.dekorate.kubernetes.config.KubernetesAdditionalResourcesProvider

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/config/OpenshiftAdditionalResourcesProvider.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/config/OpenshiftAdditionalResourcesProvider.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+package io.dekorate.openshift.config;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.dekorate.config.AdditionalResourcesProvider;
+
+public class OpenshiftAdditionalResourcesProvider implements AdditionalResourcesProvider {
+
+  @Override
+  public int order() {
+    return 2;
+  }
+
+  /**
+   * @return resource names for Openshift annotations.
+   */
+  @Override
+  public List<String> getResourceNames() {
+    return Arrays.asList("application-openshift.properties",
+        "application-openshift.yaml",
+        "application-openshift.yml");
+  }
+}

--- a/annotations/openshift-annotations/src/main/resources/META-INF/services/io.dekorate.config.AdditionalResourcesProvider
+++ b/annotations/openshift-annotations/src/main/resources/META-INF/services/io.dekorate.config.AdditionalResourcesProvider
@@ -1,0 +1,1 @@
+io.dekorate.openshift.config.OpenshiftAdditionalResourcesProvider

--- a/core/src/main/java/io/dekorate/apt/DekorateProcessor.java
+++ b/core/src/main/java/io/dekorate/apt/DekorateProcessor.java
@@ -17,6 +17,9 @@
 
 package io.dekorate.apt;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
@@ -28,6 +31,7 @@ import io.dekorate.Logger;
 import io.dekorate.LoggerFactory;
 import io.dekorate.adapter.DekorateConfigAdapter;
 import io.dekorate.annotation.Dekorate;
+import io.dekorate.config.AdditionalResourcesLocator;
 import io.dekorate.config.DekorateConfig;
 import io.dekorate.doc.Description;
 import io.dekorate.processor.AbstractAnnotationProcessor;
@@ -51,9 +55,15 @@ public class DekorateProcessor extends AbstractAnnotationProcessor {
         LOGGER.info("Found @Dekorate on: " + mainClass.toString());
         Dekorate dekorate = mainClass.getAnnotation(Dekorate.class);
         DekorateConfig dekorateConfig = DekorateConfigAdapter.adapt(dekorate);
-        String[] configFiles = dekorateConfig.getResources().length > 0 ? dekorateConfig.getResources()
-            : DEFAULT_CONFIG_FILES;
-        getSession().addPropertyConfiguration(readApplicationConfig(configFiles));
+
+        List<String> resourceNames = new ArrayList<>();
+        // resource names from annotation or default:
+        resourceNames.addAll(Arrays.asList(dekorateConfig.getResources().length > 0 ? dekorateConfig.getResources()
+            : DEFAULT_CONFIG_FILES));
+        // resource names from active Dekorate features
+        resourceNames.addAll(AdditionalResourcesLocator.getAdditionalResources());
+
+        getSession().addPropertyConfiguration(readApplicationConfig(resourceNames.toArray(new String[resourceNames.size()])));
       }
     }
     return false;

--- a/core/src/main/java/io/dekorate/config/AdditionalResourcesLocator.java
+++ b/core/src/main/java/io/dekorate/config/AdditionalResourcesLocator.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.config;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+/**
+ * Utility class to locate all the additional resources.
+ */
+public final class AdditionalResourcesLocator {
+
+  private AdditionalResourcesLocator() {
+
+  }
+
+  public static List<String> getAdditionalResources() {
+    ServiceLoader<AdditionalResourcesProvider> loader = ServiceLoader.load(AdditionalResourcesProvider.class,
+        AdditionalResourcesProvider.class.getClassLoader());
+    return StreamSupport.stream(loader.spliterator(), false)
+        .sorted(Comparator.comparingInt(AdditionalResourcesProvider::order).reversed())
+        .flatMap(provider -> provider.getResourceNames().stream())
+        .collect(Collectors.toList());
+  }
+}

--- a/core/src/main/java/io/dekorate/config/AdditionalResourcesProvider.java
+++ b/core/src/main/java/io/dekorate/config/AdditionalResourcesProvider.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+package io.dekorate.config;
+
+import java.util.List;
+
+public interface AdditionalResourcesProvider {
+
+  /**
+   * @return the priority order for the additional resources.
+   */
+  int order();
+
+  /**
+   * @return list of additional resource names that Dekorate will use.
+   */
+  List<String> getResourceNames();
+}

--- a/core/src/main/java/io/dekorate/config/DekorateProfileAdditionalResourcesProvider.java
+++ b/core/src/main/java/io/dekorate/config/DekorateProfileAdditionalResourcesProvider.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+package io.dekorate.config;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class DekorateProfileAdditionalResourcesProvider implements AdditionalResourcesProvider {
+
+  private final String DEKORATE_PROFILE = "dekorate.properties.profile";
+
+  @Override
+  public int order() {
+    return 1;
+  }
+
+  /**
+   * @return resource names when the property Dekorate profile is set.
+   */
+  @Override
+  public List<String> getResourceNames() {
+    String profile = System.getProperty(DEKORATE_PROFILE);
+    if (profile == null || profile.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<String> resourceNames = new ArrayList<>();
+    resourceNames.add("application-" + profile + ".properties");
+    resourceNames.add("application-" + profile + ".yaml");
+    resourceNames.add("application-" + profile + ".yml");
+    return resourceNames;
+  }
+}

--- a/core/src/main/resources/META-INF/services/io.dekorate.config.AdditionalResourcesProvider
+++ b/core/src/main/resources/META-INF/services/io.dekorate.config.AdditionalResourcesProvider
@@ -1,0 +1,1 @@
+io.dekorate.config.DekorateProfileAdditionalResourcesProvider

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -32,6 +32,8 @@
         <module>spring-boot-on-kubernetes-with-jib-custom-registry-example</module>
         <module>spring-boot-on-openshift-example</module>
         <module>spring-boot-on-openshift-with-jib-custom-registry-example</module>
+        <module>spring-boot-on-openshift-with-ocp-properties-example</module>
+        <module>spring-boot-on-openshift-with-dekorate-profile-example</module>
         <module>spring-boot-with-groovy-on-openshift-example</module>
         <module>spring-boot-with-existing-manifests-on-kubernetes-example</module>
         <module>spring-boot-with-fmp-on-kubernetes-example</module>

--- a/examples/spring-boot-on-openshift-with-dekorate-profile-example/pom.xml
+++ b/examples/spring-boot-on-openshift-with-dekorate-profile-example/pom.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>spring-boot-on-openshift-with-dekorate-profile-example</artifactId>
+  <version>2.7-SNAPSHOT</version>
+  <name>Dekorate :: Examples :: Spring Boot on Openshift with dekorate profile</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+
+    <version.spring-boot>2.4.5</version.spring-boot>
+    <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
+    <version.maven-failsafe-plugin>3.0.0-M3</version.maven-failsafe-plugin>
+    <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
+    <version.properties-maven-plugin>1.0.0</version.properties-maven-plugin>
+
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>docker-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-junit-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>${version.properties-maven-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>set-system-properties</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <property>
+                  <name>dekorate.properties.profile</name>
+                  <value>foo</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring-boot}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.maven-surefire-plugin}</version>
+        <inherited>true</inherited>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.maven-failsafe-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <includes>
+                <include>**/*IT.class</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/examples/spring-boot-on-openshift-with-dekorate-profile-example/src/main/java/io/dekorate/example/Controller.java
+++ b/examples/spring-boot-on-openshift-with-dekorate-profile-example/src/main/java/io/dekorate/example/Controller.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class Controller {
+
+  @RequestMapping("/")
+  public String hello() {
+    return "Hello world";
+  }
+}

--- a/examples/spring-boot-on-openshift-with-dekorate-profile-example/src/main/java/io/dekorate/example/Main.java
+++ b/examples/spring-boot-on-openshift-with-dekorate-profile-example/src/main/java/io/dekorate/example/Main.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Main.class, args);
+  }
+
+}

--- a/examples/spring-boot-on-openshift-with-dekorate-profile-example/src/main/resources/application-foo.properties
+++ b/examples/spring-boot-on-openshift-with-dekorate-profile-example/src/main/resources/application-foo.properties
@@ -1,0 +1,1 @@
+dekorate.openshift.expose=true

--- a/examples/spring-boot-on-openshift-with-dekorate-profile-example/src/test/java/io/dekorate/example/SpringBootOnOpenshiftIT.java
+++ b/examples/spring-boot-on-openshift-with-dekorate-profile-example/src/test/java/io/dekorate/example/SpringBootOnOpenshiftIT.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import io.fabric8.openshift.api.model.Route;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import io.dekorate.testing.annotation.Inject;
+import io.dekorate.testing.openshift.annotation.OpenshiftIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@OpenshiftIntegrationTest
+class SpringBootOnOpenshiftIT {
+  @Inject
+  private Route route;
+
+  @Inject
+  private URL appUrl;
+
+  @Test
+  public void shouldRespondWithHelloWorld() throws Exception {
+    assertNotNull(route);
+    assertNotNull(appUrl);
+
+    OkHttpClient client = new OkHttpClient();
+    Request request = new Request.Builder().get().url(appUrl).build();
+    Response response = client.newCall(request).execute();
+    assertEquals(response.body().string(), "Hello world");
+  }
+
+}

--- a/examples/spring-boot-on-openshift-with-dekorate-profile-example/src/test/java/io/dekorate/example/SpringBootOnOpenshiftTest.java
+++ b/examples/spring-boot-on-openshift-with-dekorate-profile-example/src/test/java/io/dekorate/example/SpringBootOnOpenshiftTest.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+package io.dekorate.example;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.openshift.api.model.BuildConfig;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+import io.dekorate.utils.Serialization;
+
+class SpringBootOnOpenshiftTest {
+
+  @Test
+  public void shouldHaveMatchingOutputImageAndTrigger() {
+    KubernetesList list = Serialization.unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/openshift.yml"));
+    assertNotNull(list);
+    DeploymentConfig d = findFirst(list, DeploymentConfig.class).orElseThrow(() -> new IllegalStateException());
+    BuildConfig b = findFirst(list, BuildConfig.class).orElseThrow(() -> new IllegalStateException());
+    assertNotNull(d);
+    assertNotNull(b);
+    assertTrue(d.getSpec().getTriggers().stream().filter(t -> t.getImageChangeParams().getFrom().getName().equals(b.getSpec().getOutput().getTo().getName())).findFirst().isPresent());
+  }
+
+  <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {
+    return (Optional<T>) list.getItems().stream()
+      .filter(i -> t.isInstance(i))
+      .findFirst();
+  }
+}

--- a/examples/spring-boot-on-openshift-with-ocp-properties-example/pom.xml
+++ b/examples/spring-boot-on-openshift-with-ocp-properties-example/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>spring-boot-on-openshift-with-ocp-properties-example</artifactId>
+  <version>2.7-SNAPSHOT</version>
+  <name>Dekorate :: Examples :: Spring Boot on Openshift with application-openshift.properties</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <java.version>1.8</java.version>
+
+    <version.spring-boot>2.4.5</version.spring-boot>
+    <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
+    <version.maven-failsafe-plugin>3.0.0-M3</version.maven-failsafe-plugin>
+    <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
+
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>docker-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-spring-starter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-junit-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>${java.version}</source>
+          <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring-boot}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.maven-surefire-plugin}</version>
+        <inherited>true</inherited>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${version.maven-failsafe-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <phase>integration-test</phase>
+            <configuration>
+              <includes>
+                <include>**/*IT.class</include>
+              </includes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/examples/spring-boot-on-openshift-with-ocp-properties-example/src/main/java/io/dekorate/example/Controller.java
+++ b/examples/spring-boot-on-openshift-with-ocp-properties-example/src/main/java/io/dekorate/example/Controller.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class Controller {
+
+  @RequestMapping("/")
+  public String hello() {
+    return "Hello world";
+  }
+}

--- a/examples/spring-boot-on-openshift-with-ocp-properties-example/src/main/java/io/dekorate/example/Main.java
+++ b/examples/spring-boot-on-openshift-with-ocp-properties-example/src/main/java/io/dekorate/example/Main.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Main {
+
+  public static void main(String[] args) {
+    SpringApplication.run(Main.class, args);
+  }
+
+}

--- a/examples/spring-boot-on-openshift-with-ocp-properties-example/src/main/resources/application-openshift.properties
+++ b/examples/spring-boot-on-openshift-with-ocp-properties-example/src/main/resources/application-openshift.properties
@@ -1,0 +1,1 @@
+dekorate.openshift.expose=true

--- a/examples/spring-boot-on-openshift-with-ocp-properties-example/src/test/java/io/dekorate/example/SpringBootOnOpenshiftIT.java
+++ b/examples/spring-boot-on-openshift-with-ocp-properties-example/src/test/java/io/dekorate/example/SpringBootOnOpenshiftIT.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.example;
+
+import io.fabric8.openshift.api.model.Route;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import io.dekorate.testing.annotation.Inject;
+import io.dekorate.testing.openshift.annotation.OpenshiftIntegrationTest;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@OpenshiftIntegrationTest
+class SpringBootOnOpenshiftIT {
+  @Inject
+  private Route route;
+
+  @Inject
+  private URL appUrl;
+
+  @Test
+  public void shouldRespondWithHelloWorld() throws Exception {
+    assertNotNull(route);
+    assertNotNull(appUrl);
+
+    OkHttpClient client = new OkHttpClient();
+    Request request = new Request.Builder().get().url(appUrl).build();
+    Response response = client.newCall(request).execute();
+    assertEquals(response.body().string(), "Hello world");
+  }
+
+}

--- a/frameworks/thorntail/src/main/java/io/dekorate/thorntail/ThorntailProcessor.java
+++ b/frameworks/thorntail/src/main/java/io/dekorate/thorntail/ThorntailProcessor.java
@@ -15,6 +15,8 @@
  */
 package io.dekorate.thorntail;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
@@ -24,6 +26,7 @@ import javax.lang.model.element.TypeElement;
 
 import io.dekorate.ConfigurationRegistry;
 import io.dekorate.Session;
+import io.dekorate.config.AdditionalResourcesLocator;
 import io.dekorate.doc.Description;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 import io.dekorate.thorntail.configurator.ThorntailPrometheusAgentConfigurator;
@@ -42,7 +45,13 @@ public class ThorntailProcessor extends AbstractAnnotationProcessor implements T
       return true;
     }
 
-    session.addPropertyConfiguration(readApplicationConfig("project-defaults.yml"));
+    List<String> resourceNames = new ArrayList<>();
+    // default resource names:
+    resourceNames.add("project-defaults.yml");
+    // resource names from active Dekorate features
+    resourceNames.addAll(AdditionalResourcesLocator.getAdditionalResources());
+
+    session.addPropertyConfiguration(readApplicationConfig(resourceNames.toArray(new String[resourceNames.size()])));
     for (TypeElement typeElement : annotations) {
       for (Element mainClass : roundEnv.getElementsAnnotatedWith(typeElement)) {
         add(mainClass);

--- a/readme.md
+++ b/readme.md
@@ -1123,9 +1123,23 @@ an `application` descriptor will override any existing annotation-specified conf
 2. `application.properties`
 3. `application.yaml`
 4. `application.yml`
-5. `application-kubernetes.properties`
-6. `application-kubernetes.yaml`
-7. `application-kubernetes.yml`
+
+Then,  it will use the properties file depending on the active Dekorate dependencies in use. For example, if we're using the dependency `io.dekorate:kubernetes-annotations`, then:
+1. `application-kubernetes.properties`
+2. `application-kubernetes.yaml`
+3. `application-kubernetes.yml`
+
+| Note that only the `openshift`, `kubernetes` and `knative` modules are providing additional properties files.
+
+Then, for Spring Boot applications, it will also take into account the Spring property `spring.profiles.active` if set:
+1. `application-${spring.profiles.active}.properties`
+2. `application-${spring.profiles.active}.yaml`
+3. `application-${spring.profiles.active}.yml`
+
+Finally, if the Dekorate profile property `dekorate.properties.profile` is set:
+1. if property `dekorate.properties.profile` is set, then `application-${dekorate.properties.profile}.properties`
+2. if property `dekorate.properties.profile` is set, then `application-${dekorate.properties.profile}.yaml`
+3. if property `dekorate.properties.profile` is set, then `application-${dekorate.properties.profile}.yml`
 
 It's important to repeat that the override that occurs by *fully* replacing any lower-priority configuration and not via any kind
 of merge between the existing and higher-priority values. This means that if you choose to override the annotation-specified


### PR DESCRIPTION
New order of properties file to use:

1. Annotations
2. `application.properties`
3. `application.yaml`
4. `application.yml`

Then,  it will use the properties file depending on the active Dekorate dependencies in use. For example, if we're using the dependency `io.dekorate:kubernetes-annotations`, then:
1. `application-kubernetes.properties`
2. `application-kubernetes.yaml`
3. `application-kubernetes.yml`

| Note that only the `openshift`, `kubernetes` and `knative` modules are providing additional properties files.

Then, for Spring Boot applications, it will also take into account the Spring property `spring.profiles.active` if set:
1. `application-${spring.profiles.active}.properties`
2. `application-${spring.profiles.active}.yaml`
3. `application-${spring.profiles.active}.yml`

Finally, if the Dekorate profile property `dekorate.properties.profile` is set:
1. if property `dekorate.properties.profile` is set, then `application-${dekorate.properties.profile}.properties`
2. if property `dekorate.properties.profile` is set, then `application-${dekorate.properties.profile}.yaml`
3. if property `dekorate.properties.profile` is set, then `application-${dekorate.properties.profile}.yml`
