### PR TITLE
Support Startup Probes for Kubernetes, Openshift and Knative

### DIFF
--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/annotation/KnativeApplication.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/annotation/KnativeApplication.java
@@ -235,6 +235,13 @@ public @interface KnativeApplication {
   Probe readinessProbe() default @Probe();
 
   /**
+   * The startup probe.
+   *
+   * @return The probe.
+   */
+  Probe startupProbe() default @Probe();
+
+  /**
    * The resources that the application container requires.
    */
   ResourceRequirements requestResources() default @ResourceRequirements();

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/annotation/KubernetesApplication.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/annotation/KubernetesApplication.java
@@ -231,6 +231,13 @@ public @interface KubernetesApplication {
   Probe readinessProbe() default @Probe();
 
   /**
+   * The startup probe.
+   *
+   * @return The probe.
+   */
+  Probe startupProbe() default @Probe();
+
+  /**
    * The resources that the application container requires.
    */
   ResourceRequirements requestResources() default @ResourceRequirements();

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/annotation/OpenshiftApplication.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/annotation/OpenshiftApplication.java
@@ -233,6 +233,13 @@ public @interface OpenshiftApplication {
   Probe readinessProbe() default @Probe();
 
   /**
+   * The startup probe.
+   *
+   * @return The probe.
+   */
+  Probe startupProbe() default @Probe();
+
+  /**
    * The resources that the application container requires.
    */
   ResourceRequirements requestResources() default @ResourceRequirements();

--- a/assets/design.md
+++ b/assets/design.md
@@ -134,9 +134,10 @@ The `decorator` looks pretty similar to the `configurator` the only difference b
 |-------------------------------|----------------|--------------------------------------------------------|
 | AddSecretVolume               | PodSpec        | Add a secret volume to all pod specs.                  |
 | AddService                    | KubernetesList | Add a service to the list.                             |
-| AddLivenessProbe              | Container      | Add a liveness probe to all containers.                |
 | AddEnvVar                     | Container      | Add a environment variable to the container.           |
+| AddLivenessProbe              | Container      | Add a liveness probe to all containers.                |
 | AddReadinessProbe             | Container      | Add a readiness probe to all containers.               |
+| AddStartupProbe               | Container      | Add a startup probe to all containers.                 |
 | AddConfigMapVolume            | PodSpec        | Add a configmap volume to the pod spec.                |
 | AddEnvToComponent             | ComponentSpec  | Add environment variable to component.                 |
 | AddAzureDiskVolume            | PodSpec        | Add an Azure disk volume to the pod spec.              |

--- a/core/src/main/java/io/dekorate/AbstractKubernetesManifestGenerator.java
+++ b/core/src/main/java/io/dekorate/AbstractKubernetesManifestGenerator.java
@@ -45,6 +45,7 @@ import io.dekorate.kubernetes.decorator.AddPvcVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddReadinessProbeDecorator;
 import io.dekorate.kubernetes.decorator.AddSecretVolumeDecorator;
 import io.dekorate.kubernetes.decorator.AddSidecarDecorator;
+import io.dekorate.kubernetes.decorator.AddStartupProbeDecorator;
 import io.dekorate.kubernetes.decorator.AddToMatchingLabelsDecorator;
 import io.dekorate.kubernetes.decorator.AddToSelectorDecorator;
 import io.dekorate.kubernetes.decorator.ApplyArgsDecorator;
@@ -184,6 +185,11 @@ public abstract class AbstractKubernetesManifestGenerator<C extends BaseConfig> 
     if (Probes.isConfigured(config.getReadinessProbe())) {
       resourceRegistry.decorate(group,
           new AddReadinessProbeDecorator(config.getName(), config.getName(), config.getReadinessProbe()));
+    }
+
+    if (Probes.isConfigured(config.getStartupProbe())) {
+      resourceRegistry.decorate(group,
+          new AddStartupProbeDecorator(config.getName(), config.getName(), config.getStartupProbe()));
     }
 
     //Container resources

--- a/core/src/main/java/io/dekorate/kubernetes/adapter/ContainerAdapter.java
+++ b/core/src/main/java/io/dekorate/kubernetes/adapter/ContainerAdapter.java
@@ -23,6 +23,7 @@ import io.dekorate.kubernetes.decorator.AddLivenessProbeDecorator;
 import io.dekorate.kubernetes.decorator.AddMountDecorator;
 import io.dekorate.kubernetes.decorator.AddPortDecorator;
 import io.dekorate.kubernetes.decorator.AddReadinessProbeDecorator;
+import io.dekorate.kubernetes.decorator.AddStartupProbeDecorator;
 import io.dekorate.kubernetes.decorator.ApplyImagePullPolicyDecorator;
 import io.dekorate.kubernetes.decorator.ApplyLimitsCpuDecorator;
 import io.dekorate.kubernetes.decorator.ApplyLimitsMemoryDecorator;
@@ -66,6 +67,10 @@ public class ContainerAdapter {
 
     if (Probes.isConfigured(container.getReadinessProbe())) {
       builder.accept(new AddReadinessProbeDecorator(name, container.getReadinessProbe()));
+    }
+
+    if (Probes.isConfigured(container.getStartupProbe())) {
+      builder.accept(new AddStartupProbeDecorator(name, container.getStartupProbe()));
     }
 
     // Container resources

--- a/core/src/main/java/io/dekorate/kubernetes/annotation/Base.java
+++ b/core/src/main/java/io/dekorate/kubernetes/annotation/Base.java
@@ -189,6 +189,13 @@ import io.sundr.builder.annotations.Pojo;
   Probe readinessProbe() default @Probe();
 
   /**
+   * The startup probe.
+   *
+   * @return The probe.
+   */
+  Probe startupProbe() default @Probe();
+
+  /**
    * The resources that the application container requires.
    */
   ResourceRequirements requestResources() default @ResourceRequirements();

--- a/core/src/main/java/io/dekorate/kubernetes/annotation/Container.java
+++ b/core/src/main/java/io/dekorate/kubernetes/annotation/Container.java
@@ -93,6 +93,13 @@ public @interface Container {
   Probe readinessProbe() default @Probe();
 
   /**
+   * The startup probe.
+   *
+   * @return The probe.
+   */
+  Probe startupProbe() default @Probe();
+
+  /**
    * The resources that the application container requires.
    */
   ResourceRequirements requestResources() default @ResourceRequirements();

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddStartupProbeDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddStartupProbeDecorator.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.kubernetes.decorator;
+
+import io.dekorate.doc.Description;
+import io.dekorate.kubernetes.config.Probe;
+import io.fabric8.kubernetes.api.model.ContainerFluent;
+
+@Description("Add a startup probe to all containers.")
+public class AddStartupProbeDecorator extends AbstractAddProbeDecorator {
+
+  public AddStartupProbeDecorator(String containerName, Probe probe) {
+    super(containerName, probe);
+  }
+
+  public AddStartupProbeDecorator(String deploymentName, String containerName, Probe probe) {
+    super(deploymentName, containerName, probe);
+  }
+
+  @Override
+  protected void doCreateProbe(ContainerFluent<?> container, Actions actions) {
+    container.withNewStartupProbe()
+        .withExec(actions.execAction)
+        .withHttpGet(actions.httpGetAction)
+        .withTcpSocket(actions.tcpSocketAction)
+        .withInitialDelaySeconds(probe.getInitialDelaySeconds())
+        .withPeriodSeconds(probe.getPeriodSeconds())
+        .withTimeoutSeconds(probe.getTimeoutSeconds())
+        .withSuccessThreshold(probe.getSuccessThreshold())
+        .withFailureThreshold(probe.getFailureThreshold())
+        .endStartupProbe();
+  }
+}

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/RemoveProbesFromInitContainerDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/RemoveProbesFromInitContainerDecorator.java
@@ -37,6 +37,6 @@ public class RemoveProbesFromInitContainerDecorator extends NamedResourceDecorat
   @Override
   public Class<? extends Decorator>[] after() {
     return new Class[] { ResourceProvidingDecorator.class, AddInitContainerDecorator.class, AddLivenessProbeDecorator.class,
-        AddReadinessProbeDecorator.class };
+        AddReadinessProbeDecorator.class, AddStartupProbeDecorator.class };
   }
 }

--- a/docs/documentation/design.md
+++ b/docs/documentation/design.md
@@ -142,9 +142,10 @@ The `decorator` looks pretty similar to the `configurator` the only difference b
 |-------------------------------|----------------|--------------------------------------------------------|
 | AddSecretVolume               | PodSpec        | Add a secret volume to all pod specs.                  |
 | AddService                    | KubernetesList | Add a service to the list.                             |
-| AddLivenessProbe              | Container      | Add a liveness probe to all containers.                |
 | AddEnvVar                     | Container      | Add a environment variable to the container.           |
 | AddReadinessProbe             | Container      | Add a readiness probe to all containers.               |
+| AddLivenessProbe              | Container      | Add a liveness probe to all containers.                |
+| AddStartupProbe               | Container      | Add a startup probe to all containers.                 |
 | AddConfigMapVolume            | PodSpec        | Add a configmap volume to the pod spec.                |
 | AddEnvToComponent             | ComponentSpec  | Add environment variable to component.                 |
 | AddAzureDiskVolume            | PodSpec        | Add an Azure disk volume to the pod spec.              |

--- a/examples/knative-example/src/main/java/io/dekorate/example/Main.java
+++ b/examples/knative-example/src/main/java/io/dekorate/example/Main.java
@@ -16,10 +16,16 @@
 package io.dekorate.example;
 
 import io.dekorate.knative.annotation.KnativeApplication;
+import io.dekorate.kubernetes.annotation.Probe;
+
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@KnativeApplication(minScale = 1, maxScale = 5, scaleToZeroEnabled = false)
+@KnativeApplication(minScale = 1, maxScale = 5, scaleToZeroEnabled = false,
+  readinessProbe = @Probe(httpActionPath = "/readiness", periodSeconds = 30, timeoutSeconds = 10),
+  livenessProbe = @Probe(httpActionPath = "/liveness", periodSeconds = 31, timeoutSeconds = 11),
+  startupProbe = @Probe(httpActionPath = "/startup", periodSeconds = 32, timeoutSeconds = 12)
+)
 @SpringBootApplication
 public class Main {
 

--- a/examples/vertx-on-kubernetes-example/pom.xml
+++ b/examples/vertx-on-kubernetes-example/pom.xml
@@ -30,7 +30,8 @@ limitations under the License.
 
     <version.vertx>3.8.2</version.vertx>
     <version.jackson>2.12.3</version.jackson>
-    <version.maven-compiler-plugin>3.3</version.maven-compiler-plugin>
+    <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
+    <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
   </properties>
 
   <dependencyManagement>
@@ -73,6 +74,16 @@ limitations under the License.
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.maven-surefire-plugin}</version>
+        <inherited>true</inherited>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+          <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>
     </plugins>

--- a/examples/vertx-on-kubernetes-example/src/main/resources/application.properties
+++ b/examples/vertx-on-kubernetes-example/src/main/resources/application.properties
@@ -1,5 +1,11 @@
 dekorate.kubernetes.ports[0].name=http
 dekorate.kubernetes.ports[0].containerPort=8080
-dekorate.kubernetes.readinessProbe.httpActionPath=/
+dekorate.kubernetes.readinessProbe.httpActionPath=/readiness
 dekorate.kubernetes.readinessProbe.periodSeconds=30
 dekorate.kubernetes.readinessProbe.timeoutSeconds=10
+dekorate.kubernetes.livenessProbe.httpActionPath=/liveness
+dekorate.kubernetes.livenessProbe.periodSeconds=31
+dekorate.kubernetes.livenessProbe.timeoutSeconds=11
+dekorate.kubernetes.startupProbe.httpActionPath=/startup
+dekorate.kubernetes.startupProbe.periodSeconds=32
+dekorate.kubernetes.startupProbe.timeoutSeconds=12

--- a/examples/vertx-on-kubernetes-example/src/test/java/io/dekorate/example/VertxTest.java
+++ b/examples/vertx-on-kubernetes-example/src/test/java/io/dekorate/example/VertxTest.java
@@ -18,11 +18,16 @@
 package io.dekorate.example;
 
 import java.util.Optional;
+import java.util.function.Function;
+
 import org.junit.jupiter.api.Test;
 
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.dekorate.testing.KubernetesResources.*;
@@ -30,10 +35,46 @@ import static io.dekorate.testing.KubernetesResources.*;
 class VertxTest {
 
   @Test
-  public void shouldContainService() throws Exception {
+  public void shouldContainService() {
     KubernetesList list = loadGenerated("kubernetes");
     Optional<Service> service = findFirst(list, Service.class);
     assertTrue(service.isPresent());
+  }
+
+  @Test
+  public void shouldContainProbes() {
+    KubernetesList list = loadGenerated("kubernetes");
+    Optional<Deployment> deployment = findFirst(list, Deployment.class);
+    assertTrue(deployment.isPresent(), "Deployment not found!");
+
+    assertReadinessProbe(deployment.get(), "/readiness", 30, 10);
+    assertLivenessProbe(deployment.get(), "/liveness", 31, 11);
+    assertStartupProbe(deployment.get(), "/startup", 32, 12);
+  }
+
+  private static void assertReadinessProbe(Deployment deployment, String actionPath,
+    int periodSeconds, int timeoutSeconds) {
+    assertProbe(deployment, Container::getReadinessProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertLivenessProbe(Deployment deployment, String actionPath,
+    int periodSeconds, int timeoutSeconds) {
+    assertProbe(deployment, Container::getLivenessProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertStartupProbe(Deployment deployment, String actionPath,
+    int periodSeconds, int timeoutSeconds) {
+    assertProbe(deployment, Container::getStartupProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertProbe(Deployment deployment,
+    Function<Container, Probe> probeFunction,
+    String actionPath, int periodSeconds, int timeoutSeconds) {
+
+    assertTrue(deployment.getSpec().getTemplate().getSpec().getContainers().stream()
+      .map(probeFunction)
+      .anyMatch(probe -> actionPath.equals(probe.getHttpGet().getPath())
+        && periodSeconds == probe.getPeriodSeconds() && timeoutSeconds == probe.getTimeoutSeconds()));
   }
 }
 

--- a/examples/vertx-on-openshift-example/pom.xml
+++ b/examples/vertx-on-openshift-example/pom.xml
@@ -30,7 +30,8 @@ limitations under the License.
 
     <version.jackson>2.12.3</version.jackson>
     <version.vertx>3.8.2</version.vertx>
-    <version.maven-compiler-plugin>3.3</version.maven-compiler-plugin>
+    <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
+    <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
   </properties>
 
   <dependencyManagement>
@@ -72,6 +73,16 @@ limitations under the License.
         <configuration>
           <source>${java.version}</source>
           <target>${java.version}</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.maven-surefire-plugin}</version>
+        <inherited>true</inherited>
+        <configuration>
+          <trimStackTrace>false</trimStackTrace>
+          <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>
     </plugins>

--- a/examples/vertx-on-openshift-example/src/main/resources/application.properties
+++ b/examples/vertx-on-openshift-example/src/main/resources/application.properties
@@ -1,5 +1,11 @@
 dekorate.openshift.ports[0].name=http
 dekorate.openshift.ports[0].containerPort=8080
-dekorate.openshift.readinessProbe.httpActionPath=/
+dekorate.openshift.readinessProbe.httpActionPath=/readiness
 dekorate.openshift.readinessProbe.periodSeconds=30
 dekorate.openshift.readinessProbe.timeoutSeconds=10
+dekorate.openshift.livenessProbe.httpActionPath=/liveness
+dekorate.openshift.livenessProbe.periodSeconds=31
+dekorate.openshift.livenessProbe.timeoutSeconds=11
+dekorate.openshift.startupProbe.httpActionPath=/startup
+dekorate.openshift.startupProbe.periodSeconds=32
+dekorate.openshift.startupProbe.timeoutSeconds=12

--- a/examples/vertx-on-openshift-example/src/test/java/io/dekorate/example/VertxTest.java
+++ b/examples/vertx-on-openshift-example/src/test/java/io/dekorate/example/VertxTest.java
@@ -18,11 +18,16 @@
 package io.dekorate.example;
 
 import java.util.Optional;
+import java.util.function.Function;
+
 import org.junit.jupiter.api.Test;
 
+import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.openshift.api.model.DeploymentConfig;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.dekorate.testing.KubernetesResources.*;
@@ -30,10 +35,46 @@ import static io.dekorate.testing.KubernetesResources.*;
 class VertxTest {
 
   @Test
-  public void shouldContainService() throws Exception {
+  public void shouldContainService() {
     KubernetesList list = loadGenerated("openshift");
     Optional<Service> service = findFirst(list, Service.class);
     assertTrue(service.isPresent());
+  }
+
+  @Test
+  public void shouldContainProbes() {
+    KubernetesList list = loadGenerated("openshift");
+    Optional<DeploymentConfig> deployment = findFirst(list, DeploymentConfig.class);
+    assertTrue(deployment.isPresent(), "DeploymentConfig not found!");
+
+    assertReadinessProbe(deployment.get(), "/readiness", 30, 10);
+    assertLivenessProbe(deployment.get(), "/liveness", 31, 11);
+    assertStartupProbe(deployment.get(), "/startup", 32, 12);
+  }
+
+  private static void assertReadinessProbe(DeploymentConfig deployment, String actionPath,
+      int periodSeconds, int timeoutSeconds) {
+    assertProbe(deployment, Container::getReadinessProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertLivenessProbe(DeploymentConfig deployment, String actionPath,
+    int periodSeconds, int timeoutSeconds) {
+    assertProbe(deployment, Container::getLivenessProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertStartupProbe(DeploymentConfig deployment, String actionPath,
+    int periodSeconds, int timeoutSeconds) {
+    assertProbe(deployment, Container::getStartupProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertProbe(DeploymentConfig deployment,
+      Function<Container, Probe> probeFunction,
+      String actionPath, int periodSeconds, int timeoutSeconds) {
+
+    assertTrue(deployment.getSpec().getTemplate().getSpec().getContainers().stream()
+      .map(probeFunction)
+      .anyMatch(probe -> actionPath.equals(probe.getHttpGet().getPath())
+        && periodSeconds == probe.getPeriodSeconds() && timeoutSeconds == probe.getTimeoutSeconds()));
   }
 }
 


### PR DESCRIPTION
The kubelet uses startup probes to know when a container application has started. If such a probe is configured, it disables liveness and readiness checks until it succeeds, making sure those probes don't interfere with the application startup. This can be used to adopt liveness checks on slow starting containers, avoiding them getting killed by the kubelet before they are up and running.

```yaml
startupProbe:
  httpGet:
    path: /healthz
    port: liveness-port
  failureThreshold: 30
  periodSeconds: 10
```

More context in [kubernetes.io/startup-probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).

Fix https://github.com/dekorateio/dekorate/issues/854