### PR TITLE
fix: delete logging configuration in helm annotation dependency

### DIFF
--- a/annotations/helm-annotations/src/main/resources/log4j2.xml
+++ b/annotations/helm-annotations/src/main/resources/log4j2.xml
@@ -1,6 +1,0 @@
-<Configuration>
-  <Loggers>
-    <!-- In case of Log4j2 dependencies are present, we need to configure jsonpath to only print INFO traces -->
-    <Logger name="com.jayway.jsonpath" level="info"/>
-  </Loggers>
-</Configuration>

--- a/annotations/helm-annotations/src/main/resources/logback.xml
+++ b/annotations/helm-annotations/src/main/resources/logback.xml
@@ -1,4 +1,0 @@
-<configuration>
-  <!-- In case of Logback dependencies are present (Spring boot examples), we need to configure jsonpath to only print INFO traces -->
-  <logger name="com.jayway.jsonpath" level="INFO"/>
-</configuration>


### PR DESCRIPTION
With this logging configuration, the spring boot applications traces were turned off.