### PR TITLE
docs: fix anchors in the index page

### DIFF
--- a/docs/_includes/home-hero-band.html
+++ b/docs/_includes/home-hero-band.html
@@ -1,8 +1,8 @@
 <div class="component homepage-hero-band full-width-bg dark-bg text-centered">
   <div class="grid-wrapper">
     <div class="width-12-12">
-      <h1>Let's Dekorate!</h1>
-      <h2>What is Dekorate?</h2>
+      <h1 class="no-anchor">Let's Dekorate!</h1>
+      <h2 class="no-anchor">What is Dekorate?</h2>
       <p>Dekorate is a one-stop jar to Kubernetes manifest generation that works for all jvm languages regardless of your build tool.
 It makes generating Kubernetes manifests as easy as adding a dependency to the classpath.
 Stop wasting time editing xml, json and yml and customize the kubernetes manifests as you configure your java application.</p>
@@ -16,8 +16,7 @@ Stop wasting time editing xml, json and yml and customize the kubernetes manifes
     </div> 
     <div class="width-4-12 heroversioncontent">
       <p class="nowavailable">Now Available</p>
-    <h3 class="heroversion">Dekorate {{ site.data.project.release.current-version | replace: ".Final", "" }}</h3>
-<!--    <p class="moreinfo"><a href="{{site.baseurl}}/downloads/">Download Now</a></p>-->
+      <h3 class="heroversion no-anchor">Dekorate {{ site.data.project.release.current-version | replace: ".Final", "" }}</h3>
     </div>
     <div class="grid__item width-2-12"></div>
   </div>

--- a/docs/_layouts/base.html
+++ b/docs/_layouts/base.html
@@ -48,7 +48,12 @@
   -->
   <script type="text/javascript">
     document.addEventListener("DOMContentLoaded", function(event) {
-      anchors.add('h1, h2, h3, h4, h5, h6');
+      anchors.add('h1:not(.no-anchor)')
+             .add('h2:not(.no-anchor)')
+             .add('h3:not(.no-anchor)')
+             .add('h4:not(.no-anchor)')
+             .add('h5:not(.no-anchor)')
+             .add('h6:not(.no-anchor)');
     });
   </script>
 </body>


### PR DESCRIPTION
For example, the `Dekorate 2.9.3` text was displaying an anchor what was not expected to have.
I've added a CSS class with name `no-anchors`, so we can use it to skip the anchors in other places.