### PR TITLE
fix: leverage builderWithDefaults to decouple handling of default values

### DIFF
--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/manifest/KubernetesManifestGenerator.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/manifest/KubernetesManifestGenerator.java
@@ -23,7 +23,6 @@ import io.dekorate.Logger;
 import io.dekorate.LoggerFactory;
 import io.dekorate.ResourceRegistry;
 import io.dekorate.config.ConfigurationSupplier;
-import io.dekorate.kubernetes.annotation.ImagePullPolicy;
 import io.dekorate.kubernetes.config.Configuration;
 import io.dekorate.kubernetes.config.Container;
 import io.dekorate.kubernetes.config.ContainerBuilder;
@@ -108,7 +107,6 @@ public class KubernetesManifestGenerator extends AbstractKubernetesManifestGener
     Container appContainer = new ContainerBuilder()
         .withName(config.getName())
         .withImage(image)
-        .withImagePullPolicy(ImagePullPolicy.IfNotPresent)
         .addNewEnvVar()
         .withName(KUBERNETES_NAMESPACE)
         .withField(METADATA_NAMESPACE)

--- a/core/src/main/java/io/dekorate/AbstractKubernetesManifestGenerator.java
+++ b/core/src/main/java/io/dekorate/AbstractKubernetesManifestGenerator.java
@@ -21,7 +21,6 @@ import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import io.dekorate.kubernetes.annotation.ImagePullPolicy;
 import io.dekorate.kubernetes.config.Annotation;
 import io.dekorate.kubernetes.config.AwsElasticBlockStoreVolume;
 import io.dekorate.kubernetes.config.AzureDiskVolume;
@@ -83,8 +82,11 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
  */
 public abstract class AbstractKubernetesManifestGenerator<C extends BaseConfig> implements ManifestGenerator<C>, WithProject {
 
+  protected static final BaseConfig DEFAULT_BASE_CONFIG = BaseConfig.newBaseConfigBuilderFromDefaults().build();
+
   protected final ResourceRegistry resourceRegistry;
   protected final ConfigurationRegistry configurationRegistry;
+
 
   public AbstractKubernetesManifestGenerator(ResourceRegistry resources, ConfigurationRegistry configurators) {
     this.resourceRegistry = resources;
@@ -111,7 +113,7 @@ public abstract class AbstractKubernetesManifestGenerator<C extends BaseConfig> 
       resourceRegistry.decorate(new ApplyServiceAccountNamedDecorator(config.getName(), config.getServiceAccount()));
     }
 
-    if (config.getImagePullPolicy() != ImagePullPolicy.IfNotPresent) {
+    if (config.getImagePullPolicy() != DEFAULT_BASE_CONFIG.getImagePullPolicy()) {
       resourceRegistry.decorate(group, new ApplyImagePullPolicyDecorator(config.getImagePullPolicy()));
     }
 
@@ -132,10 +134,6 @@ public abstract class AbstractKubernetesManifestGenerator<C extends BaseConfig> 
 
     if (Strings.isNotNullOrEmpty(config.getServiceAccount())) {
       resourceRegistry.decorate(group, new ApplyServiceAccountNamedDecorator(config.getName(), config.getServiceAccount()));
-    }
-
-    if (config.getImagePullPolicy() != ImagePullPolicy.IfNotPresent) {
-      resourceRegistry.decorate(group, new ApplyImagePullPolicyDecorator(config.getName(), config.getImagePullPolicy()));
     }
 
     for (String imagePullSecret : config.getImagePullSecrets()) {

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyApplicationContainerDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyApplicationContainerDecorator.java
@@ -50,8 +50,7 @@ public class ApplyApplicationContainerDecorator extends NamedResourceDecorator<P
     } else {
       ContainerBuilder builder = new ContainerBuilder(podSpec.buildMatchingContainer(p));
       podSpec.removeMatchingFromContainers(p);
-      ContainerAdapter.applyContainerToBuilder(builder, container);
-      podSpec.addToContainers(builder.build());
+      podSpec.addToContainers(builder.withName(container.getName()).build());
     }
   }
 

--- a/tests/issue-1006-defaults-handling/pom.xml
+++ b/tests/issue-1006-defaults-handling/pom.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  
+  <parent>
+    <artifactId>dekorate-tests</artifactId>
+    <groupId>io.dekorate</groupId>
+    <version>2.9-SNAPSHOT</version>
+    <relativePath>../</relativePath>
+  </parent>
+
+  <groupId>io.dekorate</groupId>
+  <artifactId>issue-1006-defaults-handling</artifactId>
+  <name>Dekorate :: Tests :: Annotations :: Defaults handling #1006</name>
+  <description></description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>kubernetes-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>knative-annotations</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.dekorate</groupId>
+      <artifactId>dekorate-spring-boot</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.spring-boot}</version>
+    </dependency>
+
+    <!-- Testing -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${version.junit-jupiter}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <inherited>true</inherited>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${version.spring-boot}</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/tests/issue-1006-defaults-handling/src/main/java/io/dekorate/annotationless/DemoApplication.java
+++ b/tests/issue-1006-defaults-handling/src/main/java/io/dekorate/annotationless/DemoApplication.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.annotationless;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(DemoApplication.class, args);
+  }
+
+}

--- a/tests/issue-1006-defaults-handling/src/main/java/io/dekorate/annotationless/HelloController.java
+++ b/tests/issue-1006-defaults-handling/src/main/java/io/dekorate/annotationless/HelloController.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate.annotationless;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+  private static final String HELLO = "hello world!";
+
+  @RequestMapping("/")
+  public String hello() {
+    return HELLO;
+  }
+}

--- a/tests/issue-1006-defaults-handling/src/main/resources/application.properties
+++ b/tests/issue-1006-defaults-handling/src/main/resources/application.properties
@@ -1,0 +1,7 @@
+dekorate.options.input-path=kubernetes
+
+dekorate.kubernetes.name=test-app
+dekorate.kubernetes.version=latest
+
+dekorate.knative.name=test-app
+dekorate.knative.version=latest

--- a/tests/issue-1006-defaults-handling/src/main/resources/kubernetes/knative.yml
+++ b/tests/issue-1006-defaults-handling/src/main/resources/kubernetes/knative.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: test-app
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/min-scale: "10"
+        autoscaling.knative.dev/max-scale: "20"
+    spec:
+      containerConcurrency: 3
+      containers:
+        - image: iocanel/test-app:latest
+          imagePullPolicy: Never
+          name: test-app
+          ports:
+            - containerPort: 8080
+              name: http1
+              protocol: TCP

--- a/tests/issue-1006-defaults-handling/src/main/resources/kubernetes/kubernetes.yml
+++ b/tests/issue-1006-defaults-handling/src/main/resources/kubernetes/kubernetes.yml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: test-app
+      app.kubernetes.io/version: 2.9-SNAPSHOT
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: test-app
+        app.kubernetes.io/version: 2.9-SNAPSHOT
+    spec:
+      containers:
+        - name: test-app
+          image: iocanel/test-app2:2.9-SNAPSHOT
+          imagePullPolicy: Never

--- a/tests/issue-1006-defaults-handling/src/test/java/io/dekorate/example/Issue1006DefaultsTest.java
+++ b/tests/issue-1006-defaults-handling/src/test/java/io/dekorate/example/Issue1006DefaultsTest.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2018 The original authors.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+**/
+
+package io.dekorate.example;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import io.dekorate.utils.Serialization;
+import io.fabric8.knative.serving.v1.Service;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.KubernetesList;
+import io.fabric8.kubernetes.api.model.apps.Deployment;
+
+public class Issue1006DefaultsTest {
+
+  @Test
+  public void shouldHaveOriginalPullPolicy() {
+    KubernetesList list = Serialization
+        .unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/kubernetes.yml"));
+    assertNotNull(list);
+    Deployment d = findFirst(list, Deployment.class).orElseThrow(() -> new IllegalStateException());
+    assertEquals("test-app", d.getMetadata().getName());
+    assertEquals("Never", d.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy());
+  }
+
+  @Test
+  public void shouldHaveOriginalKnativeDefaults() {
+    KubernetesList list = Serialization
+        .unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/knative.yml"));
+    assertNotNull(list);
+    Service s = findFirst(list, Service.class).orElseThrow(() -> new IllegalStateException());
+    assertEquals("test-app", s.getMetadata().getName());
+    assertEquals("Never", s.getSpec().getTemplate().getSpec().getContainers().get(0).getImagePullPolicy());
+    assertEquals(3, s.getSpec().getTemplate().getSpec().getContainerConcurrency());
+    assertEquals("10", s.getSpec().getTemplate().getMetadata().getAnnotations().get("autoscaling.knative.dev/min-scale"));
+    assertEquals("20", s.getSpec().getTemplate().getMetadata().getAnnotations().get("autoscaling.knative.dev/max-scale"));
+  }
+
+  <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {
+    return (Optional<T>) list.getItems().stream()
+        .filter(i -> t.isInstance(i))
+        .findFirst();
+  }
+
+}

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -80,6 +80,7 @@
       <module>feat-967-ingress-tls</module>
       <module>issue-983-tests-inject-in-super-class</module>
       <module>issue-987-role-binding-name</module>
+      <module>issue-1006-defaults-handling</module>
     </modules>
 
 </project>


### PR DESCRIPTION
This is related to #1006 

The pull request introduces static config objects with default values for BaseConfg, KubernetesConfig, KnativeConfig in order to maintain an instance of the default configuration so that we only apply dekorators when non-default values are used.

For now, the issue covers `ImagePullPolicy` and also global/revision autoscaling of knative which seem to be the most common cases of probelms.
