### PR TITLE
Use Maven resources filtering from custom resources

### DIFF
--- a/tests/feat-941-existing-common-resources/pom.xml
+++ b/tests/feat-941-existing-common-resources/pom.xml
@@ -15,6 +15,10 @@
   <name>Dekorate :: Tests :: Annotations :: Existing common resources #941</name>
   <description></description>
 
+  <properties>
+    <property.secret.name>my-secret</property.secret.name>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>io.dekorate</groupId>
@@ -53,6 +57,12 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/tests/feat-941-existing-common-resources/src/main/resources/kubernetes/common.yml
+++ b/tests/feat-941-existing-common-resources/src/main/resources/kubernetes/common.yml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: my-secret
+  name: ${property.secret.name}
 data:
   username: YWRtaW4=
   password: cGFzc3dvcmQK


### PR DESCRIPTION
This change proves that the Maven resources filtering feature work fine when importing custom resources.

Closes https://github.com/dekorateio/dekorate/issues/1018