### PR TITLE
Fix labels in StatefulSet resources

### DIFF
--- a/core/src/main/java/io/dekorate/kubernetes/decorator/StatefulSetSelectorDecoratorFactory.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/StatefulSetSelectorDecoratorFactory.java
@@ -3,7 +3,7 @@ package io.dekorate.kubernetes.decorator;
 
 import io.dekorate.SelectorDecoratorFactory;
 
-public class DeploymentSelectorDecoratorFactory implements SelectorDecoratorFactory {
+public class StatefulSetSelectorDecoratorFactory implements SelectorDecoratorFactory {
 
   @Override
   public AddToMatchingLabelsDecorator createAddToSelectorDecorator(String name, String key, String value) {
@@ -17,6 +17,6 @@ public class DeploymentSelectorDecoratorFactory implements SelectorDecoratorFact
 
   @Override
   public String kind() {
-    return "Deployment";
+    return "StatefulSet";
   }
 }

--- a/core/src/main/resources/META-INF/services/io.dekorate.SelectorDecoratorFactory
+++ b/core/src/main/resources/META-INF/services/io.dekorate.SelectorDecoratorFactory
@@ -1,2 +1,3 @@
 io.dekorate.kubernetes.decorator.ServiceSelectorDecoratorFactory
 io.dekorate.kubernetes.decorator.DeploymentSelectorDecoratorFactory
+io.dekorate.kubernetes.decorator.StatefulSetSelectorDecoratorFactory

--- a/tests/feat-886-kubernetes-deployment-kind-with-statefulset/src/test/java/io/dekorate/annotationless/Issue886Test.java
+++ b/tests/feat-886-kubernetes-deployment-kind-with-statefulset/src/test/java/io/dekorate/annotationless/Issue886Test.java
@@ -38,6 +38,8 @@ public class Issue886Test {
     StatefulSet d = findFirst(list, StatefulSet.class).orElseThrow(() -> new IllegalStateException());
     assertNotNull(d);
     assertEquals(2, d.getSpec().getReplicas());
+    assertEquals("feat-886-kubernetes-deployment-kind-with-statefulset",
+        d.getSpec().getSelector().getMatchLabels().get("app.kubernetes.io/name"));
   }
 
   <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {


### PR DESCRIPTION
The labels were not being added when the deployment target is a StatefulSet resource. 
Added coverage in the Dekorate test suite and fix it.

This issue has been spotted by the CI https://github.com/dekorateio/dekorate/runs/7314857759?check_suite_focus=true. To be concrete, the following failures:
- KubernetesWithInputStatefulSetResourcesTest.assertGeneratedResources
- KubernetesWithStatefulSetResourceTest.assertGeneratedResources
- OpenshiftWithStatefulSetResourceTest.assertGeneratedResources

I've confirmed that with these changes, these tests are now passing.