### PR TITLE
fix: knative was generating an empty ConfigMap

### DIFF
--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyGlobalAutoscalingClassDecorator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyGlobalAutoscalingClassDecorator.java
@@ -16,6 +16,8 @@
 **/
 package io.dekorate.knative.decorator;
 
+import static io.dekorate.knative.manifest.KnativeManifestGenerator.CONFIG_AUTOSCALER;
+
 import io.dekorate.knative.config.AutoScalerClass;
 import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
 import io.fabric8.kubernetes.api.model.ConfigMapFluent;
@@ -30,7 +32,7 @@ public class ApplyGlobalAutoscalingClassDecorator extends NamedResourceDecorator
   private final AutoScalerClass clazz;
 
   public ApplyGlobalAutoscalingClassDecorator(AutoScalerClass clazz) {
-    super("config-autoscaler");
+    super(CONFIG_AUTOSCALER);
     this.clazz = clazz;
   }
 

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyGlobalContainerConcurrencyDecorator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyGlobalContainerConcurrencyDecorator.java
@@ -16,13 +16,14 @@
 **/
 package io.dekorate.knative.decorator;
 
+import static io.dekorate.knative.manifest.KnativeManifestGenerator.CONFIG_DEFAULTS;
+
 import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
 import io.fabric8.kubernetes.api.model.ConfigMapFluent;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 
 public class ApplyGlobalContainerConcurrencyDecorator extends NamedResourceDecorator<ConfigMapFluent<?>> {
 
-  public static final String CONFIG_DEFAULTS = "config-defaults";
   private static final String CONTAINER_CONCURRENCY = "container-concurrency";
 
   private final int target;

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyGlobalRequestsPerSecondTargetDecorator.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/decorator/ApplyGlobalRequestsPerSecondTargetDecorator.java
@@ -16,6 +16,8 @@
 **/
 package io.dekorate.knative.decorator;
 
+import static io.dekorate.knative.manifest.KnativeManifestGenerator.CONFIG_AUTOSCALER;
+
 import io.dekorate.kubernetes.decorator.NamedResourceDecorator;
 import io.fabric8.kubernetes.api.model.ConfigMapFluent;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -27,7 +29,7 @@ public class ApplyGlobalRequestsPerSecondTargetDecorator extends NamedResourceDe
   private final int target;
 
   public ApplyGlobalRequestsPerSecondTargetDecorator(int target) {
-    super("config-autoscaler");
+    super(CONFIG_AUTOSCALER);
     this.target = target;
   }
 

--- a/tests/issue-939-knative-container-concurrency/src/test/java/io/dekorate/knative/Issue939KnativeContainerConcurrencyTest.java
+++ b/tests/issue-939-knative-container-concurrency/src/test/java/io/dekorate/knative/Issue939KnativeContainerConcurrencyTest.java
@@ -18,6 +18,7 @@
 package io.dekorate.knative;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Optional;
@@ -26,6 +27,7 @@ import org.junit.jupiter.api.Test;
 
 import io.dekorate.utils.Serialization;
 import io.fabric8.knative.serving.v1.Service;
+import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 
@@ -38,6 +40,7 @@ public class Issue939KnativeContainerConcurrencyTest {
     assertNotNull(list);
     Service s = findFirst(list, Service.class).orElseThrow(() -> new IllegalStateException());
     assertEquals(10, s.getSpec().getTemplate().getSpec().getContainerConcurrency());
+    assertFalse(list.getItems().stream().anyMatch(ConfigMap.class::isInstance));
   }
 
   <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {


### PR DESCRIPTION
This problem was spotted by https://github.com/dekorateio/dekorate/actions/runs/2663085841

Failing test: KnativeGlobalContainerConcurrencyTest