### PR TITLE
Fix parsing in `Git.getRemotes` to ignore submodules

### DIFF
--- a/core/src/main/java/io/dekorate/utils/Git.java
+++ b/core/src/main/java/io/dekorate/utils/Git.java
@@ -23,10 +23,10 @@ package io.dekorate.utils;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -85,13 +85,17 @@ public class Git {
   public static Map<String, String> getRemotes(Path path) {
     Map<String, String> result = new HashMap<String, String>();
     try {
-      final AtomicReference<String> currentRemote = new AtomicReference<>();
-      Files.lines(getConfig(path)).map(String::trim).forEach(l -> {
-        remoteValue(l).ifPresent(r -> currentRemote.set(r));
-        if (l.startsWith(URL) && l.contains(EQUALS)) {
-          result.put(currentRemote.get(), l.split(EQUALS)[1].trim());
-        }
-      });
+      Iterator<String> linesIter = Files.lines(getConfig(path)).map(String::trim).iterator();
+      while (linesIter.hasNext()) {
+        remoteValue(linesIter.next()).ifPresent(remote -> {
+          while (linesIter.hasNext()) {
+            String remoteLine = linesIter.next();
+            if (remoteLine.startsWith(URL) && remoteLine.contains(EQUALS)) {
+              result.put(remote, remoteLine.split(EQUALS)[1].trim());
+            }
+          }
+        });
+      }
       return result;
     } catch (Exception e) {
       return result;

--- a/core/src/test/java/io/dekorate/utils/GitTest.java
+++ b/core/src/test/java/io/dekorate/utils/GitTest.java
@@ -39,6 +39,7 @@ class GitTest {
   private static final ClassLoader loader = GitTest.class.getClassLoader();
   private static final String CONFIG_SUFFIX = "/git/config";
   private static final String GIT_SIMPLE = "git-simple";
+  private static final String GIT_SUB = "git-sub";
   private static final String GIT_SSH = "git-ssh";
   private static final String GIT_GITLAB = "git-gitlab";
   private static final Map<String, Path> configurationNameToConfigRoot = new HashMap<>(7);
@@ -46,6 +47,7 @@ class GitTest {
   @BeforeAll
   static void setup() {
     setup(GIT_SIMPLE);
+    setup(GIT_SUB);
     setup(GIT_SSH);
     setup(GIT_GITLAB);
   }
@@ -132,5 +134,15 @@ class GitTest {
     Map<String, String> remotes = Git.getRemotes(root);
     assertNotNull(remotes);
     assertFalse(remotes.isEmpty());
+  }
+
+  @ParameterizedTest(name = "should read remotes map ignoring submodules from \"{0}\"")
+  @ValueSource(strings = { GIT_SUB })
+  void filtersSubmodules(String configFile) throws Exception {
+    final Path root = getRootFor(configFile);
+    Map<String, String> remotes = Git.getRemotes(root);
+    assertNotNull(remotes);
+    assertTrue(remotes.containsKey("[remote \"origin\"]"));
+    assertEquals(1, remotes.size());
   }
 }

--- a/core/src/test/resources/git-sub/git/config
+++ b/core/src/test/resources/git-sub/git/config
@@ -1,0 +1,14 @@
+[core]
+        repositoryformatversion = 0
+        filemode = true
+        bare = false
+        logallrefupdates = true
+[submodule "sub"]
+        url = git@github.com:myorg/myprojectsub.git
+	      active = true
+[remote "origin"]
+        url = git@github.com:myorg/myproject.git
+        fetch = +refs/heads/*:refs/remotes/origin/*
+        fetch = +refs/pull/*/head:refs/pullreqs/*
+[branch "master"]
+        pushRemote = origin


### PR DESCRIPTION
The parsing of git config in the `Git.getRemotes` now properly ignores submodule references.

Previously, a any submodule sections would add a null keyed entry to the hash map. Aside from _not_ being a remote, it causes `DekorateException`s on output with the message "JSON doesn't allow `null` as a map key".