### PR TITLE
fix: knative expose property

### DIFF
--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/manifest/KnativeManifestGenerator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/manifest/KnativeManifestGenerator.java
@@ -91,7 +91,7 @@ public class KnativeManifestGenerator extends AbstractKubernetesManifestGenerato
   private static final String CONFIG_DEFAULTS = "config-defaults";
   private static final String DEFAULT_REGISTRY = "dev.local/";
 
-  private static final String KNATIVE_VISIBILITY = "serving.knative.dev/visibility";
+  private static final String KNATIVE_VISIBILITY = "networking.knative.dev/visibility";
   private static final String CLUSTER_LOCAL = "cluster-local";
 
   public KnativeManifestGenerator() {

--- a/tests/feat-572-knative-cluster-local/src/test/java/io/dekorate/annotationless/Issue572Test.java
+++ b/tests/feat-572-knative-cluster-local/src/test/java/io/dekorate/annotationless/Issue572Test.java
@@ -37,7 +37,7 @@ public class Issue572Test {
     assertNotNull(list);
     Service s = findFirst(list, Service.class).orElseThrow(() -> new IllegalStateException());
     assertNotNull(s);
-    assertEquals("cluster-local", s.getMetadata().getLabels().get("serving.knative.dev/visibility"));
+    assertEquals("cluster-local", s.getMetadata().getLabels().get("networking.knative.dev/visibility"));
   }
 
   <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {


### PR DESCRIPTION
According to https://knative.dev/docs/serving/services/private-services/, the right property is `networking.knative.dev/visibility`, not `serving.knative.dev/visibility`.