### PR TITLE
Fix typo: dekoarate->dekorate

### DIFF
--- a/docs/documentation/kubernetes.md
+++ b/docs/documentation/kubernetes.md
@@ -335,7 +335,7 @@ This is possible when using git over https, but not possible when using git over
 but have 3d-party tools use `https` instead. To force dekorate covnert vcs urls to `https` one case use the `httpsPreferred` parameter of `@VcsOptions`.
 Or using properties:
 
-    dekoarate.vcs.https-preferred=true
+    dekorate.vcs.https-preferred=true
 
 
 #### Jvm Options

--- a/readme.md
+++ b/readme.md
@@ -540,7 +540,7 @@ This is possible when using git over https, but not possible when using git over
 but have 3d-party tools use `https` instead. To force dekorate covnert vcs urls to `https` one case use the `httpsPreferred` parameter of `@VcsOptions`.
 Or using properties:
 
-    dekoarate.vcs.https-preferred=true
+    dekorate.vcs.https-preferred=true
 
 
 #### Jvm Options


### PR DESCRIPTION
Just stumbled upon this typo today when I tried to copy&paste stuff from the documentation. ;-)