### PR TITLE
Improve logging message to list: Configurators, Suppliers

### DIFF
--- a/core/src/main/java/io/dekorate/Logger.java
+++ b/core/src/main/java/io/dekorate/Logger.java
@@ -54,6 +54,10 @@ public interface Logger {
 
   void info(String message);
 
+  default void info(String message, Object... objects) {
+    info(String.format(message, objects));
+  }
+
   void warning(String message);
 
   void error(String message);

--- a/core/src/main/java/io/dekorate/ResourceRegistry.java
+++ b/core/src/main/java/io/dekorate/ResourceRegistry.java
@@ -15,6 +15,8 @@
  */
 package io.dekorate;
 
+import static io.dekorate.utils.Development.isVerbose;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -35,6 +37,7 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 public class ResourceRegistry {
 
   private static final String DEFAULT_GROUP = "kubernetes";
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResourceRegistry.class);
   private final Map<String, KubernetesListBuilder> groups = new LinkedHashMap<>();
   private final KubernetesListBuilder global = new KubernetesListBuilder();
   private final Set<Decorator> globalDecorators = new HashSet<>();
@@ -176,6 +179,10 @@ public class ResourceRegistry {
         union.addAll(decorators);
         union.addAll(globalDecorators);
         for (Decorator d : applyConstraints(union)) {
+          if (isVerbose()) {
+            LOGGER.info("Applying decorator '%s'", d.getClass().getName());
+          }
+
           groups.get(group).accept(d);
         }
       }
@@ -192,6 +199,10 @@ public class ResourceRegistry {
         union.addAll(decorators);
         union.addAll(globalDecorators);
         for (Decorator d : applyConstraints(union)) {
+          if (isVerbose()) {
+            LOGGER.info("Applying decorator '%s'", d.getClass().getName());
+          }
+
           customGroups.get(group).accept(d);
         }
       }

--- a/core/src/main/java/io/dekorate/Session.java
+++ b/core/src/main/java/io/dekorate/Session.java
@@ -15,6 +15,8 @@
  */
 package io.dekorate;
 
+import static io.dekorate.utils.Development.isVerbose;
+
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -351,9 +353,13 @@ public class Session {
         });
   }
 
-  private static void generate(ManifestGenerator h, ConfigurationRegistry configurationRegistry) {
+  private void generate(ManifestGenerator h, ConfigurationRegistry configurationRegistry) {
     configurationRegistry.stream().forEach(c -> {
       if (h.accepts(c.getClass())) {
+        if (isVerbose()) {
+          LOGGER.info("Using the configuration registry '%s'", c.getClass().getName());
+        }
+
         h.generate(c);
       }
     });

--- a/core/src/main/java/io/dekorate/utils/Development.java
+++ b/core/src/main/java/io/dekorate/utils/Development.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.utils;
+
+/**
+ * Development Tool utilities class.
+ */
+public final class Development {
+
+  private static final boolean IS_VERBOSE = Boolean
+      .parseBoolean(System.getProperty("dekorate.verbose", Boolean.FALSE.toString()));
+
+  private Development() {
+
+  }
+
+  public static boolean isVerbose() {
+    return IS_VERBOSE;
+  }
+}

--- a/docs/documentation/debugging-logging.md
+++ b/docs/documentation/debugging-logging.md
@@ -7,7 +7,7 @@ permalink: /docs/debugging-logging
 
 ### Debugging and Logging
 
-To control how verbose the dekorate output is going to be you can set the log level level threshold, using the `io.dekorate.log.level` system property-drawer.
+To control how verbose the Dekorate output is going to be you can set the log level threshold, using the `io.dekorate.log.level` system property-drawer.
 
 Allowed values are:
 
@@ -16,3 +16,11 @@ Allowed values are:
 - WARN
 - INFO (default)
 - DEBUG
+
+### Troubleshooting
+
+Additionally, we can turn on the full verbose mode to troubleshoot issues at the Dekorate generation of manifests by providing the system property `dekorate.verbose=true`. 
+
+Currently, this mode will print:
+- The configuration registries applied
+- The decorators applied


### PR DESCRIPTION
Added a new system property `dekorate.version` to turn on the full verbose mode to troubleshoot issues at the Dekorate generation of manifests. This mode will print:
- The configuration registries applied
- The decorators applied

Example:

```
[INFO] --- maven-compiler-plugin:3.8.0:compile (default-compile) @ spring-boot-on-kubernetes-example ---
[INFO] Changes detected - recompiling the module!
[INFO] Compiling 2 source files to /home/jcarvaja/sources/dekorate/examples/spring-boot-on-kubernetes-example/target/classes
[INFO] Found @KubernetesApplication on: io.dekorate.example.Main
[INFO] Initializing dekorate session.
[INFO] Found Spring web annotation!
[INFO] Found @SpringBootApplication on: io.dekorate.example.Main
[INFO] Generating manifests.
[INFO] Using the configuration registry 'io.dekorate.kubernetes.config.EditableKubernetesConfig'
[INFO] Processing kubernetes configuration.
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddServiceResourceDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddIngressDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddToMatchingLabelsDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.ApplyApplicationContainerDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddToSelectorDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddToMatchingLabelsDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddLabelDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddToSelectorDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddLabelDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddPortDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddReadinessProbeDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddLivenessProbeDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddVcsUrlAnnotationDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddCommitIdAnnotationDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.RemoveProbesFromInitContainerDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.ApplyImageDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.AddIngressRuleDecorator'
[INFO] Applying decorator 'io.dekorate.kubernetes.decorator.ApplyDeploymentStrategyDecorator'
[INFO] Writing: file:///home/jcarvaja/sources/dekorate/examples/spring-boot-on-kubernetes-example/target/classes/META-INF/dekorate/kubernetes.json
[INFO] Writing: file:///home/jcarvaja/sources/dekorate/examples/spring-boot-on-kubernetes-example/target/classes/META-INF/dekorate/kubernetes.yml
[INFO] Closing dekorate session. 
```

Fix https://github.com/dekorateio/dekorate/issues/781