### PR TITLE
Update Kubernetes Client dependency to most recent version 5.12.1

### DIFF
--- a/annotations/prometheus-annotations/src/main/java/io/dekorate/prometheus/client/dsl/internal/ServiceMonitorOperationsImpl.java
+++ b/annotations/prometheus-annotations/src/main/java/io/dekorate/prometheus/client/dsl/internal/ServiceMonitorOperationsImpl.java
@@ -17,17 +17,17 @@ package io.dekorate.prometheus.client.dsl.internal;
 
 import io.dekorate.prometheus.model.ServiceMonitor;
 import io.dekorate.prometheus.model.ServiceMonitorList;
-import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ClientContext;
 import io.fabric8.kubernetes.client.dsl.Resource;
 import io.fabric8.kubernetes.client.dsl.base.HasMetadataOperation;
 import io.fabric8.kubernetes.client.dsl.base.OperationContext;
-import okhttp3.OkHttpClient;
+import io.fabric8.kubernetes.client.dsl.internal.HasMetadataOperationsImpl;
 
 public class ServiceMonitorOperationsImpl
     extends HasMetadataOperation<ServiceMonitor, ServiceMonitorList, Resource<ServiceMonitor>> {
 
-  public ServiceMonitorOperationsImpl(OkHttpClient client, Config config) {
-    this(new OperationContext().withOkhttpClient(client).withConfig(config));
+  public ServiceMonitorOperationsImpl(ClientContext clientContext) {
+    this(HasMetadataOperationsImpl.defaultContext(clientContext));
   }
 
   public ServiceMonitorOperationsImpl(OperationContext context) {

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <version.commons-compress>1.21</version.commons-compress>
     <version.jansi>1.18</version.jansi>
     <version.jackson>2.12.3</version.jackson>
-    <version.kubernetes-client>5.10.0</version.kubernetes-client>
+    <version.kubernetes-client>5.12.1</version.kubernetes-client>
     <version.sundrio>0.60.0</version.sundrio>
     <version.jayway.jsonpath>2.6.0</version.jayway.jsonpath>
 
@@ -82,7 +82,6 @@
     <!-- Formatting Plugins -->
     <version.formatter-maven-plugin>2.12.2</version.formatter-maven-plugin>
     <version.impsort-maven-plugin>1.6.2</version.impsort-maven-plugin>
-
 
     <!-- Release Plugins -->
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>


### PR DESCRIPTION
All changes: https://github.com/fabric8io/kubernetes-client/compare/v5.10.0...v5.12.1

We need to bump the Kubernetes Client to the most recent version to support gRPC actions (see https://github.com/dekorateio/dekorate/issues/857)