### PR TITLE
fix: use current date to cache mvn repo

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -30,11 +30,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+        shell: bash
       - name: Cache .m2 registry
         uses: actions/cache@v2.1.5
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Install artifacts
         run: ./mvnw -f pom.xml ${MAVEN_ARGS} -DskipTests clean install
@@ -49,6 +54,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+        shell: bash
+      - name: Cache .m2 registry
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}
+          restore-keys: ${{ runner.os }}-maven-
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.4.1
         with:
@@ -57,12 +73,6 @@ jobs:
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: 'docker'
           start args: '--force'
-      - name: Cache .m2 registry
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-maven-
       - name: Setup Java 8
         uses: actions/setup-java@v2
         with:
@@ -90,17 +100,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+        shell: bash
+      - name: Cache .m2 registry
+        uses: actions/cache@v2.1.5
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}
+          restore-keys: ${{ runner.os }}-maven-
       - name: Setup OpenShift
         uses: manusa/actions-setup-openshift@v1.1.3
         with:
           oc version: ${{ matrix.openshift }}
           github token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Cache .m2 registry
-        uses: actions/cache@v2.1.5
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}
-          restore-keys: ${{ runner.os }}-maven-
       - name: Setup Java 8
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
This caused by https://github.com/actions/runner/issues/449

See this comment that explains why it started failing now: https://github.com/actions/runner/issues/449#issuecomment-1058348592