### PR TITLE
fix: Replace jayway JsonPath by custom YAML expressions

### DIFF
--- a/annotations/helm-annotations/pom.xml
+++ b/annotations/helm-annotations/pom.xml
@@ -18,11 +18,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.jayway.jsonpath</groupId>
-      <artifactId>json-path</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
       <scope>compile</scope>

--- a/annotations/helm-annotations/src/main/java/io/dekorate/helm/annotation/ValueReference.java
+++ b/annotations/helm-annotations/src/main/java/io/dekorate/helm/annotation/ValueReference.java
@@ -28,11 +28,9 @@ public @interface ValueReference {
   String property();
 
   /**
-   * The JSONPath expressions where to map the property.
-   *
-   * It uses <a href="https://tools.ietf.org/id/draft-goessner-dispatch-jsonpath-00.html">JSONPath expression specification</a>.
+   * The path expressions where to map the property.
    */
-  String[] jsonPaths();
+  String[] paths();
 
   String profile() default "";
 

--- a/annotations/helm-annotations/src/main/java/io/dekorate/helm/util/HelmExpressionParser.java
+++ b/annotations/helm-annotations/src/main/java/io/dekorate/helm/util/HelmExpressionParser.java
@@ -1,0 +1,247 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ **/
+package io.dekorate.helm.util;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import io.dekorate.utils.Strings;
+
+/**
+ * Utility to parse expressions in YAML resources that are in the form of Maps.
+ */
+public class HelmExpressionParser {
+
+  private static final String NO_REPLACEMENT = "no";
+  private static final String ESCAPE = "'";
+  private static final String DOT = ".";
+
+  private final List<Map<Object, Object>> resources;
+
+  public HelmExpressionParser(List<Map<Object, Object>> resources) {
+    this.resources = resources;
+  }
+
+  /**
+   * Read and set the value at `path` with the replacement value.
+   *
+   * @param path The path expression where to read and replace the value.
+   * @param replacement The value to replace.
+   * @return the list of values that have been found at `path`.
+   */
+  public Object readAndSet(String path, String replacement) {
+    Set<Object> values = new HashSet<>();
+    for (Map<Object, Object> resource : resources) {
+      Object value = readValuesForResource(resource, path, replacement);
+      if (value != null) {
+        values.add(value);
+      }
+    }
+
+    return uniqueResult(values, path);
+  }
+
+  private static Object readValuesForResource(Map<Object, Object> resource, String path, String replacement) {
+
+    String currentPart;
+    int nextIndex;
+    PathProcessor processor;
+    if (path.startsWith("(")) {
+      // Handle expressions where path is "(kind == Service).rest":
+      // increase pointer to ".rest":
+      nextIndex = path.indexOf(")");
+      // current part is now "kind == Service":
+      currentPart = path.substring(1, nextIndex);
+      processor = locateExpressionPathProcessor(currentPart);
+    } else if (path.startsWith(ESCAPE)) {
+      // Handle escaped parts where path is "'a.b.c'.rest"
+      String nextPart = path.substring(1);
+      // increase pointer to ".rest":
+      nextIndex = nextPart.indexOf(ESCAPE);
+      // current part is now "a.b.c":
+      currentPart = nextPart.substring(0, nextIndex);
+      processor = new PartPathProcessor(currentPart);
+    } else {
+      // Handle normal parts where path is "spec.rest"
+      // if we have several dots, for example: "..spec.rest", we move the pointer to "spec.rest"
+      while (path.indexOf(DOT) == 0) {
+        path = path.substring(1);
+      }
+
+      // increase pointer to ".rest":
+      nextIndex = path.indexOf(DOT);
+      // current part is now "spec":
+      currentPart = normalize(nextIndex > 0 ? path.substring(0, nextIndex) : path);
+      processor = new PartPathProcessor(currentPart);
+    }
+
+    Object result = null;
+    if (processor.canHandle(resource)) {
+      result = processor.handle(resource);
+      if (result instanceof Map) {
+        return readValuesForResource((Map) result, path.substring(nextIndex + 1), replacement);
+      } else if (result instanceof List) {
+        String nextPath = path.substring(nextIndex + 1);
+        Set<Object> values = new HashSet<>();
+        for (Object inner : (List) result) {
+          if (inner instanceof Map) {
+            Object value = readValuesForResource((Map) inner, nextPath, replacement);
+            if (value != null) {
+              values.add(value);
+            }
+          }
+        }
+
+        return uniqueResult(values, nextPath);
+      }
+
+      if (!NO_REPLACEMENT.equals(replacement)) {
+        resource.put(currentPart, replacement);
+      }
+    }
+
+    return result;
+  }
+
+  private static Object uniqueResult(Set<Object> set, String path) {
+    if (set.size() > 1) {
+      throw new IllegalStateException("Several matches for the path: " + path + ". Found: " + set);
+    } else if (set.isEmpty()) {
+      return null;
+    }
+
+    return set.iterator().next();
+  }
+
+  private static PathProcessor locateExpressionPathProcessor(String expression) {
+    for (PathExpression type : PathExpression.values()) {
+      if (expression.contains(type.getOperator())) {
+        return type.getPathProcessor(expression);
+      }
+    }
+
+    throw new IllegalStateException("Unrecognised expression: " + expression);
+  }
+
+  private static String normalize(String text) {
+    if (Strings.isNullOrEmpty(text)) {
+      return text;
+    }
+
+    String normalized = text.trim();
+    if (normalized.startsWith(ESCAPE)) {
+      normalized = normalized.substring(1, normalized.length() - 1);
+    }
+
+    return normalized;
+  }
+
+  static class PartPathProcessor implements PathProcessor {
+
+    private final String part;
+
+    PartPathProcessor(String part) {
+      this.part = part;
+    }
+
+    @Override
+    public boolean canHandle(Map<Object, Object> resource) {
+      return resource.containsKey(part);
+    }
+
+    @Override
+    public Object handle(Map<Object, Object> resource) {
+      return resource.get(part);
+    }
+  }
+
+  static class AndPathExpression implements PathProcessor {
+
+    private final List<PathProcessor> conditions;
+
+    AndPathExpression(String condition) {
+      this.conditions = new ArrayList<>();
+      String[] subConditions = condition.split(PathExpression.AND.getOperator());
+      for (String subCondition : subConditions) {
+        this.conditions.add(locateExpressionPathProcessor(subCondition));
+      }
+    }
+
+    @Override
+    public boolean canHandle(Map<Object, Object> resource) {
+      return conditions.stream().allMatch(c -> c.canHandle(resource));
+    }
+
+    @Override
+    public Object handle(Map<Object, Object> resource) {
+      return resource;
+    }
+  }
+
+  static class IsEqualPathExpression implements PathProcessor {
+
+    private final String left;
+    private final String right;
+
+    IsEqualPathExpression(String condition) {
+      String[] parts = condition.split(PathExpression.IS_EQUAL.getOperator());
+      this.left = normalize(parts[0]);
+      this.right = normalize(parts[1]);
+    }
+
+    @Override
+    public boolean canHandle(Map<Object, Object> resource) {
+      Object value = readValuesForResource(resource, left, NO_REPLACEMENT);
+      return value != null && value instanceof String && Strings.equals((String) value, right);
+    }
+
+    @Override
+    public Object handle(Map<Object, Object> resource) {
+      return resource;
+    }
+  }
+
+  interface PathProcessor {
+    boolean canHandle(Map<Object, Object> resource);
+
+    Object handle(Map<Object, Object> resource);
+  }
+
+  enum PathExpression {
+    AND("&&", AndPathExpression::new), IS_EQUAL("==", IsEqualPathExpression::new);
+
+    String operator;
+    Function<String, PathProcessor> supplier;
+
+    PathExpression(String operator, Function<String, PathProcessor> supplier) {
+      this.operator = operator;
+      this.supplier = supplier;
+    }
+
+    public String getOperator() {
+      return operator;
+    }
+
+    public PathProcessor getPathProcessor(String condition) {
+      return supplier.apply(condition);
+    }
+  }
+}

--- a/annotations/helm-annotations/src/main/resources/log4j2.xml
+++ b/annotations/helm-annotations/src/main/resources/log4j2.xml
@@ -1,6 +1,0 @@
-<Configuration>
-  <Loggers>
-    <!-- In case of Log4j2 dependencies are present, we need to configure jsonpath to only print INFO traces -->
-    <Logger name="com.jayway.jsonpath" level="info"/>
-  </Loggers>
-</Configuration>

--- a/annotations/helm-annotations/src/main/resources/logback.xml
+++ b/annotations/helm-annotations/src/main/resources/logback.xml
@@ -1,4 +1,0 @@
-<configuration>
-  <!-- In case of Logback dependencies are present (Spring boot examples), we need to configure jsonpath to only print INFO traces -->
-  <logger name="com.jayway.jsonpath" level="INFO"/>
-</configuration>

--- a/annotations/helm-annotations/src/test/java/io/dekorate/helm/util/HelmExpressionParserTest.java
+++ b/annotations/helm-annotations/src/test/java/io/dekorate/helm/util/HelmExpressionParserTest.java
@@ -56,7 +56,7 @@ public class HelmExpressionParserTest {
   }
 
   @Test
-  public void parseExpressionWithTwoEqualOperationsAndNotFound() throws IOException {
+  public void parseExpressionWithAndOperatorAndNotFound() throws IOException {
     Object found = parser.readAndSet("(kind == Deployment && metadata.name == notFound).metadata.name",
         "{{ .Values.app.name }}");
     assertNull(found);
@@ -64,11 +64,36 @@ public class HelmExpressionParserTest {
   }
 
   @Test
-  public void parseExpressionWithTwoEqualOperationsAndFound() throws IOException {
+  public void parseExpressionWithAndOperatorAndFound() throws IOException {
     Object found = parser.readAndSet("(kind == Deployment && metadata.name == example).metadata.name",
         "{{ .Values.app.name }}");
     assertEquals("example", found);
     assertGeneratedYaml("parseExpressionWithEqual");
+  }
+
+  @Test
+  public void parseExpressionWithOrOperatorAndNotFound() throws IOException {
+    Object found = parser.readAndSet("(metadata.name == notFound1 || metadata.name == notFound2).metadata.name",
+        "{{ .Values.app.name }}");
+    assertNull(found);
+    assertGeneratedYaml("no-changes");
+  }
+
+  @Test
+  public void parseExpressionWithOrOperatorAndFound() throws IOException {
+    Object found = parser.readAndSet("(metadata.name == example || metadata.name == notFound).metadata.name",
+        "{{ .Values.app.name }}");
+    assertEquals("example", found);
+    assertGeneratedYaml("parseExpressionWithOrOperatorAndFound");
+  }
+
+  @Test
+  public void parseExpressionWithSeveralFilters() throws IOException {
+    Object found = parser.readAndSet(
+        "(kind == Deployment && metadata.name == example).spec.template.spec.containers.(name == example).ports.containerPort",
+        "{{ .Values.app.containerPort }}");
+    assertEquals(8080, found);
+    assertGeneratedYaml("parseExpressionWithSeveralFilters");
   }
 
   private void assertGeneratedYaml(String method) throws IOException {

--- a/annotations/helm-annotations/src/test/java/io/dekorate/helm/util/HelmExpressionParserTest.java
+++ b/annotations/helm-annotations/src/test/java/io/dekorate/helm/util/HelmExpressionParserTest.java
@@ -1,0 +1,80 @@
+package io.dekorate.helm.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.compress.utils.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.utils.Serialization;
+
+public class HelmExpressionParserTest {
+
+  private static final File TEST_FILE = new File(HelmExpressionParserTest.class.getResource("/test-kubernetes.yml").getFile());
+
+  private List<Map<Object, Object>> resources;
+  private HelmExpressionParser parser;
+
+  @BeforeEach
+  public void setup() throws IOException {
+    resources = Serialization.unmarshalAsListOfMaps(TEST_FILE.toPath());
+    parser = new HelmExpressionParser(resources);
+  }
+
+  @Test
+  public void parseSimpleExpression() throws IOException {
+    Object found = parser.readAndSet("metadata.name", "{{ .Values.app.name }}");
+    assertEquals("example", found);
+    assertGeneratedYaml("parseSimpleExpression");
+  }
+
+  @Test
+  public void parseExpressionWithEscape() throws IOException {
+    Object found = parser.readAndSet("spec.selector.matchLabels.'app.kubernetes.io/name'", "{{ .Values.app.label }}");
+    assertEquals("example", found);
+    assertGeneratedYaml("parseExpressionWithEscape");
+  }
+
+  @Test
+  public void parseArrayExpression() throws IOException {
+    Object found = parser.readAndSet("spec.ports.port", "{{ .Values.app.port }}");
+    assertEquals(80, found);
+    assertGeneratedYaml("parseArrayExpression");
+  }
+
+  @Test
+  public void parseExpressionWithEqual() throws IOException {
+    Object found = parser.readAndSet("(kind == Deployment).metadata.name", "{{ .Values.app.name }}");
+    assertEquals("example", found);
+    assertGeneratedYaml("parseExpressionWithEqual");
+  }
+
+  @Test
+  public void parseExpressionWithTwoEqualOperationsAndNotFound() throws IOException {
+    Object found = parser.readAndSet("(kind == Deployment && metadata.name == notFound).metadata.name",
+        "{{ .Values.app.name }}");
+    assertNull(found);
+    assertGeneratedYaml("no-changes");
+  }
+
+  @Test
+  public void parseExpressionWithTwoEqualOperationsAndFound() throws IOException {
+    Object found = parser.readAndSet("(kind == Deployment && metadata.name == example).metadata.name",
+        "{{ .Values.app.name }}");
+    assertEquals("example", found);
+    assertGeneratedYaml("parseExpressionWithEqual");
+  }
+
+  private void assertGeneratedYaml(String method) throws IOException {
+    String actual = Serialization.yamlMapper().writeValueAsString(resources);
+    String expected = new String(
+        IOUtils.toByteArray(getClass().getResourceAsStream("/expected-" + method + "-kubernetes.yml")));
+    assertEquals(expected, actual, "Unexpected generated YAML file. Found: " + actual);
+  }
+}

--- a/annotations/helm-annotations/src/test/resources/expected-no-changes-kubernetes.yml
+++ b/annotations/helm-annotations/src/test/resources/expected-no-changes-kubernetes.yml
@@ -1,0 +1,35 @@
+---
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: example
+    spec:
+      ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+      type: ClusterIP
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: example
+    spec:
+      replicas: 3
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: example
+      template:
+        metadata:
+          app.kubernetes.io/name: example
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              name: example
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP

--- a/annotations/helm-annotations/src/test/resources/expected-parseArrayExpression-kubernetes.yml
+++ b/annotations/helm-annotations/src/test/resources/expected-parseArrayExpression-kubernetes.yml
@@ -1,0 +1,35 @@
+---
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: example
+    spec:
+      ports:
+        - name: http
+          port: "{{ .Values.app.port }}"
+          targetPort: 8080
+      type: ClusterIP
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: example
+    spec:
+      replicas: 3
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: example
+      template:
+        metadata:
+          app.kubernetes.io/name: example
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              name: example
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP

--- a/annotations/helm-annotations/src/test/resources/expected-parseExpressionWithEqual-kubernetes.yml
+++ b/annotations/helm-annotations/src/test/resources/expected-parseExpressionWithEqual-kubernetes.yml
@@ -1,0 +1,35 @@
+---
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: example
+    spec:
+      ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+      type: ClusterIP
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: "{{ .Values.app.name }}"
+    spec:
+      replicas: 3
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: example
+      template:
+        metadata:
+          app.kubernetes.io/name: example
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              name: example
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP

--- a/annotations/helm-annotations/src/test/resources/expected-parseExpressionWithEscape-kubernetes.yml
+++ b/annotations/helm-annotations/src/test/resources/expected-parseExpressionWithEscape-kubernetes.yml
@@ -1,0 +1,35 @@
+---
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: example
+    spec:
+      ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+      type: ClusterIP
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: example
+    spec:
+      replicas: 3
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: "{{ .Values.app.label }}"
+      template:
+        metadata:
+          app.kubernetes.io/name: example
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              name: example
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP

--- a/annotations/helm-annotations/src/test/resources/expected-parseExpressionWithOrOperatorAndFound-kubernetes.yml
+++ b/annotations/helm-annotations/src/test/resources/expected-parseExpressionWithOrOperatorAndFound-kubernetes.yml
@@ -1,0 +1,35 @@
+---
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: "{{ .Values.app.name }}"
+    spec:
+      ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+      type: ClusterIP
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: "{{ .Values.app.name }}"
+    spec:
+      replicas: 3
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: example
+      template:
+        metadata:
+          app.kubernetes.io/name: example
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              name: example
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP

--- a/annotations/helm-annotations/src/test/resources/expected-parseExpressionWithSeveralFilters-kubernetes.yml
+++ b/annotations/helm-annotations/src/test/resources/expected-parseExpressionWithSeveralFilters-kubernetes.yml
@@ -1,0 +1,35 @@
+---
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: example
+    spec:
+      ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+      type: ClusterIP
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: example
+    spec:
+      replicas: 3
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: example
+      template:
+        metadata:
+          app.kubernetes.io/name: example
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              name: example
+              ports:
+                - containerPort: "{{ .Values.app.containerPort }}"
+                  name: http
+                  protocol: TCP

--- a/annotations/helm-annotations/src/test/resources/expected-parseSimpleExpression-kubernetes.yml
+++ b/annotations/helm-annotations/src/test/resources/expected-parseSimpleExpression-kubernetes.yml
@@ -1,0 +1,35 @@
+---
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: "{{ .Values.app.name }}"
+    spec:
+      ports:
+        - name: http
+          port: 80
+          targetPort: 8080
+      type: ClusterIP
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: "{{ .Values.app.name }}"
+    spec:
+      replicas: 3
+      selector:
+        matchLabels:
+          app.kubernetes.io/name: example
+      template:
+        metadata:
+          app.kubernetes.io/name: example
+        spec:
+          containers:
+            - env:
+                - name: KUBERNETES_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              name: example
+              ports:
+                - containerPort: 8080
+                  name: http
+                  protocol: TCP

--- a/annotations/helm-annotations/src/test/resources/test-kubernetes.yml
+++ b/annotations/helm-annotations/src/test/resources/test-kubernetes.yml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example
+spec:
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: example
+  template:
+    metadata:
+        app.kubernetes.io/name: example
+    spec:
+      containers:
+        - env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          name: example
+          ports:
+            - containerPort: 8080
+              name: http
+              protocol: TCP

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/decorator/AddIngressDecorator.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/decorator/AddIngressDecorator.java
@@ -97,7 +97,7 @@ public class AddIngressDecorator extends ResourceProvidingDecorator<KubernetesLi
 
   private ConfigReference buildConfigReferenceHost() {
     String property = generateConfigReferenceName("host", config.getName());
-    String jsonPath = "$.[?(@.kind == 'Ingress' && @.metadata.name == '" + config.getName() + "')].spec.rules..host";
-    return new ConfigReference(property, jsonPath, config.getHost());
+    String path = "(kind == Ingress && metadata.name == " + config.getName() + ").spec.rules.host";
+    return new ConfigReference(property, path, config.getHost());
   }
 }

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/ApplyReplicasToDeploymentConfigDecorator.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/ApplyReplicasToDeploymentConfigDecorator.java
@@ -58,11 +58,11 @@ public class ApplyReplicasToDeploymentConfigDecorator extends NamedResourceDecor
 
   private ConfigReference buildConfigReferenceReplicas() {
     String property = generateConfigReferenceName("replicas", getName());
-    String jsonPath = "$.[?(@.kind == 'DeploymentConfig')].spec.replicas";
+    String path = "(kind == DeploymentConfig).spec.replicas";
     if (!Strings.equals(getName(), ANY)) {
-      jsonPath = "$.[?(@.kind == 'DeploymentConfig' && @.metadata.name == '" + getName() + "')].spec.replicas";
+      path = "(kind == DeploymentConfig && metadata.name == " + getName() + ").spec.replicas";
     }
 
-    return new ConfigReference(property, jsonPath, replicas);
+    return new ConfigReference(property, path, replicas);
   }
 }

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/decorator/AddBuildConfigResourceDecorator.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/decorator/AddBuildConfigResourceDecorator.java
@@ -105,10 +105,8 @@ public class AddBuildConfigResourceDecorator extends ResourceProvidingDecorator<
 
   private ConfigReference buildConfigReferenceTag() {
     String property = generateConfigReferenceName("tag", config.getName(), getImageStreamName());
-    String jsonPath = "$.[?(@.kind == 'BuildConfig' && @.metadata.name == '" + config.getName()
-        + "')].spec.strategy.sourceStrategy.from.name";
-
-    return new ConfigReference(property, jsonPath);
+    String path = "(kind == BuildConfig && metadata.name == " + config.getName() + ")].spec.strategy.sourceStrategy.from.name";
+    return new ConfigReference(property, path);
   }
 
   private String getImageStreamName() {

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/decorator/AddBuilderImageStreamResourceDecorator.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/decorator/AddBuilderImageStreamResourceDecorator.java
@@ -69,10 +69,9 @@ public class AddBuilderImageStreamResourceDecorator extends ResourceProvidingDec
 
   private ConfigReference buildConfigReferenceBuilderImage() {
     String property = generateConfigReferenceName("builder-image", config.getName(), getImageStreamName());
-    String jsonPath = "$.[?(@.kind == 'ImageStream' && @.metadata.name == '" + getImageStreamName()
-        + "')].spec.dockerImageRepository";
+    String path = "(kind == ImageStream && metadata.name == " + getImageStreamName() + ").spec.dockerImageRepository";
     String value = Images.removeTag(config.getBuilderImage());
-    return new ConfigReference(property, jsonPath, value);
+    return new ConfigReference(property, path, value);
   }
 
   private String getImageStreamName() {

--- a/assets/config.md
+++ b/assets/config.md
@@ -471,7 +471,7 @@ The section below describes all the available subtypes.
 | Property   | Type     | Description                                                                                                                                                                                | Default Value |
 |------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | property   | String   | The name of the property in the Helm values file.                                                                                                                                          |               |
-| jsonPaths  | String   | A comma-separated list of [JSONPath](https://tools.ietf.org/id/draft-goessner-dispatch-jsonpath-00.html) expressions to map the Dekorate auto-generated properties to the final Helm values file.        |               |
+| paths  | String   | A comma-separated list of path expressions to map the Dekorate auto-generated properties to the final Helm values file.        |               |
 | profile    | String   | The dependency repository.                                                                                                                                                                 | (empty)       |
 | value      | String   | The dependency repository.                                                                                                                                                                 | (empty)       |
 

--- a/core/src/main/java/io/dekorate/ConfigReference.java
+++ b/core/src/main/java/io/dekorate/ConfigReference.java
@@ -25,25 +25,25 @@ import io.dekorate.utils.Strings;
  */
 public class ConfigReference {
   private String property;
-  private String[] jsonPaths;
+  private String[] paths;
   private Object value;
   private String profile;
 
-  public ConfigReference(String property, String jsonPath) {
-    this(property, new String[] { jsonPath });
+  public ConfigReference(String property, String path) {
+    this(property, new String[] { path });
   }
 
-  public ConfigReference(String property, String[] jsonPaths) {
-    this(property, jsonPaths, null, null);
+  public ConfigReference(String property, String[] paths) {
+    this(property, paths, null, null);
   }
 
-  public ConfigReference(String property, String jsonPath, Object value) {
-    this(property, new String[] { jsonPath }, value, null);
+  public ConfigReference(String property, String path, Object value) {
+    this(property, new String[] { path }, value, null);
   }
 
-  public ConfigReference(String property, String[] jsonPaths, Object value, String profile) {
+  public ConfigReference(String property, String[] paths, Object value, String profile) {
     this.property = property;
-    this.jsonPaths = jsonPaths;
+    this.paths = paths;
     this.value = value;
     this.profile = profile;
   }
@@ -56,10 +56,10 @@ public class ConfigReference {
   }
 
   /**
-   * @return json path to resolve the property in the generated JSON manifest.
+   * @return the expression paths to resolve the property in the generated YAML manifest.
    */
-  public String[] getJsonPaths() {
-    return jsonPaths;
+  public String[] getPaths() {
+    return paths;
   }
 
   /**

--- a/core/src/main/java/io/dekorate/Session.java
+++ b/core/src/main/java/io/dekorate/Session.java
@@ -178,7 +178,7 @@ public class Session {
         }
       } else {
         LOGGER.warning("Unknown generator '" + key + "' will be ignored. "
-          + "Known generators are: " + configurationGenerators.keySet());
+            + "Known generators are: " + configurationGenerators.keySet());
       }
     }
   }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddEnvVarDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddEnvVarDecorator.java
@@ -165,17 +165,17 @@ public class AddEnvVarDecorator extends ApplicationContainerDecorator<ContainerB
 
   private ConfigReference buildConfigReferenceForEnvValue() {
     String property = generateConfigReferenceName("envs." + env.getName(), getContainerName());
-    String envFilter = ".env.[?(@.name == '" + env.getName() + "')].value";
-    String jsonPath = "$..spec.template.spec.containers." + envFilter;
+    String envFilter = ".env.(name == " + env.getName() + ").value";
+    String path = "spec.template.spec.containers." + envFilter;
     if (!Strings.equals(getDeploymentName(), ANY) && !Strings.equals(getContainerName(), ANY)) {
-      jsonPath = "$.[?(@.metadata.name == '" + getDeploymentName() + "')].spec.template.spec.containers[?(@.name == '"
-          + getContainerName() + "')]" + envFilter;
+      path = "(metadata.name == " + getDeploymentName() + ").spec.template.spec.containers.(name == "
+          + getContainerName() + ")" + envFilter;
     } else if (!Strings.equals(getDeploymentName(), ANY)) {
-      jsonPath = "$.[?(@.metadata.name == '" + getDeploymentName() + "')].spec.template.spec.containers." + envFilter;
+      path = "(metadata.name == " + getDeploymentName() + ").spec.template.spec.containers." + envFilter;
     } else if (!Strings.equals(getContainerName(), ANY)) {
-      jsonPath = "$..spec.template.spec.containers[?(@.name == '" + getContainerName() + "')]" + envFilter;
+      path = "spec.template.spec.containers.(name == " + getContainerName() + ")" + envFilter;
     }
 
-    return new ConfigReference(property, jsonPath, env.getValue());
+    return new ConfigReference(property, path, env.getValue());
   }
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyImageDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyImageDecorator.java
@@ -56,17 +56,17 @@ public class ApplyImageDecorator extends ApplicationContainerDecorator<Container
 
   private ConfigReference buildConfigReferenceForImage() {
     String property = generateConfigReferenceName("image", getContainerName(), getDeploymentName());
-    String jsonPath = "$..spec.template.spec.containers..image";
+    String path = "spec.template.spec.containers.image";
     if (!Strings.equals(getDeploymentName(), ANY) && !Strings.equals(getContainerName(), ANY)) {
-      jsonPath = "$.[?(@.metadata.name == '" + getDeploymentName() + "')].spec.template.spec.containers[?(@.name == '"
-          + getContainerName() + "')].image";
+      path = "(metadata.name == " + getDeploymentName() + ")].spec.template.spec.containers"
+          + ".(name == " + getContainerName() + ").image";
     } else if (!Strings.equals(getDeploymentName(), ANY)) {
-      jsonPath = "$.[?(@.metadata.name == '" + getDeploymentName() + "')].spec.template.spec.containers..image";
+      path = "(metadata.name == " + getDeploymentName() + ").spec.template.spec.containers.image";
     } else if (!Strings.equals(getContainerName(), ANY)) {
-      jsonPath = "$..spec.template.spec.containers[?(@.name == '" + getContainerName() + "')].image";
+      path = "spec.template.spec.containers.(name == " + getContainerName() + ").image";
     }
 
-    return new ConfigReference(property, jsonPath, image);
+    return new ConfigReference(property, path, image);
   }
 
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyReplicasToDeploymentDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyReplicasToDeploymentDecorator.java
@@ -56,11 +56,11 @@ public class ApplyReplicasToDeploymentDecorator extends NamedResourceDecorator<D
 
   private ConfigReference buildConfigReferenceReplicas() {
     String property = generateConfigReferenceName("replicas", getName());
-    String jsonPath = "$.[?(@.kind == 'Deployment')].spec.replicas";
+    String path = "(kind == Deployment).spec.replicas";
     if (!Strings.equals(getName(), ANY)) {
-      jsonPath = "$.[?(@.kind == 'Deployment' && @.metadata.name == '" + getName() + "')].spec.replicas";
+      path = "(kind == Deployment && metadata.name == " + getName() + ").spec.replicas";
     }
 
-    return new ConfigReference(property, jsonPath);
+    return new ConfigReference(property, path);
   }
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyReplicasToStatefulSetDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyReplicasToStatefulSetDecorator.java
@@ -39,11 +39,11 @@ public class ApplyReplicasToStatefulSetDecorator extends NamedResourceDecorator<
 
   private ConfigReference buildConfigReferenceReplicas() {
     String property = generateConfigReferenceName("replicas", getName());
-    String jsonPath = "$.[?(@.kind == 'StatefulSet')].spec.replicas";
+    String path = "(kind == StatefulSet).spec.replicas";
     if (!Strings.equals(getName(), ANY)) {
-      jsonPath = "$.[?(@.kind == 'StatefulSet' && @.metadata.name == '" + getName() + "')].spec.replicas";
+      path = "(kind == StatefulSet && metadata.name == " + getName() + ").spec.replicas";
     }
 
-    return new ConfigReference(property, jsonPath);
+    return new ConfigReference(property, path);
   }
 }

--- a/core/src/main/java/io/dekorate/utils/Strings.java
+++ b/core/src/main/java/io/dekorate/utils/Strings.java
@@ -124,7 +124,7 @@ public class Strings {
   /**
    * Convert kebab case to camel case.
    * 
-   * @param The input string.
+   * @param str The input string.
    * @return The camel cased string.
    */
   public static String kebabToCamelCase(String str) {

--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -517,7 +517,7 @@ The section below describes all the available subtypes.
 | Property   | Type     | Description                                                                                                                                                                                | Default Value |
 |------------|----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
 | property   | String   | The name of the property in the Helm values file.                                                                                                                                          |               |
-| jsonPaths  | String   | A comma-separated list of [JSONPath](https://tools.ietf.org/id/draft-goessner-dispatch-jsonpath-00.html) expressions to map the Dekorate auto-generated properties to the final Helm values file.        |               |
+| paths  | String   | A comma-separated list of path expressions to map the Dekorate auto-generated properties to the final Helm values file.        |               |
 | profile    | String   | The dependency repository.                                                                                                                                                                 | (empty)       |
 | value      | String   | The dependency repository.                                                                                                                                                                 | (empty)       |
 

--- a/docs/documentation/helm.md
+++ b/docs/documentation/helm.md
@@ -165,7 +165,9 @@ myModule:
   name: this-is-another-name
 ```
 
-- Escaping characters in path expressions
+**What features do path expressions support?**
+
+- Escape characters
 
 If you want to select properties which key contains special characters like '.', you need to escape them using `'`, for example:
 
@@ -174,16 +176,37 @@ If you want to select properties which key contains special characters like '.',
 dekorate.helm.values[0].paths=spec.selector.matchLabels.'app.kubernetes.io/name'
 ```
 
-- Filtering in path expressions
+- Filter
 
 If you want to only map properties of certain resource type, you can add as many conditions you need in the path such as:
 
 ```
 ## To map the property only for Service resources:
 dekorate.helm.values[0].paths=(kind == Service).metadata.name
-## To map the property only for Service resources AND resources that has an annotation 'key' with value 'some' 
-dekorate.helm.values[1].paths=(kind == Service && metadata.annotations.'key' == 'some.text').metadata.name
 ```
+
+Additionally, we can write the filter including the "and" operator using "&&" or the "or" operator using "||": 
+
+```
+## To map the property only for Service resources AND resources that has an annotation 'key' with value 'some' 
+dekorate.helm.values[0].paths=(kind == Service && metadata.annotations.'key' == 'some.text').metadata.name
+
+## To map the property only for either Deployment OR DeploymentConfig resources 
+dekorate.helm.values[1].paths=(kind == Deployment || kind == DeploymentConfig).metadata.name
+```
+
+Also, filters can be placed at any place in the path expression and also at multiple times. Let's see an example of this: we want to map the container port of containers with name `example` and only for Deployment resources:
+
+```
+## To map the property only for Deployment resource AND containers with a concrete name 
+dekorate.helm.values[0].paths=(kind == Deployment).spec.template.spec.containers.(name == example).ports.containerPort
+```
+
+**What is not supported using path expressions?**
+
+- We can't use wildcards or regular expressions.
+- We can't write complex filters that involves AND/OR conditions. For example: the filter `(kind == Deployment && kind == DeploymentConfig || name == example)` is not supported.
+- We can't select elements by index. For example, if we want to map the second container, we can't do: `spec.template.spec.containers.2.ports.containerPort`.
 
 ##### Mapping multiple properties at once
 

--- a/examples/helm-on-kubernetes-example/src/main/resources/application.properties
+++ b/examples/helm-on-kubernetes-example/src/main/resources/application.properties
@@ -9,27 +9,24 @@ dekorate.helm.dependencies[1].name=dependency-name-b
 dekorate.helm.dependencies[1].alias=app
 # Normal use case
 dekorate.helm.values[0].property=helmOnKubernetesExample.name
-dekorate.helm.values[0].jsonPaths=$..metadata.name,$.[?(@.kind == 'Ingress')].spec.rules..http.paths..backend.service.name
+dekorate.helm.values[0].paths=metadata.name,(kind == Ingress).spec.rules.http.paths.backend.service.name
 # When json path is not found
 dekorate.helm.values[1].property=helmOnKubernetesExample.not-found
-dekorate.helm.values[1].jsonPaths=$.metadata.not-found
-# Using brackets json path
-dekorate.helm.values[2].property=helmOnKubernetesExample.commit-id
-dekorate.helm.values[2].jsonPaths=$[?(@.kind == 'Deployment')]['spec']['template']['metadata']['annotations']['app.dekorate.io/commit-id']
+dekorate.helm.values[1].paths=metadata.not-found
 # Using values
-dekorate.helm.values[3].property=helmOnKubernetesExample.vcs-url
-dekorate.helm.values[3].jsonPaths=$[?(@.kind == 'Deployment')]['spec']['template']['metadata']['annotations']['app.dekorate.io/vcs-url']
-dekorate.helm.values[3].value=Overridden
+dekorate.helm.values[2].property=helmOnKubernetesExample.vcs-url
+dekorate.helm.values[2].paths=(kind == Deployment).spec.template.metadata.annotations.'app.dekorate.io/vcs-url'
+dekorate.helm.values[2].value=Overridden
 # Using values with profile
-dekorate.helm.values[4].property=helmOnKubernetesExample.vcs-url
-dekorate.helm.values[4].jsonPaths=$[?(@.kind == 'Deployment')]['spec']['template']['metadata']['annotations']['app.dekorate.io/vcs-url']
-dekorate.helm.values[4].value=Only for DEV!
-dekorate.helm.values[4].profile=dev
+dekorate.helm.values[3].property=helmOnKubernetesExample.vcs-url
+dekorate.helm.values[3].paths=(kind == Deployment).spec.template.metadata.annotations.'app.dekorate.io/vcs-url'
+dekorate.helm.values[3].value=Only for DEV!
+dekorate.helm.values[3].profile=dev
 # Providing a different value for existing property (ingress.port)
-dekorate.helm.values[5].property=helmOnKubernetesExample.host
-dekorate.helm.values[5].jsonPaths=$.[?(@.kind == 'Ingress')].spec.rules..host
-dekorate.helm.values[5].value=my-test-host
-dekorate.helm.values[5].profile=dev
+dekorate.helm.values[4].property=helmOnKubernetesExample.host
+dekorate.helm.values[4].paths=(kind == Ingress).spec.rules.host
+dekorate.helm.values[4].value=my-test-host
+dekorate.helm.values[4].profile=dev
 dekorate.kubernetes.replicas=3
 dekorate.kubernetes.expose=true
 dekorate.kubernetes.host=my-host

--- a/examples/helm-on-kubernetes-example/src/test/java/io/dekorate/example/HelmKubernetesExampleTest.java
+++ b/examples/helm-on-kubernetes-example/src/test/java/io/dekorate/example/HelmKubernetesExampleTest.java
@@ -79,8 +79,6 @@ class HelmKubernetesExampleTest {
     assertEquals(3, helmExampleValues.get("replicas"));
     // Should NOT contain not-found: as this property is ignored
     assertNull(helmExampleValues.get("not-found"));
-    // Should contain commit-id
-    assertNotNull(helmExampleValues.get("commitId"));
     // Should contain vcs-url with the overridden value from properties
     assertEquals("Overridden", helmExampleValues.get("vcsUrl"));
   }
@@ -100,8 +98,6 @@ class HelmKubernetesExampleTest {
     assertEquals(3, helmExampleValues.get("replicas"));
     // Should NOT contain not-found: as this property is ignored
     assertNull(helmExampleValues.get("not-found"));
-    // Should contain commit-id
-    assertNotNull(helmExampleValues.get("commitId"));
     // Should contain vcs-url with the value from properties
     assertEquals("Only for DEV!", helmExampleValues.get("vcsUrl"));
     // Should contain ingress with the value from properties

--- a/examples/helm-on-openshift-example/src/main/java/io/dekorate/example/Main.java
+++ b/examples/helm-on-openshift-example/src/main/java/io/dekorate/example/Main.java
@@ -23,10 +23,9 @@ import io.dekorate.helm.annotation.ValueReference;
 import io.dekorate.openshift.annotation.OpenshiftApplication;
 
 @HelmChart(name = "myOcpChart",
-  values = { @ValueReference(property = "helmOnOpenshiftExample.not-found", jsonPaths = "$.metadata.not-found"),
-    @ValueReference(property = "helmOnOpenshiftExample.commit-id", jsonPaths = "$[?(@.kind == 'DeploymentConfig')]['spec']['template']['metadata']['annotations']['app.dekorate.io/commit-id']"),
-    @ValueReference(property = "helmOnOpenshiftExample.vcs-url", jsonPaths = "$[?(@.kind == 'DeploymentConfig')]['spec']['template']['metadata']['annotations']['app.dekorate.io/vcs-url']", value = "Overridden"),
-    @ValueReference(property = "helmOnOpenshiftExample.vcs-url", jsonPaths = "$[?(@.kind == 'DeploymentConfig')]['spec']['template']['metadata']['annotations']['app.dekorate.io/vcs-url']", value = "Only for DEV!", profile = "dev")
+  values = { @ValueReference(property = "helmOnOpenshiftExample.not-found", paths = "metadata.not-found"),
+    @ValueReference(property = "helmOnOpenshiftExample.vcs-url", paths = "(kind == DeploymentConfig).spec.template.metadata.annotations.'app.dekorate.io/vcs-url'", value = "Overridden"),
+    @ValueReference(property = "helmOnOpenshiftExample.vcs-url", paths = "(kind == DeploymentConfig).spec.template.metadata.annotations.'app.dekorate.io/vcs-url'", value = "Only for DEV!", profile = "dev")
 })
 @SpringBootApplication
 public class Main {

--- a/examples/helm-on-openshift-example/src/test/java/io/dekorate/example/HelmOpenshiftExampleTest.java
+++ b/examples/helm-on-openshift-example/src/test/java/io/dekorate/example/HelmOpenshiftExampleTest.java
@@ -73,8 +73,6 @@ class HelmOpenshiftExampleTest {
     assertEquals(3, helmExampleValues.get("replicas"));
     // Should NOT contain not-found: as this property is ignored
     assertNull(helmExampleValues.get("not-found"));
-    // Should contain commit-id
-    assertNotNull(helmExampleValues.get("commitId"));
     // Should contain vcs-url with the overridden value from properties
     assertEquals("Overridden", helmExampleValues.get("vcsUrl"));
   }
@@ -95,8 +93,6 @@ class HelmOpenshiftExampleTest {
     assertEquals(3, helmExampleValues.get("replicas"));
     // Should NOT contain not-found: as this property is ignored
     assertNull(helmExampleValues.get("not-found"));
-    // Should contain commit-id
-    assertNotNull(helmExampleValues.get("commitId"));
     // Should contain vcs-url with the value from properties
     assertEquals("Only for DEV!", helmExampleValues.get("vcsUrl"));
   }


### PR DESCRIPTION
Due to Jayway JsonPath dependency introduces some unnecessary dependencies at runtime and also print some annoying traces, we have decided to get rid of the support of JsonPath. 

To replace JsonPath, we've introduced a custom YAML expressions very similar to JsonPath, but without needing to parse from/to YAML to Json. 

Documentation has been updated