### PR TITLE
fix: invalid warnings when running the Dekorate session

### DIFF
--- a/core/src/main/java/io/dekorate/Session.java
+++ b/core/src/main/java/io/dekorate/Session.java
@@ -162,23 +162,17 @@ public class Session {
   }
 
   public void addConfiguration(Map<String, Object> map, BiConsumer<ConfigurationGenerator, Map<String, Object>> consumer) {
-    for (Map.Entry<String, Object> entry : map.entrySet()) {
-      String key = entry.getKey();
-      Object value = entry.getValue();
-      ConfigurationGenerator generator = configurationGenerators.get(key);
-      if (generator != null) {
-        if (value instanceof Map) {
-          Map<String, Object> generatorMap = new HashMap<>();
-          Class configClass = configtypes.get(key);
-          String newKey = configClass.getName();
-          Generators.applyPrimitives(configClass, (Map<String, Object>) value);
-          Generators.populateArrays(configClass, (Map<String, Object>) value);
-          generatorMap.put(newKey, value);
-          consumer.accept(generator, Maps.kebabToCamelCase(generatorMap));
-        }
-      } else {
-        LOGGER.warning("Unknown generator '" + key + "' will be ignored. "
-            + "Known generators are: " + configurationGenerators.keySet());
+    for (ConfigurationGenerator generator : configurationGenerators.values()) {
+      String key = generator.getKey();
+      Object value = map.get(key);
+      if (value instanceof Map) {
+        Map<String, Object> generatorMap = new HashMap<>();
+        Class configClass = configtypes.get(key);
+        String newKey = configClass.getName();
+        Generators.applyPrimitives(configClass, (Map<String, Object>) value);
+        Generators.populateArrays(configClass, (Map<String, Object>) value);
+        generatorMap.put(newKey, value);
+        consumer.accept(generator, Maps.kebabToCamelCase(generatorMap));
       }
     }
   }


### PR DESCRIPTION
There are some system properties that are not directly mapped using generators like `dekorate.build` or `dekorate.push`. These properties will either enable some special handling, functionality and/or include some other properties. 

The problem is that at the moment, the session is checking whether these properties are properly mapped and if not, it will trace a warning. 

Therefore, as these properties are programmatically used and there are many more like `dekorate.input.dir`, `dekorate.output.dir`, `dekorate.image-pull-secrets`, `dekorate.properties.profile`, `dekorate.verbose`, `dekorate.test.xxx`, ... and maybe more coming in the future, I think the best way is to not trace this warning ever. 

The alternative is to maintain a list with all the above values, however I don't really like this approach as this list will be likely became out-date when adding a new unmapped property.

Fix https://github.com/dekorateio/dekorate/issues/995