### PR TITLE
Spring Boot: Change default actuator liveness/readiness probes

### DIFF
--- a/frameworks/spring-boot/src/main/java/io/dekorate/spring/generator/SpringBootApplicationGenerator.java
+++ b/frameworks/spring-boot/src/main/java/io/dekorate/spring/generator/SpringBootApplicationGenerator.java
@@ -86,10 +86,10 @@ public interface SpringBootApplicationGenerator extends ConfigurationGenerator, 
 
     if (isActuatorAvailable()) {
       //Users configuration should take priority, so add but don't overwrite.
-      session.getConfigurationRegistry().add(
-          new AddLivenessProbeConfigurator(new ProbeBuilder().withHttpActionPath("/actuator/info").build(), false));
+      session.getConfigurationRegistry().add(new AddLivenessProbeConfigurator(
+          new ProbeBuilder().withHttpActionPath("/actuator/health/liveness").build(), false));
       session.getConfigurationRegistry().add(new AddReadinessProbeConfigurator(
-          new ProbeBuilder().withHttpActionPath("/actuator/health").build(), false));
+          new ProbeBuilder().withHttpActionPath("/actuator/health/readiness").build(), false));
     }
 
     if (isSpringCloudKubernetesAvailable()) {


### PR DESCRIPTION
From Spring Boot 2.3, the `/actuator/info` endpoint which is used by the liveness probe, will only be exposed if and only if there is data to present (or it's forced by using `management.endpoints.web.exposure.include=info`).

Moreover, from Spring Boot 2.3, we should use the health liveness / readiness endpoints.