### PR TITLE
refactor: set correct version for docs

### DIFF
--- a/docs/_data/project.yml
+++ b/docs/_data/project.yml
@@ -1,3 +1,3 @@
 name: Dekorate
 release:
-  current-version: 2.6.0
+  current-version: 2.9.0


### PR DESCRIPTION
Quick PR to update manually the Dekorate version in site and docs. FYI next time it will be done by [this job](https://github.com/dekorateio/dekorate/blob/f6f1350d65510ed302646832460338d0a7c96fbb/.github/workflows/website.yml#L13) that triggers when a new tag is pushed.