### PR TITLE
Knative: Fix generated resources

### DIFF
--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyAnnotationsToServiceTemplate.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyAnnotationsToServiceTemplate.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+package io.dekorate.knative.decorator;
+
+import java.util.Map;
+
+import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
+import io.dekorate.utils.Maps;
+import io.fabric8.knative.serving.v1.ServiceFluent;
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+
+public class ApplyAnnotationsToServiceTemplate extends NamedResourceDecorator<ServiceFluent<?>> {
+
+  private static final String SERVICE_KIND = "Service";
+
+  private final Map<String, String> annotations;
+
+  public ApplyAnnotationsToServiceTemplate(String name, String... annotations) {
+    this(name, Maps.from(annotations));
+  }
+
+  public ApplyAnnotationsToServiceTemplate(String name, Map<String, String> annotations) {
+    super(SERVICE_KIND, name);
+    this.annotations = annotations;
+  }
+
+  @Override
+  public void andThenVisit(ServiceFluent<?> service, ObjectMeta resourceMeta) {
+    service.editOrNewSpec().editOrNewTemplate().editOrNewMetadata()
+        .addToAnnotations(annotations)
+        .endMetadata().endTemplate().endSpec();
+  }
+}

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyGlobalContainerConcurrencyDecorator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyGlobalContainerConcurrencyDecorator.java
@@ -22,12 +22,13 @@ import io.fabric8.kubernetes.api.model.ObjectMeta;
 
 public class ApplyGlobalContainerConcurrencyDecorator extends NamedResourceDecorator<ConfigMapFluent<?>> {
 
+  public static final String CONFIG_DEFAULTS = "config-defaults";
   private static final String CONTAINER_CONCURRENCY = "container-concurrency";
 
   private final int target;
 
   public ApplyGlobalContainerConcurrencyDecorator(int target) {
-    super("config-autoscaler");
+    super(CONFIG_DEFAULTS);
     this.target = target;
   }
 

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyLocalAutoscalingClassDecorator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyLocalAutoscalingClassDecorator.java
@@ -18,26 +18,13 @@
 package io.dekorate.knative.decorator;
 
 import io.dekorate.knative.config.AutoScalerClass;
-import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
-import io.fabric8.knative.serving.v1.ServiceFluent;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 
-public class ApplyLocalAutoscalingClassDecorator extends NamedResourceDecorator<ServiceFluent<?>> {
+public class ApplyLocalAutoscalingClassDecorator extends ApplyAnnotationsToServiceTemplate {
 
   private static final String AUTOSCALING_CLASS = "autoscaling.knative.dev/class";
   private static final String AUTOSCALING_CLASS_SUFFIX = ".autoscaling.knative.dev";
 
-  private final AutoScalerClass clazz;
-
   public ApplyLocalAutoscalingClassDecorator(String name, AutoScalerClass clazz) {
-    super("Service", name);
-    this.clazz = clazz;
-  }
-
-  @Override
-  public void andThenVisit(ServiceFluent<?> service, ObjectMeta resourceMeta) {
-    service.editMetadata()
-        .addToAnnotations(AUTOSCALING_CLASS, clazz.name().toLowerCase() + AUTOSCALING_CLASS_SUFFIX)
-        .endMetadata();
+    super(name, AUTOSCALING_CLASS, clazz.name().toLowerCase() + AUTOSCALING_CLASS_SUFFIX);
   }
 }

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyLocalAutoscalingMetricDecorator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyLocalAutoscalingMetricDecorator.java
@@ -18,25 +18,12 @@
 package io.dekorate.knative.decorator;
 
 import io.dekorate.knative.config.AutoscalingMetric;
-import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
-import io.fabric8.knative.serving.v1.ServiceFluent;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
 
-public class ApplyLocalAutoscalingMetricDecorator extends NamedResourceDecorator<ServiceFluent<?>> {
+public class ApplyLocalAutoscalingMetricDecorator extends ApplyAnnotationsToServiceTemplate {
 
   private static final String AUTOSCALING_METRIC = "autoscaling.knative.dev/metric";
 
-  private final AutoscalingMetric clazz;
-
   public ApplyLocalAutoscalingMetricDecorator(String name, AutoscalingMetric clazz) {
-    super("Service", name);
-    this.clazz = clazz;
-  }
-
-  @Override
-  public void andThenVisit(ServiceFluent<?> service, ObjectMeta resourceMeta) {
-    service.editMetadata()
-        .addToAnnotations(AUTOSCALING_METRIC, clazz.name().toLowerCase())
-        .endMetadata();
+    super(name, AUTOSCALING_METRIC, clazz.name().toLowerCase());
   }
 }

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyLocalAutoscalingTargetDecorator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyLocalAutoscalingTargetDecorator.java
@@ -17,25 +17,11 @@
 
 package io.dekorate.knative.decorator;
 
-import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
-import io.fabric8.knative.serving.v1.ServiceFluent;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-
-public class ApplyLocalAutoscalingTargetDecorator extends NamedResourceDecorator<ServiceFluent<?>> {
+public class ApplyLocalAutoscalingTargetDecorator extends ApplyAnnotationsToServiceTemplate {
 
   private static final String AUTOSCALING_TARGET = "autoscaling.knative.dev/target";
 
-  private final int target;
-
   public ApplyLocalAutoscalingTargetDecorator(String name, int target) {
-    super("Service", name);
-    this.target = target;
-  }
-
-  @Override
-  public void andThenVisit(ServiceFluent<?> service, ObjectMeta resourceMeta) {
-    service.editMetadata()
-        .addToAnnotations(AUTOSCALING_TARGET, String.valueOf(target))
-        .endMetadata();
+    super(name, AUTOSCALING_TARGET, String.valueOf(target));
   }
 }

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyLocalTargetUtilizationPercentageDecorator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyLocalTargetUtilizationPercentageDecorator.java
@@ -17,25 +17,11 @@
 
 package io.dekorate.knative.decorator;
 
-import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
-import io.fabric8.knative.serving.v1.ServiceFluent;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-
-public class ApplyLocalTargetUtilizationPercentageDecorator extends NamedResourceDecorator<ServiceFluent<?>> {
+public class ApplyLocalTargetUtilizationPercentageDecorator extends ApplyAnnotationsToServiceTemplate {
 
   private static final String UTILIZATION_PERCENTAGE = "autoscaling.knative.dev/targetUtilizationPercentage";
 
-  private final int target;
-
   public ApplyLocalTargetUtilizationPercentageDecorator(String name, int target) {
-    super("Service", name);
-    this.target = target;
-  }
-
-  @Override
-  public void andThenVisit(ServiceFluent<?> service, ObjectMeta resourceMeta) {
-    service.editMetadata()
-        .addToAnnotations(UTILIZATION_PERCENTAGE, String.valueOf(target))
-        .endMetadata();
+    super(name, UTILIZATION_PERCENTAGE, String.valueOf(target));
   }
 }

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyMaxScaleDecorator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyMaxScaleDecorator.java
@@ -17,25 +17,11 @@
 
 package io.dekorate.knative.decorator;
 
-import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
-import io.fabric8.knative.serving.v1.ServiceFluent;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-
-public class ApplyMaxScaleDecorator extends NamedResourceDecorator<ServiceFluent<?>> {
+public class ApplyMaxScaleDecorator extends ApplyAnnotationsToServiceTemplate {
 
   private static final String MAX_SCALE = "autoscaling.knative.dev/maxScale";
 
-  private final int scale;
-
   public ApplyMaxScaleDecorator(String name, int scale) {
-    super("Service", name);
-    this.scale = scale;
-  }
-
-  @Override
-  public void andThenVisit(ServiceFluent<?> service, ObjectMeta resourceMeta) {
-    service.editMetadata()
-        .addToAnnotations(MAX_SCALE, String.valueOf(scale))
-        .endMetadata();
+    super(name, MAX_SCALE, String.valueOf(scale));
   }
 }

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyMinScaleDecorator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyMinScaleDecorator.java
@@ -17,25 +17,11 @@
 
 package io.dekorate.knative.decorator;
 
-import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
-import io.fabric8.knative.serving.v1.ServiceFluent;
-import io.fabric8.kubernetes.api.model.ObjectMeta;
-
-public class ApplyMinScaleDecorator extends NamedResourceDecorator<ServiceFluent<?>> {
+public class ApplyMinScaleDecorator extends ApplyAnnotationsToServiceTemplate {
 
   private static final String MIN_SCALE = "autoscaling.knative.dev/minScale";
 
-  private final int scale;
-
   public ApplyMinScaleDecorator(String name, int scale) {
-    super("Service", name);
-    this.scale = scale;
-  }
-
-  @Override
-  public void andThenVisit(ServiceFluent<?> service, ObjectMeta resourceMeta) {
-    service.editMetadata()
-        .addToAnnotations(MIN_SCALE, String.valueOf(scale))
-        .endMetadata();
+    super(name, MIN_SCALE, String.valueOf(scale));
   }
 }

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/manifest/KnativeManifestGenerator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/manifest/KnativeManifestGenerator.java
@@ -84,6 +84,9 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 public class KnativeManifestGenerator extends AbstractKubernetesManifestGenerator<KnativeConfig> implements WithProject {
 
   private static final String KNATIVE = "knative";
+  private static final String KNATIVE_SERVING = "knative-serving";
+  private static final String CONFIG_AUTOSCALER = "config-autoscaler";
+  private static final String CONFIG_DEFAULTS = "config-defaults";
   private static final String DEFAULT_REGISTRY = "dev.local/";
 
   private static final String KNATIVE_VISIBILITY = "serving.knative.dev/visibility";
@@ -146,8 +149,8 @@ public class KnativeManifestGenerator extends AbstractKubernetesManifestGenerato
     }
 
     if (!config.isScaleToZeroEnabled()) {
-      resourceRegistry.decorate(KNATIVE, new AddConfigMapResourceProvidingDecorator("config-autoscaler"));
-      resourceRegistry.decorate(KNATIVE, new AddConfigMapDataDecorator("config-autoscaler", "enable-scale-to-zero",
+      resourceRegistry.decorate(KNATIVE, new AddConfigMapResourceProvidingDecorator(CONFIG_AUTOSCALER, KNATIVE_SERVING));
+      resourceRegistry.decorate(KNATIVE, new AddConfigMapDataDecorator(CONFIG_AUTOSCALER, "enable-scale-to-zero",
           String.valueOf(config.isAutoDeployEnabled())));
     }
 
@@ -194,7 +197,7 @@ public class KnativeManifestGenerator extends AbstractKubernetesManifestGenerato
     // Global autoscaling configuration
     if (config.getGlobalAutoScaling() != null) {
       if (!isDefault(config.getGlobalAutoScaling())) {
-        resourceRegistry.decorate(KNATIVE, new AddConfigMapResourceProvidingDecorator("config-autoscaler"));
+        resourceRegistry.decorate(KNATIVE, new AddConfigMapResourceProvidingDecorator(CONFIG_AUTOSCALER, KNATIVE_SERVING));
         if (config.getGlobalAutoScaling().getAutoScalerClass() != null
             && config.getGlobalAutoScaling().getAutoScalerClass() != AutoScalerClass.kpa) {
           resourceRegistry.decorate(KNATIVE,
@@ -215,7 +218,7 @@ public class KnativeManifestGenerator extends AbstractKubernetesManifestGenerato
 
       if (config.getGlobalAutoScaling().getContainerConcurrency() != null
           && config.getGlobalAutoScaling().getContainerConcurrency() != 0) {
-        resourceRegistry.decorate(KNATIVE, new AddConfigMapResourceProvidingDecorator("config-defaults"));
+        resourceRegistry.decorate(KNATIVE, new AddConfigMapResourceProvidingDecorator(CONFIG_DEFAULTS, KNATIVE_SERVING));
         resourceRegistry.decorate(KNATIVE,
             new ApplyGlobalContainerConcurrencyDecorator(config.getGlobalAutoScaling().getContainerConcurrency()));
       }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddConfigMapResourceProvidingDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddConfigMapResourceProvidingDecorator.java
@@ -22,9 +22,11 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 public class AddConfigMapResourceProvidingDecorator extends ResourceProvidingDecorator<KubernetesListBuilder> {
 
   private final String name;
+  private final String namespace;
 
-  public AddConfigMapResourceProvidingDecorator(String name) {
+  public AddConfigMapResourceProvidingDecorator(String name, String namespace) {
     this.name = name;
+    this.namespace = namespace;
   }
 
   @Override
@@ -36,6 +38,7 @@ public class AddConfigMapResourceProvidingDecorator extends ResourceProvidingDec
     list.addNewConfigMapItem()
         .withNewMetadata()
         .withName(name)
+        .withNamespace(namespace)
         .endMetadata()
         .endConfigMapItem();
   }

--- a/core/src/main/java/io/dekorate/utils/Ports.java
+++ b/core/src/main/java/io/dekorate/utils/Ports.java
@@ -42,7 +42,7 @@ public class Ports {
       put("http", 80);
       put("https", 443);
       put("http1", 80); //This is needed for knative
-      put("h2c", 443);  //This is needed for knative
+      put("h2c", 443); //This is needed for knative
     }
   });
 

--- a/examples/knative-example/src/main/java/io/dekorate/example/Main.java
+++ b/examples/knative-example/src/main/java/io/dekorate/example/Main.java
@@ -19,7 +19,7 @@ import io.dekorate.knative.annotation.KnativeApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@KnativeApplication
+@KnativeApplication(minScale = 1, maxScale = 5, scaleToZeroEnabled = false)
 @SpringBootApplication
 public class Main {
 

--- a/tests/feat-575-knative-local-autoscaling/src/test/java/io/dekorate/knative/Feat575LocalAutoscalingTest.java
+++ b/tests/feat-575-knative-local-autoscaling/src/test/java/io/dekorate/knative/Feat575LocalAutoscalingTest.java
@@ -37,9 +37,9 @@ public class Feat575LocalAutoscalingTest {
         .unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/knative.yml"));
     assertNotNull(list);
     Service s = findFirst(list, Service.class).orElseThrow(() -> new IllegalStateException());
-    String metric = s.getMetadata().getAnnotations().get("autoscaling.knative.dev/metric");
+    String metric = s.getSpec().getTemplate().getMetadata().getAnnotations().get("autoscaling.knative.dev/metric");
     assertEquals("rps", metric);
-    String target = s.getMetadata().getAnnotations().get("autoscaling.knative.dev/target");
+    String target = s.getSpec().getTemplate().getMetadata().getAnnotations().get("autoscaling.knative.dev/target");
     assertEquals("100", target);
   }
 

--- a/tests/issue-586-knative-scale-bounds/src/test/java/io/dekorate/knative/Issue586ScaleBoundsTest.java
+++ b/tests/issue-586-knative-scale-bounds/src/test/java/io/dekorate/knative/Issue586ScaleBoundsTest.java
@@ -37,8 +37,8 @@ public class Issue586ScaleBoundsTest {
         .unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/knative.yml"));
     assertNotNull(list);
     Service s = findFirst(list, Service.class).orElseThrow(() -> new IllegalStateException());
-    String minScale = s.getMetadata().getAnnotations().get("autoscaling.knative.dev/minScale");
-    String maxScale = s.getMetadata().getAnnotations().get("autoscaling.knative.dev/maxScale");
+    String minScale = s.getSpec().getTemplate().getMetadata().getAnnotations().get("autoscaling.knative.dev/minScale");
+    String maxScale = s.getSpec().getTemplate().getMetadata().getAnnotations().get("autoscaling.knative.dev/maxScale");
     assertEquals("3", minScale);
     assertEquals("5", maxScale);
 


### PR DESCRIPTION
The Knative generated manifests have the following issues:
- The generated `config-autoscaler` configmap does not set the namespace which should always be `knative-serving` (see for example https://knative.dev/docs/serving/autoscaling/scale-to-zero/#enable-scale-to-zero).
- Some properties do add the annotations at Knative service metadata level, and it should add them at Knative service spec template metadata level.
- The property `dekorate.knative.global-auto-scaling.containerConcurrency` (hard limit option) wrongly uses the `config-autoscaler` configmap and it should use `config-defaults` configmap (see https://knative.dev/docs/serving/autoscaling/concurrency/#hard-limit)

Fix https://github.com/dekorateio/dekorate/issues/869