### PR TITLE
refactor: fix website job

### DIFF
--- a/.github/publish-docs.sh
+++ b/.github/publish-docs.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-version=$1;
-
-yq eval ".release.current-version = \"$version\"" docs/_data/project.yml | sponge docs/_data/project.yml
-git checkout -b gh-pages
-git add docs/_data/project.yml
-git commit -m "chore: update project version for Dekorate docs."
-git push origin -u gh-pages
-

--- a/.github/set-version.sh
+++ b/.github/set-version.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+release_version=$1;
+if [ -z $release_version ]; then
+  echo "Option --release_version is required!"
+  exit 1
+fi
+
+echo "Setting release_version=$release_version"
+yq eval ".release.current-version = \"$release_version\"" docs/_data/project.yml | sponge docs/_data/project.yml
+

--- a/.github/set-version.sh
+++ b/.github/set-version.sh
@@ -2,7 +2,7 @@
 
 release_version=$1;
 if [ -z $release_version ]; then
-  echo "Option --release_version is required!"
+  echo "Release version param is required!"
   exit 1
 fi
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -4,18 +4,24 @@ on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
+
 jobs:
   publish-website:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-      - name: Render docs and publish
+      - name: Set version
+        run: |
+          sudo apt-get install moreutils
+          .github/set-version.sh $GITHUB_REF_NAME
+      - name: Commit files
         run: |
           git config --global user.name "Dekorate"
           git config --global user.email "cmoullia-staff@redhat.com"
-          sudo apt-get install moreutils
-          echo $RELEASE_VERSION
-          echo ${{ env.RELEASE_VERSION }}
-          .github/publish-docs.sh $RELEASE_VERSION
+          git add docs/_data/project.yml
+          git commit -m "chore: update project version for Dekorate docs."
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages


### PR DESCRIPTION
The github action triggers on a tag push. It will set the correct version in the [file](https://github.com/dekorateio/dekorate/blob/9d56563ec00d087e1e055a6a690f36deb6f3db90/docs/_data/project.yml#L4-L3) used by Jekyll for gathering the Dekorate version in the whole site.

Fixes #860 
