### PR TITLE
fix: annotation processsor now return SourceVersion.latest()

### DIFF
--- a/annotations/docker-annotations/src/main/java/io/dekorate/docker/apt/DockerAnnotationProcessor.java
+++ b/annotations/docker-annotations/src/main/java/io/dekorate/docker/apt/DockerAnnotationProcessor.java
@@ -21,8 +21,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -30,7 +28,6 @@ import io.dekorate.Session;
 import io.dekorate.docker.annotation.DockerBuild;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes({ "io.dekorate.docker.annotation.DockerBuild" })
 public class DockerAnnotationProcessor extends AbstractAnnotationProcessor {
 

--- a/annotations/helm-annotations/src/main/java/io/dekorate/helm/apt/HelmAnnotationProcessor.java
+++ b/annotations/helm-annotations/src/main/java/io/dekorate/helm/apt/HelmAnnotationProcessor.java
@@ -24,15 +24,12 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
 import io.dekorate.helm.annotation.HelmChart;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes({ "io.dekorate.helm.annotation.HelmChart" })
 public class HelmAnnotationProcessor extends AbstractAnnotationProcessor {
 

--- a/annotations/jaeger-annotations/src/main/java/io/dekorate/jaeger/apt/JaegerAgentAnnotationProcessor.java
+++ b/annotations/jaeger-annotations/src/main/java/io/dekorate/jaeger/apt/JaegerAgentAnnotationProcessor.java
@@ -19,15 +19,12 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
 import io.dekorate.jaeger.annotation.EnableJaegerAgent;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes({ "io.dekorate.jaeger.annotation.EnableJaegerAgent" })
 public class JaegerAgentAnnotationProcessor extends AbstractAnnotationProcessor {
 

--- a/annotations/jib-annotations/src/main/java/io/dekorate/jib/apt/JibProcessor.java
+++ b/annotations/jib-annotations/src/main/java/io/dekorate/jib/apt/JibProcessor.java
@@ -19,15 +19,12 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
 import io.dekorate.jib.annotation.JibBuild;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes("io.dekorate.jib.annotation.JibBuild")
 public class JibProcessor extends AbstractAnnotationProcessor {
 

--- a/annotations/kind-annotations/src/main/java/io/dekorate/kind/apt/KindAnnotationProcessor.java
+++ b/annotations/kind-annotations/src/main/java/io/dekorate/kind/apt/KindAnnotationProcessor.java
@@ -19,8 +19,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -30,7 +28,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.kind.annotation.Kind;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Generates kubernetes manifests.")
 @SupportedAnnotationTypes("io.dekorate.kind.annotation.Kind")
 public class KindAnnotationProcessor extends AbstractAnnotationProcessor {

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/apt/KnativeAnnotationProcessor.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/apt/KnativeAnnotationProcessor.java
@@ -19,8 +19,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -30,7 +28,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.knative.annotation.KnativeApplication;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Generates knative manifests.")
 @SupportedAnnotationTypes("io.dekorate.knative.annotation.KnativeApplication")
 public class KnativeAnnotationProcessor extends AbstractAnnotationProcessor {

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/annotation/KubernetesApplication.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/annotation/KubernetesApplication.java
@@ -270,7 +270,7 @@ public @interface KubernetesApplication {
   /**
    * @return the TLS secret name to be used in the Ingress resource.
    */
-  Ingress ingress() default @Ingress;
+  Ingress ingress() default @Ingress();
 
   /**
    * Controls whether the generated {@link Service} will be headless.

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/apt/KubernetesAnnotationProcessor.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/apt/KubernetesAnnotationProcessor.java
@@ -19,8 +19,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -30,7 +28,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.kubernetes.annotation.KubernetesApplication;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Generates kubernetes manifests.")
 @SupportedAnnotationTypes("io.dekorate.kubernetes.annotation.KubernetesApplication")
 public class KubernetesAnnotationProcessor extends AbstractAnnotationProcessor {

--- a/annotations/minikube-annotations/src/main/java/io/dekorate/minikube/apt/MinikubeAnnotationProcessor.java
+++ b/annotations/minikube-annotations/src/main/java/io/dekorate/minikube/apt/MinikubeAnnotationProcessor.java
@@ -19,8 +19,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -30,7 +28,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.minikube.annotation.Minikube;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Generates kubernetes manifests for Minikube.")
 @SupportedAnnotationTypes("io.dekorate.minikube.annotation.Minikube")
 public class MinikubeAnnotationProcessor extends AbstractAnnotationProcessor {

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/apt/OpenshiftAnnotationProcessor.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/apt/OpenshiftAnnotationProcessor.java
@@ -20,8 +20,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -29,7 +27,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.openshift.annotation.OpenshiftApplication;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Generates openshift manifests.")
 @SupportedAnnotationTypes("io.dekorate.openshift.annotation.OpenshiftApplication")
 public class OpenshiftAnnotationProcessor extends AbstractAnnotationProcessor {

--- a/annotations/option-annotations/src/main/java/io/dekorate/option/apt/GeneratorOptionsProcessor.java
+++ b/annotations/option-annotations/src/main/java/io/dekorate/option/apt/GeneratorOptionsProcessor.java
@@ -19,8 +19,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -29,7 +27,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.option.annotation.GeneratorOptions;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Processing generator options, which are used for customizing the generation process")
 @SupportedAnnotationTypes({
     "io.dekorate.annotation.Dekorate",

--- a/annotations/option-annotations/src/main/java/io/dekorate/option/apt/JvmOptionsProcessor.java
+++ b/annotations/option-annotations/src/main/java/io/dekorate/option/apt/JvmOptionsProcessor.java
@@ -19,8 +19,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -29,7 +27,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.option.annotation.JvmOptions;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Jvm options, which are used for the target deployment.")
 @SupportedAnnotationTypes("io.dekorate.option.annotation.JvmOptions")
 public class JvmOptionsProcessor extends AbstractAnnotationProcessor implements WithSession {

--- a/annotations/option-annotations/src/main/java/io/dekorate/option/apt/VcsOptionsProcessor.java
+++ b/annotations/option-annotations/src/main/java/io/dekorate/option/apt/VcsOptionsProcessor.java
@@ -19,8 +19,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -28,7 +26,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.option.annotation.VcsOptions;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Vcs options, which are used for the target deployment.")
 @SupportedAnnotationTypes("io.dekorate.option.annotation.VcsOptions")
 public class VcsOptionsProcessor extends AbstractAnnotationProcessor {

--- a/annotations/prometheus-annotations/src/main/java/io/dekorate/prometheus/apt/ServiceMonitorAnnotationProcessor.java
+++ b/annotations/prometheus-annotations/src/main/java/io/dekorate/prometheus/apt/ServiceMonitorAnnotationProcessor.java
@@ -19,15 +19,12 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
 import io.dekorate.processor.AbstractAnnotationProcessor;
 import io.dekorate.prometheus.annotation.EnableServiceMonitor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes({ "io.dekorate.prometheus.annotation.EnableServiceMonitor" })
 public class ServiceMonitorAnnotationProcessor extends AbstractAnnotationProcessor {
 

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/apt/S2iAnnotationProcessor.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/apt/S2iAnnotationProcessor.java
@@ -21,15 +21,12 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
 import io.dekorate.processor.AbstractAnnotationProcessor;
 import io.dekorate.s2i.annotation.S2iBuild;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @SupportedAnnotationTypes({ "io.dekorate.s2i.annotation.S2iBuild" })
 public class S2iAnnotationProcessor extends AbstractAnnotationProcessor {
 

--- a/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/apt/ServiceBindingAnnotationProcessor.java
+++ b/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/apt/ServiceBindingAnnotationProcessor.java
@@ -19,8 +19,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -28,7 +26,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 import io.dekorate.servicebinding.annotation.ServiceBinding;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Generate ServiceBinding custom resources.")
 @SupportedAnnotationTypes("io.dekorate.servicebinding.annotation.ServiceBinding")
 public class ServiceBindingAnnotationProcessor extends AbstractAnnotationProcessor {

--- a/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/apt/TektonAnnotationProcessor.java
+++ b/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/apt/TektonAnnotationProcessor.java
@@ -20,8 +20,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -29,7 +27,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 import io.dekorate.tekton.annotation.TektonApplication;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Generates tekton manifests.")
 @SupportedAnnotationTypes("io.dekorate.tekton.annotation.TektonApplication")
 public class TektonAnnotationProcessor extends AbstractAnnotationProcessor {

--- a/core/src/main/java/io/dekorate/apt/DekorateProcessor.java
+++ b/core/src/main/java/io/dekorate/apt/DekorateProcessor.java
@@ -24,8 +24,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -38,7 +36,6 @@ import io.dekorate.config.DekorateConfig;
 import io.dekorate.doc.Description;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Detects @Dekorate and configures application based on the specified configuration files.")
 @SupportedAnnotationTypes({ "io.dekorate.annotation.Dekorate" })
 public class DekorateProcessor extends AbstractAnnotationProcessor {

--- a/core/src/main/java/io/dekorate/processor/AbstractAnnotationProcessor.java
+++ b/core/src/main/java/io/dekorate/processor/AbstractAnnotationProcessor.java
@@ -34,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.tools.FileObject;
 import javax.tools.StandardLocation;
@@ -57,7 +58,13 @@ public abstract class AbstractAnnotationProcessor extends AbstractProcessor impl
   protected static final String DOT = ".";
 
   protected Logger LOGGER;
+
   private final AtomicReference<ProcessingEnvironment> processingEnvRef = new AtomicReference<>();
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.latest();
+  }
 
   @Override
   public synchronized void init(ProcessingEnvironment processingEnv) {

--- a/frameworks/jaxrs/src/main/java/io/dekorate/jaxrs/apt/ApplicationPathAnnotationProcessor.java
+++ b/frameworks/jaxrs/src/main/java/io/dekorate/jaxrs/apt/ApplicationPathAnnotationProcessor.java
@@ -24,8 +24,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.ws.rs.ApplicationPath;
@@ -35,7 +33,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 import io.dekorate.utils.Strings;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Detects JAX-RS and servlet annotations and registers the http port.")
 @SupportedAnnotationTypes("javax.ws.rs.ApplicationPath")
 public class ApplicationPathAnnotationProcessor extends AbstractAnnotationProcessor {

--- a/frameworks/jaxrs/src/main/java/io/dekorate/jaxrs/apt/PathAnnotationProcessor.java
+++ b/frameworks/jaxrs/src/main/java/io/dekorate/jaxrs/apt/PathAnnotationProcessor.java
@@ -24,8 +24,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import javax.ws.rs.Path;
@@ -35,7 +33,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 import io.dekorate.utils.Strings;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Detects JAX-RS @Path annotation and registers the http port.")
 @SupportedAnnotationTypes("javax.ws.rs.Path")
 public class PathAnnotationProcessor extends AbstractAnnotationProcessor {

--- a/frameworks/spring-boot/src/main/java/io/dekorate/spring/apt/SpringBootApplicationProcessor.java
+++ b/frameworks/spring-boot/src/main/java/io/dekorate/spring/apt/SpringBootApplicationProcessor.java
@@ -22,8 +22,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -36,7 +34,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 import io.dekorate.spring.config.SpringBootApplicationGenerator;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Detects Spring Boot and set the runtime attribute to Spring Boot.")
 @SupportedAnnotationTypes({ "org.springframework.boot.autoconfigure.SpringBootApplication" })
 public class SpringBootApplicationProcessor extends AbstractAnnotationProcessor implements SpringBootApplicationGenerator {

--- a/frameworks/spring-boot/src/main/java/io/dekorate/spring/apt/SpringBootBeanProcessor.java
+++ b/frameworks/spring-boot/src/main/java/io/dekorate/spring/apt/SpringBootBeanProcessor.java
@@ -25,8 +25,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -36,7 +34,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 import io.dekorate.spring.BeanListener;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Detects Spring Boot and set the runtime attribute to Spring Boot.")
 @SupportedAnnotationTypes({ "org.springframework.context.annotation.Bean" })
 public class SpringBootBeanProcessor extends AbstractAnnotationProcessor {

--- a/frameworks/spring-boot/src/main/java/io/dekorate/spring/apt/SpringBootWebProcessor.java
+++ b/frameworks/spring-boot/src/main/java/io/dekorate/spring/apt/SpringBootWebProcessor.java
@@ -24,8 +24,6 @@ import java.util.stream.Collectors;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -37,7 +35,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 import io.dekorate.spring.config.SpringBootWebAnnotationGenerator;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Detects Spring Boot web endpoints and registers the http port.")
 @SupportedAnnotationTypes({ "org.springframework.web.bind.annotation.RestController",
     "org.springframework.web.bind.annotation.RequestMapping", "org.springframework.web.bind.annotation.GetMapping",

--- a/frameworks/thorntail/src/main/java/io/dekorate/thorntail/ThorntailProcessor.java
+++ b/frameworks/thorntail/src/main/java/io/dekorate/thorntail/ThorntailProcessor.java
@@ -21,8 +21,6 @@ import java.util.Set;
 
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
-import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
@@ -33,7 +31,6 @@ import io.dekorate.doc.Description;
 import io.dekorate.processor.AbstractAnnotationProcessor;
 import io.dekorate.thorntail.configurator.ThorntailPrometheusAgentConfigurator;
 
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
 @Description("Detects JAX-RS and servlet annotations and registers the http port.")
 @SupportedAnnotationTypes({ "javax.ws.rs.ApplicationPath", "javax.ws.rs.Path", "javax.servlet.annotation.WebServlet" })
 public class ThorntailProcessor extends AbstractAnnotationProcessor implements ThorntailWebAnnotationGenerator {


### PR DESCRIPTION
As there is no good solution for this problem, given that we want to be compatible with a wide range of jdk version, we'll get hacky.

We'll follow the approach suggested by @dmlloyd in this pull request: https://github.com/kohsuke/metainf-services/pull/4.