### PR TITLE
fix: run the checks job on push, instead of in pull requests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,31 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # 
-name: Build
-
-env:
-  MAVEN_ARGS: -B -e
+name: Perform Checks
 
 on:
   push:
     branches:
       - main
-  pull_request:
+  workflow_dispatch:
 
 jobs:
-  build:
-    name: Java ${{ matrix.java }} Maven
+  check:
+    name: Perform checks
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        java: [8,11,17]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
-      - name: Setup Java
-        uses: actions/setup-java@v2
+      - name: Check dead links in documentation
+        uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
-          java-version: ${{ matrix.java }}
-          distribution: 'temurin'
-      - name: Build Project
-        run: ./mvnw ${MAVEN_ARGS} clean install
+          use-quiet-mode: 'yes'
+          config-file: '.github/markdown-link-check.json'


### PR DESCRIPTION
This is because some links are not available until they are available in the main branch.

Related failure that we'll about with this change: https://github.com/dekorateio/dekorate/runs/6290448335?check_suite_focus=true