### PR TITLE
helm: support of path expressions with wildcard

### DIFF
--- a/annotations/helm-annotations/src/test/java/io/dekorate/helm/util/HelmExpressionParserTest.java
+++ b/annotations/helm-annotations/src/test/java/io/dekorate/helm/util/HelmExpressionParserTest.java
@@ -96,6 +96,24 @@ public class HelmExpressionParserTest {
     assertGeneratedYaml("parseExpressionWithSeveralFilters");
   }
 
+  @Test
+  public void parseExpressionWithWildcard() throws IOException {
+    Object found = parser.readAndSet(
+        "*.spec.containers.(name == example).ports.containerPort",
+        "{{ .Values.app.containerPort }}");
+    assertEquals(8080, found);
+    assertGeneratedYaml("parseExpressionWithSeveralFilters");
+  }
+
+  @Test
+  public void parseExpressionWithWildcardAndArrays() throws IOException {
+    Object found = parser.readAndSet(
+        "*.ports.containerPort",
+        "{{ .Values.app.containerPort }}");
+    assertEquals(8080, found);
+    assertGeneratedYaml("parseExpressionWithSeveralFilters");
+  }
+
   private void assertGeneratedYaml(String method) throws IOException {
     String actual = Serialization.yamlMapper().writeValueAsString(resources);
     String expected = new String(


### PR DESCRIPTION
- Wildcard: map properties at any level

If we want to map a property that is placed at a very depth level, for example, the `containerPort` property:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: example
spec:
  replicas: 3
  selector:
    matchLabels:
      app.kubernetes.io/name: example
  template:
    metadata:
        app.kubernetes.io/name: example
    spec:
      containers:
        - env:
            - name: KUBERNETES_NAMESPACE
              valueFrom:
                fieldRef:
                  fieldPath: metadata.namespace
          name: example
          ports:
            - containerPort: 8080 // we want to map this property!
              name: http
              protocol: TCP
```

If we want to map the property `containerPort`, we would need to write all the parent properties as in:

```
dekorate.helm.values[0].paths=spec.template.spec.containers.ports.containerPort
```

And what about if the `containerPort` property is at one place in the Deployment resources, but at another place in the DeploymentConfig resources? We would need to provide two expressions. 

To ease up this use case, we can use wildcards. For example: 

```
## To map the container port property for containers with name "example"
dekorate.helm.values[0].paths=*.spec.containers.(name == example).ports.containerPort
## To map the container port property for all the resources at any position.
dekorate.helm.values[1].paths=*.ports.containerPort
```