### PR TITLE
docs: Fixed small typo in the URL to Jaeger example

### DIFF
--- a/docs/documentation/jaeger.md
+++ b/docs/documentation/jaeger.md
@@ -45,4 +45,4 @@ public class Main {
 }
 ```
 #### related examples
-- [spring boot with jaeger on kubernetes example](https://github.com/dekorateio/dekorate/tree/main/examples/spring-boot-with-jeager-on-kubernetes-example)
+- [spring boot with jaeger on kubernetes example](https://github.com/dekorateio/dekorate/tree/main/examples/spring-boot-with-jaeger-on-kubernetes-example)


### PR DESCRIPTION
The URL to Jaeger example was pointing to a resource that does exist.