### PR TITLE
feat: include helm model in helm annotations in noapt classifier

### DIFF
--- a/annotations/helm-annotations/pom.xml
+++ b/annotations/helm-annotations/pom.xml
@@ -162,6 +162,7 @@
                     <include>io/dekorate/helm/configurator/**</include>
                     <include>io/dekorate/helm/manifest/**</include>
                     <include>io/dekorate/helm/util/**</include>
+                    <include>io/dekorate/helm/model/**</include>
                     <include>META-INF/services/io.dekorate.*</include>
                     <include>META-INF/MANIFEST.MF</include>
                   </includes>


### PR DESCRIPTION
Adding the model sources in the noapt classifier is necessary to overwrite the provided configuration.