### PR TITLE
Helm: Ensure deterministic order when applying config references

### DIFF
--- a/annotations/helm-annotations/src/main/java/io/dekorate/helm/listener/HelmWriterSessionListener.java
+++ b/annotations/helm-annotations/src/main/java/io/dekorate/helm/listener/HelmWriterSessionListener.java
@@ -16,7 +16,6 @@
  **/
 package io.dekorate.helm.listener;
 
-import static io.dekorate.helm.config.HelmBuildConfigGenerator.HELM;
 import static io.dekorate.helm.util.HelmTarArchiver.createTarBall;
 
 import java.io.File;
@@ -303,11 +302,11 @@ public class HelmWriterSessionListener implements SessionListener, WithProject, 
               values = valuesByProfile.get(valueProfile);
               if (values == null) {
                 values = new HashMap<>();
-                valuesByProfile.putIfAbsent(valueProfile, values);
+                valuesByProfile.put(valueProfile, values);
               }
             }
 
-            values.putIfAbsent(valueReferenceProperty, value);
+            values.put(valueReferenceProperty, value);
           }
         }
       }

--- a/core/src/main/java/io/dekorate/ResourceRegistry.java
+++ b/core/src/main/java/io/dekorate/ResourceRegistry.java
@@ -22,11 +22,11 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import io.dekorate.kubernetes.decorator.Decorator;
 import io.dekorate.utils.Metadata;
@@ -213,7 +213,7 @@ public class ResourceRegistry {
   }
 
   public List<WithConfigReferences> getConfigReferences() {
-    List<WithConfigReferences> configReferences = new LinkedList<>();
+    Set<Decorator> configReferences = new HashSet<>();
 
     Set<Decorator> allDecorators = new HashSet<>();
     allDecorators.addAll(globalDecorators);
@@ -222,11 +222,14 @@ public class ResourceRegistry {
 
     for (Decorator decorator : allDecorators) {
       if (decorator instanceof WithConfigReferences) {
-        configReferences.add((WithConfigReferences) decorator);
+        configReferences.add(decorator);
       }
     }
 
-    return configReferences;
+    return applyConstraints(configReferences)
+        .stream()
+        .map(WithConfigReferences.class::cast)
+        .collect(Collectors.toList());
   }
 
   public List<Decorator> applyConstraints(Set<Decorator> decorators) {


### PR DESCRIPTION
This issue has been spotted in https://github.com/quarkiverse/quarkus-helm/issues/41 and after these changes, now it worked fine. 

It ensures deterministic order and will always use the last value found.