### PR TITLE
fix: populate Dekorate docker group and version from system properties

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,3 +51,12 @@ jobs:
           distribution: 'temurin'
       - name: Build Project
         run: ./mvnw ${MAVEN_ARGS} clean install
+      - name: Zip Artifacts
+        if: failure()
+        run: |
+          zip -R manifests-build-jvm${{ matrix.java }}.zip 'classes/META-INF/dekorate/*'
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: ci-manifests
+          path: manifests-build-jvm${{ matrix.java }}.zip

--- a/.github/workflows/integration-tests-with-dockerio.yml
+++ b/.github/workflows/integration-tests-with-dockerio.yml
@@ -87,6 +87,15 @@ jobs:
       - name: Install and Run Integration Tests
         run: |
           ./mvnw -B clean install -Presources -Pwith-examples -Pwith-tests -Pwith-service-binding-examples -Pwith-knative-examples -Duser.name=dekorateio -Dformat.skip=true -Ddocker-registry=docker.io
+      - name: Zip Artifacts
+        if: failure()
+        run: |
+          zip -R manifests-k8s-jvm${{ matrix.java }}.zip 'classes/META-INF/dekorate/*'
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: ci-manifests
+          path: manifests-k8s-jvm${{ matrix.java }}.zip
 
   openshift:
     name: Openshift Build
@@ -128,3 +137,12 @@ jobs:
           oc import-image fabric8/s2i-java:2.3 --from=docker.io/fabric8/s2i-java:2.3 --confirm
           oc tag --source docker docker.io/fabric8/s2i-java:2.3 s2i-java:2.3
           ./mvnw -B clean install -Presources -Pwith-examples -Pwith-tests -Duser.name=dekorateio -Dformat.skip=true -Ddocker-registry=docker.io
+      - name: Zip Artifacts
+        if: failure()
+        run: |
+          zip -R manifests-ocp-jvm${{ matrix.java }}.zip 'classes/META-INF/dekorate/*'
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: ci-manifests
+          path: manifests-ocp-jvm${{ matrix.java }}.zip

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -92,6 +92,15 @@ jobs:
         run: |
           eval $(minikube docker-env)
           ./mvnw -B clean install -Presources -Pwith-examples -Pwith-tests -Pwith-service-binding-examples -Pwith-knative-examples -Duser.name=noregistry -Dformat.skip=true -Dkubernetes.image-pull-policy=IfNotPresent
+      - name: Zip Artifacts
+        if: failure()
+        run: |
+          zip -R manifests-k8s-jvm${{ matrix.java }}.zip 'classes/META-INF/dekorate/*'
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: ci-manifests
+          path: manifests-k8s-jvm${{ matrix.java }}.zip
 
   openshift:
     name: Openshift Build
@@ -132,3 +141,12 @@ jobs:
           oc import-image fabric8/s2i-java:2.3 --from=docker.io/fabric8/s2i-java:2.3 --confirm
           oc tag --source docker docker.io/fabric8/s2i-java:2.3 s2i-java:2.3
           ./mvnw -B clean install -Presources -Pwith-examples -Pwith-tests -Duser.name=dekorateio -Dformat.skip=true
+      - name: Zip Artifacts
+        if: failure()
+        run: |
+          zip -R manifests-ocp-jvm${{ matrix.java }}.zip 'classes/META-INF/dekorate/*'
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: ci-manifests
+          path: manifests-ocp-jvm${{ matrix.java }}.zip

--- a/annotations/docker-annotations/src/main/java/io/dekorate/docker/annotation/DockerBuild.java
+++ b/annotations/docker-annotations/src/main/java/io/dekorate/docker/annotation/DockerBuild.java
@@ -30,7 +30,6 @@ import io.sundr.builder.annotations.Pojo;
 @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
 @Pojo(name = "DockerBuildConfig", autobox = true, mutable = true, superClass = ImageConfiguration.class, relativePath = "../config", withStaticAdapterMethod = false, adapter = @Adapter(name = "DockerBuildConfigAdapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
-
 @Retention(RetentionPolicy.RUNTIME)
 public @interface DockerBuild {
 

--- a/core/src/main/java/io/dekorate/kubernetes/configurator/ApplyBuildToImageConfiguration.java
+++ b/core/src/main/java/io/dekorate/kubernetes/configurator/ApplyBuildToImageConfiguration.java
@@ -18,6 +18,7 @@ package io.dekorate.kubernetes.configurator;
 import io.dekorate.doc.Description;
 import io.dekorate.kubernetes.config.Configurator;
 import io.dekorate.kubernetes.config.ImageConfigurationFluent;
+import io.dekorate.utils.Strings;
 
 @Description("Apply build related info to image configuration.")
 public class ApplyBuildToImageConfiguration extends Configurator<ImageConfigurationFluent> {
@@ -25,14 +26,20 @@ public class ApplyBuildToImageConfiguration extends Configurator<ImageConfigurat
   private static final String DEKORATE_BUILD = "dekorate.build";
   private static final String DEKORATE_PUSH = "dekorate.push";
   private static final String DEKORATE_DOCKER_REGISTRY = "dekorate.docker.registry";
+  private static final String DEKORATE_DOCKER_GROUP = "dekorate.docker.group";
+  private static final String DEKORATE_DOCKER_VERSION = "dekorate.docker.version";
 
   @Override
   public void visit(ImageConfigurationFluent config) {
-    String registry = System.getProperty(DEKORATE_DOCKER_REGISTRY, config.getRegistry());
+    String registry = Strings.defaultIfEmpty(System.getProperty(DEKORATE_DOCKER_REGISTRY), config.getRegistry());
+    String group = Strings.defaultIfEmpty(System.getProperty(DEKORATE_DOCKER_GROUP), config.getGroup());
+    String version = Strings.defaultIfEmpty(System.getProperty(DEKORATE_DOCKER_VERSION), config.getVersion());
     config.withAutoBuildEnabled(
         Boolean.parseBoolean(System.getProperty(DEKORATE_BUILD, String.valueOf(config.getAutoBuildEnabled()))))
-        .withAutoPushEnabled(
-            Boolean.parseBoolean(System.getProperty(DEKORATE_PUSH, String.valueOf(config.getAutoPushEnabled()))))
-        .withRegistry(registry);
+      .withAutoPushEnabled(
+        Boolean.parseBoolean(System.getProperty(DEKORATE_PUSH, String.valueOf(config.getAutoPushEnabled()))))
+      .withRegistry(registry)
+      .withGroup(group)
+      .withVersion(version);
   }
 }

--- a/docs/documentation/docker-build-hook.md
+++ b/docs/documentation/docker-build-hook.md
@@ -22,16 +22,16 @@ or if you are using gradle:
 ```bash
 gradle build -Ddekorate.build=true   
 ```
-When push is enabled, the registry can be specified as part of the annotation, or via system properties.
+When push is enabled, the registry, the group and the version can be specified as part of the annotation, or via system properties. 
 Here's an example via annotation configuration:
 ```java
-@EnableDockerBuild(registry="quay.io")
+@DockerBuild(registry = "quay.io", group = "user", version = "1.0")
 public class Main {
 }
 ```    
 Here's how it can be done via build properties (system properties):
 ```bash
-mvn clean install -Ddekorate.docker.registry=quay.io -Ddekorate.push=true    
+mvn clean install -Ddekorate.docker.registry=quay.io -Ddekorate.docker.group=user -Ddekorate.docker.version=1.0 -Ddekorate.push=true    
 ```
 
 Note: Dekorate will **NOT** push images on its own. It will delegate to the `docker` binary. So the user needs to make sure

--- a/docs/documentation/junit-extensions.md
+++ b/docs/documentation/junit-extensions.md
@@ -39,7 +39,7 @@ This dependency gives access to [@KubernetesIntegrationTest](https://raw.githubu
 By adding the annotation to your test class the following things will happen:
 
 1. The extension will check if a kubernetes cluster is available (if not tests will be skipped).
-2. If `@EnableDockerBuild` is present in the project, a docker build will be triggered.
+2. If `@DockerBuild` is present in the project, a docker build will be triggered.
 3. All generated manifests will be applied.
 4. Will wait until applied resources are ready.
 5. Dependencies will be injected (e.g. KubernetesClient, Pod etc)
@@ -184,7 +184,7 @@ This dependency gives access to [@KnativeIntegrationTest](https://raw.githubuser
 By adding the annotation to your test class the following things will happen:
 
 1. The extension will check if a kubernetes cluster is available (if not tests will be skipped).
-2. If `@EnableDockerBuild` is present in the project, a docker build will be triggered.
+2. If `@DockerBuild` is present in the project, a docker build will be triggered.
 3. All generated manifests will be applied.
 4. Will wait until applied resources and the Knative services are ready.
 5. Dependencies will be injected (e.g. KnativeClient, Service, Knative Routes, etc)

--- a/examples/spring-boot-on-kubernetes-example/readme.md
+++ b/examples/spring-boot-on-kubernetes-example/readme.md
@@ -19,7 +19,7 @@ The application is using:
 Which contains all the required modules, including the annotation processors that detect spring web applications.
 
 The [Main.class](src/main/java/io/dekorate/example/Main.java) is annotated with `@KubernetesApplication` which triggers the resource generation.
-It's also annotated with `@EnableDockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
+It's also annotated with `@DockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
 `dekorate.build=true` to the build for example:
 
     mvn clean install -Ddekorate.build=true

--- a/examples/spring-boot-on-kubernetes-with-jib-custom-registry-example/readme.md
+++ b/examples/spring-boot-on-kubernetes-with-jib-custom-registry-example/readme.md
@@ -19,7 +19,7 @@ The application is using:
 Which contains all the required modules, including the annotation processors that detects spring web applications.
 
 The [Main.class](src/main/java/io/dekorate/example/Main.java) is annotated with `@KubernetesApplication` which triggers the resource generation.
-It's also annotated with `@EnableDockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
+It's also annotated with `@DockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
 `dekorate.build=true` to the build for example:
 
     mvn clean install -Ddekorate.build=true

--- a/examples/spring-boot-on-kubernetes-with-jib-example/readme.md
+++ b/examples/spring-boot-on-kubernetes-with-jib-example/readme.md
@@ -19,7 +19,7 @@ The application is using:
 Which contains all the required modules, including the annotation processors that detects spring web applications.
 
 The [Main.class](src/main/java/io/dekorate/example/Main.java) is annotated with `@KubernetesApplication` which triggers the resource generation.
-It's also annotated with `@EnableDockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
+It's also annotated with `@DockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
 `dekorate.build=true` to the build for example:
 
     mvn clean install -Ddekorate.build=true

--- a/examples/spring-boot-on-kubernetes-with-sbo-example/readme.md
+++ b/examples/spring-boot-on-kubernetes-with-sbo-example/readme.md
@@ -19,7 +19,7 @@ The application is using:
 Which contains all the required modules, including the annotation processors that detect spring web applications.
 
 The [Main.class](src/main/java/io/dekorate/example/Main.java) is annotated with `@KubernetesApplication` which triggers the resource generation.
-It's also annotated with `@EnableDockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
+It's also annotated with `@DockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
 `dekorate.build=true` to the build for example:
 
     mvn clean install -Ddekorate.build=true

--- a/examples/spring-boot-on-openshift-example/src/test/java/io/dekorate/example/SpringBootOnOpenshiftTest.java
+++ b/examples/spring-boot-on-openshift-example/src/test/java/io/dekorate/example/SpringBootOnOpenshiftTest.java
@@ -40,7 +40,8 @@ class SpringBootOnOpenshiftTest {
     BuildConfig b = findFirst(list, BuildConfig.class).orElseThrow(() -> new IllegalStateException());
     assertNotNull(d);
     assertNotNull(b);
-    assertTrue(d.getSpec().getTriggers().stream().filter(t -> t.getImageChangeParams().getFrom().getName().equals(b.getSpec().getOutput().getTo().getName())).findFirst().isPresent());
+    assertTrue(d.getSpec().getTriggers().stream().anyMatch(t -> t.getImageChangeParams().getFrom().getName().equals(b.getSpec().getOutput().getTo().getName())),
+      "Could not find trigger with image change params from: " + b.getSpec().getOutput().getTo().getName());
   }
 
   <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {

--- a/examples/spring-boot-with-tekton-and-m2-pvc-example/readme.md
+++ b/examples/spring-boot-with-tekton-and-m2-pvc-example/readme.md
@@ -19,7 +19,7 @@ The application is using:
 Which contains all the required modules, including the annotation processors that detect spring web applications.
 
 The [Main.class](src/main/java/io/dekorate/example/Main.java) is annotated with `@KubernetesApplication` which triggers the resource generation.
-It's also annotated with `@EnableDockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
+It's also annotated with `@DockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
 `dekorate.build=true` to the build for example:
 
     mvn clean install -Ddekorate.build=true

--- a/examples/spring-boot-with-tekton-example/readme.md
+++ b/examples/spring-boot-with-tekton-example/readme.md
@@ -19,7 +19,7 @@ The application is using:
 Which contains all the required modules, including the annotation processors that detect spring web applications.
 
 The [Main.class](src/main/java/io/dekorate/example/Main.java) is annotated with `@KubernetesApplication` which triggers the resource generation.
-It's also annotated with `@EnableDockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
+It's also annotated with `@DockerBuild`. This annotation allows the user to trigger a docker build after the compilation, by passing the system property 
 `dekorate.build=true` to the build for example:
 
     mvn clean install -Ddekorate.build=true

--- a/readme.md
+++ b/readme.md
@@ -1249,7 +1249,7 @@ gradle build -Ddekorate.build=true
 When push is enabled, the registry can be specified as part of the annotation, or via system properties.
 Here's an example via annotation configuration:
 ```java
-@EnableDockerBuild(registry="quay.io")
+@DockerBuild(registry="quay.io")
 public class Main {
 }
 ```    
@@ -1350,7 +1350,7 @@ This dependency gives access to [@KubernetesIntegrationTest](testing/kubernetes-
 By adding the annotation to your test class the following things will happen:
 
 1. The extension will check if a kubernetes cluster is available (if not tests will be skipped).
-2. If `@EnableDockerBuild` is present in the project, a docker build will be triggered.
+2. If `@DockerBuild` is present in the project, a docker build will be triggered.
 3. All generated manifests will be applied.
 4. Will wait until applied resources are ready.
 5. Dependencies will be injected (e.g. KubernetesClient, Pod etc)

--- a/tests/issue-963-docker-system-properties/Dockerfile
+++ b/tests/issue-963-docker-system-properties/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:8u171-alpine3.7
+RUN apk --no-cache add curl
+COPY target/*.jar example.jar
+CMD java ${JAVA_OPTS} -jar example.jar

--- a/tests/issue-963-docker-system-properties/pom.xml
+++ b/tests/issue-963-docker-system-properties/pom.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright 2018 The original authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <artifactId>dekorate-tests</artifactId>
+    <groupId>io.dekorate</groupId>
+    <version>2.9-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>issue-963-docker-system-properties</artifactId>
+  <packaging>jar</packaging>
+  <name>Dekorate :: Tests :: Annotations :: Docker :: Docker system properties for #963</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>${properties-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>initialize-system-properties</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>set-system-properties</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <property>
+                  <name>dekorate.docker.registry</name>
+                  <value>quay.io</value>
+                </property>
+                <property>
+                  <name>dekorate.docker.group</name>
+                  <value>from-maven</value>
+                </property>
+                <property>
+                  <name>dekorate.docker.version</name>
+                  <value>1.0</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>clear-system-properties</id>
+            <phase>install</phase>
+            <goals>
+              <goal>set-system-properties</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <property>
+                  <name>dekorate.docker.registry</name>
+                  <value></value>
+                </property>
+                <property>
+                  <name>dekorate.docker.group</name>
+                  <value></value>
+                </property>
+                <property>
+                  <name>dekorate.docker.version</name>
+                  <value></value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.maven-surefire-plugin}</version>
+        <inherited>true</inherited>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${version.maven-compiler-plugin}</version>
+        <configuration>
+          <source>${java.source}</source>
+          <target>${java.target}</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/issue-963-docker-system-properties/src/main/java/io/dekorate/example/Main.java
+++ b/tests/issue-963-docker-system-properties/src/main/java/io/dekorate/example/Main.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dekorate.example;
+
+import io.dekorate.annotation.Dekorate;
+
+@Dekorate
+public class Main {
+
+  public static void main(String[] args) {
+  }
+
+}

--- a/tests/issue-963-docker-system-properties/src/main/resources/application.yml
+++ b/tests/issue-963-docker-system-properties/src/main/resources/application.yml
@@ -1,0 +1,4 @@
+dekorate:
+  docker:
+    registry: localhost:3000
+    group: default

--- a/tests/issue-963-docker-system-properties/src/test/java/io/dekorate/example/Issue963Test.java
+++ b/tests/issue-963-docker-system-properties/src/test/java/io/dekorate/example/Issue963Test.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.dekorate.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.utils.Serialization;
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+
+public class Issue963Test {
+
+  @Test
+  public void shouldOverrideDockerConfigurationUsingValuesFromMavenPropertiesPlugin() {
+    KubernetesList list = Serialization
+        .unmarshalAsList(Issue963Test.class.getClassLoader().getResourceAsStream("META-INF/dekorate/kubernetes.yml"));
+    assertNotNull(list);
+    Deployment d = findFirst(list, Deployment.class).orElseThrow(() -> new IllegalStateException());
+    assertNotNull(d);
+    Container c = d.getSpec().getTemplate().getSpec().getContainers().get(0);
+    assertNotNull(c);
+    String image = c.getImage();
+    // Maven properties plugin overrides:
+    // registry from localhost:3000 to quay.io
+    // group from default to from-maven
+    // version from module version to 1.0
+    assertEquals("quay.io/from-maven/issue-963-docker-system-properties:1.0", image);
+  }
+
+  <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {
+    return (Optional<T>) list.getItems().stream()
+        .filter(i -> t.isInstance(i))
+        .findFirst();
+  }
+
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -76,6 +76,7 @@
       <module>issue-939-knative-container-concurrency</module>
       <module>feat-941-existing-common-resources</module>
       <module>feat-943-configmap-volumes</module>
+      <module>issue-963-docker-system-properties</module>
     </modules>
 
 </project>


### PR DESCRIPTION
Additionally, I've changed the annotation `@EnableDockerBuild` to `@DockerBuild` that was renamed in Dekorate 2.x.

Fix https://github.com/dekorateio/dekorate/issues/963