### PR TITLE
Fix JSON auto generated files

### DIFF
--- a/core/src/main/java/io/dekorate/utils/Serialization.java
+++ b/core/src/main/java/io/dekorate/utils/Serialization.java
@@ -139,12 +139,9 @@ public class Serialization {
     try {
       if (object instanceof KubernetesList) {
         KubernetesList list = (KubernetesList) object;
-        if (list.getItems().size() == 1) {
-          return JSON_MAPPER.writeValueAsString(list.getItems().get(0));
-        }
         return list.getItems().stream()
             .map(Serialization::writeValueAsJsonSafe)
-            .collect(Collectors.joining());
+            .collect(Collectors.joining(",", "[", "]"));
       }
       return JSON_MAPPER.writeValueAsString(object);
     } catch (JsonProcessingException e) {


### PR DESCRIPTION
At the moment, the auto-generated file `kubernetes.json` looks like:

```json
{ object 1}{ object 2}{ object 3}
```

Which is not well formatted. This PR fixes this and produces the JSON file in the right format:

```json
[{ object 1}, 
{ object 2},
{ object 3}]
```