### PR TITLE
Move Probe tests from `examples` to `tests`

### DIFF
--- a/examples/knative-example/src/test/java/io/dekorate/example/KnativeExampleTest.java
+++ b/examples/knative-example/src/test/java/io/dekorate/example/KnativeExampleTest.java
@@ -18,10 +18,8 @@ package io.dekorate.example;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
-import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,7 +29,6 @@ import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.Probe;
 
 class KnativeExampleTest {
 
@@ -54,41 +51,6 @@ class KnativeExampleTest {
     assertEquals("knative-serving", configMap.getMetadata().getNamespace());
     assertEquals(1, configMap.getData().size());
     assertEquals("false", configMap.getData().get("enable-scale-to-zero"));
-  }
-
-  @Test
-  public void shouldContainProbes() {
-    KubernetesList list = Serialization.unmarshalAsList(KnativeExampleTest.class.getClassLoader().getResourceAsStream("META-INF/dekorate/knative.yml"));
-    Service service = findFirst(list, Service.class).orElseThrow(() -> new IllegalStateException("No knative service found!"));
-
-    assertReadinessProbe(service, "/readiness", 30, 10);
-    assertLivenessProbe(service, "/liveness", 31, 11);
-    assertStartupProbe(service, "/startup", 32, 12);
-  }
-
-  private static void assertReadinessProbe(Service service, String actionPath,
-    int periodSeconds, int timeoutSeconds) {
-    assertProbe(service, Container::getReadinessProbe, actionPath, periodSeconds, timeoutSeconds);
-  }
-
-  private static void assertLivenessProbe(Service service, String actionPath,
-    int periodSeconds, int timeoutSeconds) {
-    assertProbe(service, Container::getLivenessProbe, actionPath, periodSeconds, timeoutSeconds);
-  }
-
-  private static void assertStartupProbe(Service service, String actionPath,
-    int periodSeconds, int timeoutSeconds) {
-    assertProbe(service, Container::getStartupProbe, actionPath, periodSeconds, timeoutSeconds);
-  }
-
-  private static void assertProbe(Service service,
-    Function<Container, Probe> probeFunction,
-    String actionPath, int periodSeconds, int timeoutSeconds) {
-
-    assertTrue(service.getSpec().getTemplate().getSpec().getContainers().stream()
-      .map(probeFunction)
-      .anyMatch(probe -> actionPath.equals(probe.getHttpGet().getPath())
-        && periodSeconds == probe.getPeriodSeconds() && timeoutSeconds == probe.getTimeoutSeconds()));
   }
 
   <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {

--- a/examples/vertx-on-kubernetes-example/src/main/resources/application.properties
+++ b/examples/vertx-on-kubernetes-example/src/main/resources/application.properties
@@ -1,11 +1,5 @@
 dekorate.kubernetes.ports[0].name=http
 dekorate.kubernetes.ports[0].containerPort=8080
-dekorate.kubernetes.readinessProbe.httpActionPath=/readiness
+dekorate.kubernetes.readinessProbe.httpActionPath=/
 dekorate.kubernetes.readinessProbe.periodSeconds=30
 dekorate.kubernetes.readinessProbe.timeoutSeconds=10
-dekorate.kubernetes.livenessProbe.httpActionPath=/liveness
-dekorate.kubernetes.livenessProbe.periodSeconds=31
-dekorate.kubernetes.livenessProbe.timeoutSeconds=11
-dekorate.kubernetes.startupProbe.httpActionPath=/startup
-dekorate.kubernetes.startupProbe.periodSeconds=32
-dekorate.kubernetes.startupProbe.timeoutSeconds=12

--- a/examples/vertx-on-kubernetes-example/src/test/java/io/dekorate/example/VertxTest.java
+++ b/examples/vertx-on-kubernetes-example/src/test/java/io/dekorate/example/VertxTest.java
@@ -1,33 +1,28 @@
 /**
  * Copyright 2018 The original authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
-**/
+ *
+ **/
 
 package io.dekorate.example;
 
 import java.util.Optional;
-import java.util.function.Function;
-
 import org.junit.jupiter.api.Test;
 
-import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.Service;
-import io.fabric8.kubernetes.api.model.apps.Deployment;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static io.dekorate.testing.KubernetesResources.*;
@@ -35,46 +30,10 @@ import static io.dekorate.testing.KubernetesResources.*;
 class VertxTest {
 
   @Test
-  public void shouldContainService() {
+  public void shouldContainService() throws Exception {
     KubernetesList list = loadGenerated("kubernetes");
     Optional<Service> service = findFirst(list, Service.class);
     assertTrue(service.isPresent());
-  }
-
-  @Test
-  public void shouldContainProbes() {
-    KubernetesList list = loadGenerated("kubernetes");
-    Optional<Deployment> deployment = findFirst(list, Deployment.class);
-    assertTrue(deployment.isPresent(), "Deployment not found!");
-
-    assertReadinessProbe(deployment.get(), "/readiness", 30, 10);
-    assertLivenessProbe(deployment.get(), "/liveness", 31, 11);
-    assertStartupProbe(deployment.get(), "/startup", 32, 12);
-  }
-
-  private static void assertReadinessProbe(Deployment deployment, String actionPath,
-    int periodSeconds, int timeoutSeconds) {
-    assertProbe(deployment, Container::getReadinessProbe, actionPath, periodSeconds, timeoutSeconds);
-  }
-
-  private static void assertLivenessProbe(Deployment deployment, String actionPath,
-    int periodSeconds, int timeoutSeconds) {
-    assertProbe(deployment, Container::getLivenessProbe, actionPath, periodSeconds, timeoutSeconds);
-  }
-
-  private static void assertStartupProbe(Deployment deployment, String actionPath,
-    int periodSeconds, int timeoutSeconds) {
-    assertProbe(deployment, Container::getStartupProbe, actionPath, periodSeconds, timeoutSeconds);
-  }
-
-  private static void assertProbe(Deployment deployment,
-    Function<Container, Probe> probeFunction,
-    String actionPath, int periodSeconds, int timeoutSeconds) {
-
-    assertTrue(deployment.getSpec().getTemplate().getSpec().getContainers().stream()
-      .map(probeFunction)
-      .anyMatch(probe -> actionPath.equals(probe.getHttpGet().getPath())
-        && periodSeconds == probe.getPeriodSeconds() && timeoutSeconds == probe.getTimeoutSeconds()));
   }
 }
 

--- a/examples/vertx-on-openshift-example/src/main/resources/application.properties
+++ b/examples/vertx-on-openshift-example/src/main/resources/application.properties
@@ -1,11 +1,5 @@
 dekorate.openshift.ports[0].name=http
 dekorate.openshift.ports[0].containerPort=8080
-dekorate.openshift.readinessProbe.httpActionPath=/readiness
+dekorate.openshift.readinessProbe.httpActionPath=/
 dekorate.openshift.readinessProbe.periodSeconds=30
 dekorate.openshift.readinessProbe.timeoutSeconds=10
-dekorate.openshift.livenessProbe.httpActionPath=/liveness
-dekorate.openshift.livenessProbe.periodSeconds=31
-dekorate.openshift.livenessProbe.timeoutSeconds=11
-dekorate.openshift.startupProbe.httpActionPath=/startup
-dekorate.openshift.startupProbe.periodSeconds=32
-dekorate.openshift.startupProbe.timeoutSeconds=12

--- a/tests/feat-642-knative-traffic-splitting/pom.xml
+++ b/tests/feat-642-knative-traffic-splitting/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>io.dekorate</groupId>
   <artifactId>feat-642-knative-traffic-splitting</artifactId>
-  <name>Dekorate :: Tests :: Annotations :: Knative :: Traffci #642</name>
+  <name>Dekorate :: Tests :: Annotations :: Knative :: Traffic #642</name>
   <description></description>
 
   <dependencies>

--- a/tests/feat-knative-probes/pom.xml
+++ b/tests/feat-knative-probes/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2018 The original authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>dekorate-tests</artifactId>
+    <groupId>io.dekorate</groupId>
+    <version>2.9-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>io.dekorate</groupId>
+  <version>2.9-SNAPSHOT</version>
+  <artifactId>feat-probes-knative</artifactId>
+  <name>Dekorate :: Tests :: Probes :: Knative</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>knative-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>dekorate-spring-boot</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>knative-junit-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/tests/feat-knative-probes/src/main/java/io/dekorate/example/Controller.java
+++ b/tests/feat-knative-probes/src/main/java/io/dekorate/example/Controller.java
@@ -12,28 +12,17 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **/
-
+ */
 package io.dekorate.example;
 
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.Service;
+@RestController
+public class Controller {
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static io.dekorate.testing.KubernetesResources.*;
-
-class VertxTest {
-
-  @Test
-  public void shouldContainService() throws Exception {
-    KubernetesList list = loadGenerated("openshift");
-    Optional<Service> service = findFirst(list, Service.class);
-    assertTrue(service.isPresent());
+  @RequestMapping("/")
+  public String hello() {
+    return "Hello world";
   }
 }
-

--- a/tests/feat-knative-probes/src/main/java/io/dekorate/example/Main.java
+++ b/tests/feat-knative-probes/src/main/java/io/dekorate/example/Main.java
@@ -15,11 +15,13 @@
  */
 package io.dekorate.example;
 
-import io.dekorate.knative.annotation.KnativeApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-@KnativeApplication(minScale = 1, maxScale = 5, scaleToZeroEnabled = false)
+import io.dekorate.knative.annotation.KnativeApplication;
+import io.dekorate.kubernetes.annotation.Probe;
+
+@KnativeApplication(minScale = 1, maxScale = 5, scaleToZeroEnabled = false, readinessProbe = @Probe(httpActionPath = "/readiness", periodSeconds = 30, timeoutSeconds = 10), livenessProbe = @Probe(httpActionPath = "/liveness", periodSeconds = 31, timeoutSeconds = 11), startupProbe = @Probe(httpActionPath = "/startup", periodSeconds = 32, timeoutSeconds = 12))
 @SpringBootApplication
 public class Main {
 

--- a/tests/feat-knative-probes/src/test/java/io/dekorate/example/KnativeExampleTest.java
+++ b/tests/feat-knative-probes/src/test/java/io/dekorate/example/KnativeExampleTest.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dekorate.example;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.utils.Serialization;
+import io.fabric8.knative.serving.v1.Service;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.Probe;
+
+class KnativeExampleTest {
+
+  @Test
+  public void shouldContainProbes() {
+    KubernetesList list = Serialization
+        .unmarshalAsList(KnativeExampleTest.class.getClassLoader().getResourceAsStream("META-INF/dekorate/knative.yml"));
+    Service service = findFirst(list, Service.class).orElseThrow(() -> new IllegalStateException("No knative service found!"));
+
+    assertReadinessProbe(service, "/readiness", 30, 10);
+    assertLivenessProbe(service, "/liveness", 31, 11);
+    assertStartupProbe(service, "/startup", 32, 12);
+  }
+
+  private static void assertReadinessProbe(Service service, String actionPath,
+      int periodSeconds, int timeoutSeconds) {
+    assertProbe(service, Container::getReadinessProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertLivenessProbe(Service service, String actionPath,
+      int periodSeconds, int timeoutSeconds) {
+    assertProbe(service, Container::getLivenessProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertStartupProbe(Service service, String actionPath,
+      int periodSeconds, int timeoutSeconds) {
+    assertProbe(service, Container::getStartupProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertProbe(Service service,
+      Function<Container, Probe> probeFunction,
+      String actionPath, int periodSeconds, int timeoutSeconds) {
+
+    assertTrue(service.getSpec().getTemplate().getSpec().getContainers().stream()
+        .map(probeFunction)
+        .anyMatch(probe -> actionPath.equals(probe.getHttpGet().getPath())
+            && periodSeconds == probe.getPeriodSeconds() && timeoutSeconds == probe.getTimeoutSeconds()));
+  }
+
+  <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {
+    return (Optional<T>) list.getItems().stream()
+        .filter(i -> t.isInstance(i))
+        .findFirst();
+  }
+}

--- a/tests/feat-kubernetes-probes/pom.xml
+++ b/tests/feat-kubernetes-probes/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2018 The original authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>dekorate-tests</artifactId>
+    <groupId>io.dekorate</groupId>
+    <version>2.9-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>io.dekorate</groupId>
+  <version>2.9-SNAPSHOT</version>
+  <artifactId>feat-probes-kubernetes</artifactId>
+  <name>Dekorate :: Tests :: Probes :: Kubernetes</name>
+
+  <properties>
+    <version.vertx>3.8.2</version.vertx>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>${version.vertx}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-junit-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/tests/feat-kubernetes-probes/src/main/java/io/dekorate/example/Main.java
+++ b/tests/feat-kubernetes-probes/src/main/java/io/dekorate/example/Main.java
@@ -1,39 +1,42 @@
 /**
  * Copyright 2018 The original authors.
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **/
+ * 
+**/
 
 package io.dekorate.example;
 
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
+import io.dekorate.annotation.Dekorate;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
 
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.Service;
+@Dekorate
+public class Main extends AbstractVerticle {
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static io.dekorate.testing.KubernetesResources.*;
-
-class VertxTest {
-
-  @Test
-  public void shouldContainService() throws Exception {
-    KubernetesList list = loadGenerated("openshift");
-    Optional<Service> service = findFirst(list, Service.class);
-    assertTrue(service.isPresent());
+  @Override
+  public void start(Future<Void> future) {
+    vertx
+        .createHttpServer()
+        .requestHandler(r -> {
+          r.response().end("hello world!");
+        })
+        .listen(8080, result -> {
+          if (result.succeeded()) {
+            future.complete();
+          } else {
+            future.fail(result.cause());
+          }
+        });
   }
 }
-

--- a/tests/feat-kubernetes-probes/src/main/resources/application.properties
+++ b/tests/feat-kubernetes-probes/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+dekorate.kubernetes.ports[0].name=http
+dekorate.kubernetes.ports[0].containerPort=8080
+dekorate.kubernetes.readinessProbe.httpActionPath=/readiness
+dekorate.kubernetes.readinessProbe.periodSeconds=30
+dekorate.kubernetes.readinessProbe.timeoutSeconds=10
+dekorate.kubernetes.livenessProbe.httpActionPath=/liveness
+dekorate.kubernetes.livenessProbe.periodSeconds=31
+dekorate.kubernetes.livenessProbe.timeoutSeconds=11
+dekorate.kubernetes.startupProbe.httpActionPath=/startup
+dekorate.kubernetes.startupProbe.periodSeconds=32
+dekorate.kubernetes.startupProbe.timeoutSeconds=12

--- a/tests/feat-kubernetes-probes/src/test/java/io/dekorate/example/VertxTest.java
+++ b/tests/feat-kubernetes-probes/src/test/java/io/dekorate/example/VertxTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate.example;
+
+import static io.dekorate.testing.KubernetesResources.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+
+class VertxTest {
+
+  @Test
+  public void shouldContainService() {
+    KubernetesList list = loadGenerated("kubernetes");
+    Optional<Service> service = findFirst(list, Service.class);
+    assertTrue(service.isPresent());
+  }
+
+  @Test
+  public void shouldContainProbes() {
+    KubernetesList list = loadGenerated("kubernetes");
+    Optional<Deployment> deployment = findFirst(list, Deployment.class);
+    assertTrue(deployment.isPresent(), "Deployment not found!");
+
+    assertReadinessProbe(deployment.get(), "/readiness", 30, 10);
+    assertLivenessProbe(deployment.get(), "/liveness", 31, 11);
+    assertStartupProbe(deployment.get(), "/startup", 32, 12);
+  }
+
+  private static void assertReadinessProbe(Deployment deployment, String actionPath,
+      int periodSeconds, int timeoutSeconds) {
+    assertProbe(deployment, Container::getReadinessProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertLivenessProbe(Deployment deployment, String actionPath,
+      int periodSeconds, int timeoutSeconds) {
+    assertProbe(deployment, Container::getLivenessProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertStartupProbe(Deployment deployment, String actionPath,
+      int periodSeconds, int timeoutSeconds) {
+    assertProbe(deployment, Container::getStartupProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertProbe(Deployment deployment,
+      Function<Container, Probe> probeFunction,
+      String actionPath, int periodSeconds, int timeoutSeconds) {
+
+    assertTrue(deployment.getSpec().getTemplate().getSpec().getContainers().stream()
+        .map(probeFunction)
+        .anyMatch(probe -> actionPath.equals(probe.getHttpGet().getPath())
+            && periodSeconds == probe.getPeriodSeconds() && timeoutSeconds == probe.getTimeoutSeconds()));
+  }
+}

--- a/tests/feat-openshift-probes/pom.xml
+++ b/tests/feat-openshift-probes/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2018 The original authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>dekorate-tests</artifactId>
+    <groupId>io.dekorate</groupId>
+    <version>2.9-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>io.dekorate</groupId>
+  <version>2.9-SNAPSHOT</version>
+  <artifactId>feat-probes-openshift</artifactId>
+  <name>Dekorate :: Tests :: Probes :: OpenShift</name>
+
+  <properties>
+    <version.vertx>3.8.2</version.vertx>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>${version.vertx}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>openshift-junit-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/tests/feat-openshift-probes/src/main/java/io/dekorate/example/Main.java
+++ b/tests/feat-openshift-probes/src/main/java/io/dekorate/example/Main.java
@@ -1,39 +1,42 @@
 /**
  * Copyright 2018 The original authors.
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- **/
+ * 
+**/
 
 package io.dekorate.example;
 
-import java.util.Optional;
-import org.junit.jupiter.api.Test;
+import io.dekorate.annotation.Dekorate;
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.Future;
 
-import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.kubernetes.api.model.HasMetadata;
-import io.fabric8.kubernetes.api.model.Service;
+@Dekorate
+public class Main extends AbstractVerticle {
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static io.dekorate.testing.KubernetesResources.*;
-
-class VertxTest {
-
-  @Test
-  public void shouldContainService() throws Exception {
-    KubernetesList list = loadGenerated("openshift");
-    Optional<Service> service = findFirst(list, Service.class);
-    assertTrue(service.isPresent());
+  @Override
+  public void start(Future<Void> future) {
+    vertx
+        .createHttpServer()
+        .requestHandler(r -> {
+          r.response().end("hello world!");
+        })
+        .listen(8080, result -> {
+          if (result.succeeded()) {
+            future.complete();
+          } else {
+            future.fail(result.cause());
+          }
+        });
   }
 }
-

--- a/tests/feat-openshift-probes/src/main/resources/application.properties
+++ b/tests/feat-openshift-probes/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+dekorate.openshift.ports[0].name=http
+dekorate.openshift.ports[0].containerPort=8080
+dekorate.openshift.readinessProbe.httpActionPath=/readiness
+dekorate.openshift.readinessProbe.periodSeconds=30
+dekorate.openshift.readinessProbe.timeoutSeconds=10
+dekorate.openshift.livenessProbe.httpActionPath=/liveness
+dekorate.openshift.livenessProbe.periodSeconds=31
+dekorate.openshift.livenessProbe.timeoutSeconds=11
+dekorate.openshift.startupProbe.httpActionPath=/startup
+dekorate.openshift.startupProbe.periodSeconds=32
+dekorate.openshift.startupProbe.timeoutSeconds=12

--- a/tests/feat-openshift-probes/src/test/java/io/dekorate/example/VertxTest.java
+++ b/tests/feat-openshift-probes/src/test/java/io/dekorate/example/VertxTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+
+package io.dekorate.example;
+
+import static io.dekorate.testing.KubernetesResources.*;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+
+class VertxTest {
+
+  @Test
+  public void shouldContainService() {
+    KubernetesList list = loadGenerated("openshift");
+    Optional<Service> service = findFirst(list, Service.class);
+    assertTrue(service.isPresent());
+  }
+
+  @Test
+  public void shouldContainProbes() {
+    KubernetesList list = loadGenerated("openshift");
+    Optional<DeploymentConfig> deployment = findFirst(list, DeploymentConfig.class);
+    assertTrue(deployment.isPresent(), "DeploymentConfig not found!");
+
+    assertReadinessProbe(deployment.get(), "/readiness", 30, 10);
+    assertLivenessProbe(deployment.get(), "/liveness", 31, 11);
+    assertStartupProbe(deployment.get(), "/startup", 32, 12);
+  }
+
+  private static void assertReadinessProbe(DeploymentConfig deployment, String actionPath,
+      int periodSeconds, int timeoutSeconds) {
+    assertProbe(deployment, Container::getReadinessProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertLivenessProbe(DeploymentConfig deployment, String actionPath,
+      int periodSeconds, int timeoutSeconds) {
+    assertProbe(deployment, Container::getLivenessProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertStartupProbe(DeploymentConfig deployment, String actionPath,
+      int periodSeconds, int timeoutSeconds) {
+    assertProbe(deployment, Container::getStartupProbe, actionPath, periodSeconds, timeoutSeconds);
+  }
+
+  private static void assertProbe(DeploymentConfig deployment,
+      Function<Container, Probe> probeFunction,
+      String actionPath, int periodSeconds, int timeoutSeconds) {
+
+    assertTrue(deployment.getSpec().getTemplate().getSpec().getContainers().stream()
+        .map(probeFunction)
+        .anyMatch(probe -> actionPath.equals(probe.getHttpGet().getPath())
+            && periodSeconds == probe.getPeriodSeconds() && timeoutSeconds == probe.getTimeoutSeconds()));
+  }
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -60,6 +60,9 @@
       <module>issue-775-sb-server-port</module>
       <module>issue-791-missing-imagestream-with-default-configuration</module>
       <module>issue-821-docker-build-on-ocp-test</module>
+      <module>feat-kubernetes-probes</module>
+      <module>feat-openshift-probes</module>
+      <module>feat-knative-probes</module>
     </modules>
 
 </project>


### PR DESCRIPTION
In this PR: https://github.com/dekorateio/dekorate/pull/875, we added the Probe coverage under the examples, where it should go under the tests modules.