### PR TITLE
Merge properties from system properties and application properties

### DIFF
--- a/core/src/main/java/io/dekorate/Session.java
+++ b/core/src/main/java/io/dekorate/Session.java
@@ -133,7 +133,7 @@ public class Session {
       }
     }
 
-    //Initialize configuration with System properites.
+    //Initialize configuration with System properties.
     //The properties will get re-read after application configuration to enforce priorities.
     //The reason we do that now, is that System properties may potentially affect where we read application configuration from
     //Example: DekorateProfileAdditionalResourcesProvider

--- a/core/src/main/java/io/dekorate/processor/AbstractAnnotationProcessor.java
+++ b/core/src/main/java/io/dekorate/processor/AbstractAnnotationProcessor.java
@@ -110,7 +110,7 @@ public abstract class AbstractAnnotationProcessor extends AbstractProcessor impl
     // - from application config
     props.putAll(readApplicationConfig(resourceNames.toArray(new String[resourceNames.size()])));
     // - from system properties
-    props.putAll(readDekorateSystemProperties());
+    Maps.merge(props, readDekorateSystemProperties());
     return props;
   }
 


### PR DESCRIPTION
Before these changes, if user provides a system property, for example: `dekorate.options.push=true`, and having another property in the `application.properties` file, for example `dekorate.options.input-path=k8s`, Dekorate ignored the properties from the application properties and only takes the one from the system properties.