### PR TITLE
fix: add missing step to install jbang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
+      - name: Setup jbang
+        run: curl -Ls https://sh.jbang.dev | bash -s - app setup
       - name: Build Project
         run: ./mvnw ${MAVEN_ARGS} clean install
       - name: Zip Artifacts

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -38,6 +38,8 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+      - name: Setup jbang
+        run: curl -Ls https://sh.jbang.dev | bash -s - app setup
       - name: Maven release ${{steps.metadata.outputs.current-version}}
         run: |
           ./mvnw clean install -DskipTests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,8 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+      - name: Setup jbang
+        run: curl -Ls https://sh.jbang.dev | bash -s - app setup
       - name: Maven release ${{steps.metadata.outputs.current-version}}
         run: |
           ./mvnw clean install -DskipTests


### PR DESCRIPTION
The pull request adds step for installing jbang in release workflows.
In addition it does add the step to the pr, just for verifying it works.