### PR TITLE
Add Quarkus Main CI job

### DIFF
--- a/.github/workflows/downstream-projects-check.yml
+++ b/.github/workflows/downstream-projects-check.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # 
-name: Downstream project compatibility check
+name: Downstream projects compatibility check
 
 env:
   MAVEN_ARGS: -B -e
@@ -24,8 +24,8 @@ on:
       - main
 
 jobs:
-  build:
-    name: Java ${{ matrix.java }} Maven
+  quarkus:
+    name: Quarkus Main
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/quarkus-main-ci.yml
+++ b/.github/workflows/quarkus-main-ci.yml
@@ -1,0 +1,56 @@
+# Copyright 2018 The original authors.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 
+name: Verify Dekorate with Quarkus
+
+env:
+  MAVEN_ARGS: -B -e
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    name: Java ${{ matrix.java }} Maven
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [11]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.4
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+      - name: Build Dekorate
+        run: ./mvnw ${MAVEN_ARGS} clean install
+      - name: Build Quarkus
+        run: |
+          DEKORATE_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          git clone https://github.com/quarkusio/quarkus
+          cd quarkus
+          ./mvnw ${MAVEN_ARGS} clean install -Dquickly -Ddekorate.version=$DEKORATE_VERSION
+      - name: Tests Quarkus Kubernetes Tests
+        run: |
+          cd quarkus/extensions/kubernetes
+          ./mvnw ${MAVEN_ARGS} clean install -Ddekorate.version=$DEKORATE_VERSION
+      - name: Tests Quarkus Kubernetes Integration Tests
+        run: |
+          cd quarkus/integration-tests/kubernetes
+          ./mvnw ${MAVEN_ARGS} clean verify -Ddekorate.version=$DEKORATE_VERSION

--- a/.github/workflows/quarkus-main-ci.yml
+++ b/.github/workflows/quarkus-main-ci.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # 
-name: Verify Dekorate with Quarkus
+name: Downstream project compatibility check
 
 env:
   MAVEN_ARGS: -B -e


### PR DESCRIPTION
This CI job is to verify if we introduce any breaking changes and also to verify we don't break the Quarkus functionality. 

Test output: https://github.com/Sgitario/dekorate/runs/6981118817?check_suite_focus=true which it fails because the `WithConfigReferences` interface changed. 