### PR TITLE
test: allow to override testing configuration using system properties

### DIFF
--- a/docs/documentation/junit-extensions.md
+++ b/docs/documentation/junit-extensions.md
@@ -91,7 +91,29 @@ This is important since in the `test` phase the application is not packaged. Her
 </plugin>
 ```
 
-#### related examples
+##### Integration Test Configuration
+
+We can customize the deployment configuration within the test execution using the Kubernetes integration test annotation:
+
+```java
+@KubernetesIntegrationTest(deployEnabled = true,
+  buildEnabled = true,
+  readinessTimeout = 300000,
+  additionalModules = {} 
+)
+class KubernetesIT {
+    // ...
+}
+```
+
+| Field                 | Type     | Description                                                                         | Overridable using System Property | Default Value |
+|-----------------------|----------|-------------------------------------------------------------------------------------|-----------------------------------|---------------|
+| deployEnabled         | boolean  | Flag to define whether the extension should automatically apply resources.          | dekorate.test.deploy.enabled      |          true |
+| buildEnabled          | boolean  | Flag to define whether the extension should automatically perform container builds. | dekorate.test.build.enabled       |          true |
+| readinessTimeout      | long     | The amount of time in milliseconds to wait for application to become ready.         | dekorate.test.readiness.timeout   |        300000 |
+| additionalModules     | String[] | List of additional modules to be loaded by the test framework.                      | dekorate.test.additional-modules  |               |
+
+##### related examples
 - [spring boot on kubernetes example](https://github.com/dekorateio/dekorate/tree/main/examples/spring-boot-on-kubernetes-example)
 
 #### OpenShift extension for JUnit5
@@ -115,7 +137,33 @@ By adding the annotation to your test class the following things will happen:
 6. Test will run
 7. Applied resources will be removed.
 
-#### related examples
+##### Integration Test Configuration
+
+We can customize the deployment configuration within the test execution using the OpenShift integration test annotation:
+
+```java
+@OpenshiftIntegrationTest(deployEnabled = true,
+  buildEnabled = true,
+  pushEnabled = false,
+  imageStreamTagTimeout = 120000,
+  readinessTimeout = 300000,
+  additionalModules = {} 
+)
+class OpenShiftIT {
+    // ...
+}
+```
+
+| Field                 | Type     | Description                                                                         | Overridable using System Property            | Default Value |
+|-----------------------|----------|-------------------------------------------------------------------------------------|----------------------------------------------|---------------|
+| deployEnabled         | boolean  | Flag to define whether the extension should automatically apply resources.          | dekorate.test.deploy.enabled                 |          true |
+| buildEnabled          | boolean  | Flag to define whether the extension should automatically perform container builds. | dekorate.test.build.enabled                  |          true |
+| pushEnabled           | boolean  | Flag to define whether the extension should automatically push image.               | dekorate.test.openshift.push.enabled         |         false |
+| imageStreamTagTimeout | long     | The amount of time in seconds to wait for the image stream tags to be available.    | dekorate.test.openshift.image-stream.timeout |        120000 |
+| readinessTimeout      | long     | The amount of time in milliseconds to wait for application to become ready.         | dekorate.test.readiness.timeout              |        300000 |
+| additionalModules     | String[] | List of additional modules to be loaded by the test framework.                      | dekorate.test.additional-modules             |               |
+
+##### related examples
 - [spring boot on openshift example](https://github.com/dekorateio/dekorate/tree/main/examples/spring-boot-on-openshift-example)
 - [spring boot with groovy on openshift example](https://github.com/dekorateio/dekorate/tree/main/examples/spring-boot-with-groovy-on-openshift-example)
 - [spring boot with gradle on openshift example](https://github.com/dekorateio/dekorate/tree/main/examples/spring-boot-with-gradle-on-openshift-example)
@@ -285,3 +333,4 @@ Doing so, the test framework will locate the Dekorate manifests that have been p
 ##### related examples
 - [Multi-Module projects on OpenShift example](https://github.com/dekorateio/dekorate/tree/main/examples/multimodule-projects-on-openshift-example)
 - [Multi-Module projects on Kubernetes example](https://github.com/dekorateio/dekorate/tree/main/examples/multimodule-projects-on-kubernetes-example)
+

--- a/testing/core-junit/src/main/java/io/dekorate/testing/WithIntegrationTestConfig.java
+++ b/testing/core-junit/src/main/java/io/dekorate/testing/WithIntegrationTestConfig.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.testing;
+
+import java.util.Optional;
+
+public interface WithIntegrationTestConfig {
+  default Optional<Boolean> getDeployEnabledFromProperties() {
+    return Optional.ofNullable(System.getProperty("dekorate.test.deploy.enabled")).map(Boolean::parseBoolean);
+  }
+
+  default Optional<Boolean> getBuildEnabledFromProperties() {
+    return Optional.ofNullable(System.getProperty("dekorate.test.build.enabled")).map(Boolean::parseBoolean);
+  }
+
+  default Optional<Long> getReadinessTimeoutFromProperties() {
+    return Optional.ofNullable(System.getProperty("dekorate.test.readiness.timeout")).map(Long::parseLong);
+  }
+
+  default Optional<String[]> getAdditionalModulesFromProperties() {
+    return Optional.ofNullable(System.getProperty("dekorate.test.additional-modules")).map(v -> v.split(","));
+  }
+}

--- a/testing/kubernetes-junit/src/main/java/io/dekorate/testing/annotation/KubernetesIntegrationTest.java
+++ b/testing/kubernetes-junit/src/main/java/io/dekorate/testing/annotation/KubernetesIntegrationTest.java
@@ -47,7 +47,7 @@ public @interface KubernetesIntegrationTest {
   boolean deployEnabled() default true;
 
   /**
-   * Flag to define whether the extension should automatically apply resources.
+   * Flag to define whether the extension should automatically perform container builds.
    * 
    * @return True, if extensions should automatically perform container builds.
    */

--- a/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/annotation/OpenshiftIntegrationTest.java
+++ b/testing/openshift-junit/src/main/java/io/dekorate/testing/openshift/annotation/OpenshiftIntegrationTest.java
@@ -47,7 +47,7 @@ public @interface OpenshiftIntegrationTest {
   boolean deployEnabled() default true;
 
   /**
-   * Flag to define whether the extension should automatically apply resources.
+   * Flag to define whether the extension should automatically perform container builds.
    * 
    * @return True, if extensions should automatically perform container builds.
    */


### PR DESCRIPTION
When we launch a test using:

```java
@OpenshiftIntegrationTest
public class ManagedOpenShiftIT {
   @Inject
    Pod pod;
   // ...
}
```

By default, the extension will build and deploy the application using the dekorate generated resources.

However, users might want to run the test in an `unmanaged` way, this is:

```java
@OpenshiftIntegrationTest(deployEnabled = false, buildEnabled = false)
public class UnmanagedOpenShiftIT {
   @Inject
    Pod pod;
  // ...
}
```

And the extension will keep resolving the instances like Pod, Utils, etc. 

With these changes, we can override the default test configuration using system properties, for example, for Kubernetes:

| Field                 | Type     | Description                                                                         | Overridable using System Property | Default Value |
|-----------------------|----------|-------------------------------------------------------------------------------------|-----------------------------------|---------------|
| deployEnabled         | boolean  | Flag to define whether the extension should automatically apply resources.          | dekorate.test.deploy.enabled      |          true |
| buildEnabled          | boolean  | Flag to define whether the extension should automatically perform container builds. | dekorate.test.build.enabled       |          true |
| readinessTimeout      | long     | The amount of time in milliseconds to wait for application to become ready.         | dekorate.test.readiness.timeout   |        300000 |
| additionalModules     | String[] | List of additional modules to be loaded by the test framework.                      | dekorate.test.additional-modules  |               |

Fix https://github.com/dekorateio/dekorate/issues/801