### PR TITLE
docs: fix documentation about the property `properties-profile`

### DIFF
--- a/docs/documentation/annotation-less-configuration.md
+++ b/docs/documentation/annotation-less-configuration.md
@@ -36,10 +36,10 @@ Then, for Spring Boot applications, it will also take into account the Spring pr
 2. `application-${spring.profiles.active}.yaml`
 3. `application-${spring.profiles.active}.yml`
 
-Finally, if the Dekorate profile property `dekorate.properties-profile` is set:
-1. if property `dekorate.properties-profile` is set, then `application-${dekorate.properties-profile}.properties`
-2. if property `dekorate.properties-profile` is set, then `application-${dekorate.properties-profile}.yaml`
-3. if property `dekorate.properties-profile` is set, then `application-${dekorate.properties-profile}.yml`
+Finally, if the Dekorate profile property `dekorate.options.properties-profile` is set:
+1. if property `dekorate.options.properties-profile` is set, then `application-${dekorate.options.properties-profile}.properties`
+2. if property `dekorate.options.properties-profile` is set, then `application-${dekorate.options.properties-profile}.yaml`
+3. if property `dekorate.options.properties-profile` is set, then `application-${dekorate.options.properties-profile}.yml`
 
 It's important to repeat that the override that occurs by *fully* replacing any lower-priority configuration and not via any kind
 of merge between the existing and higher-priority values. This means that if you choose to override the annotation-specified

--- a/examples/spring-boot-on-openshift-with-dekorate-profile-example/pom.xml
+++ b/examples/spring-boot-on-openshift-with-dekorate-profile-example/pom.xml
@@ -58,14 +58,31 @@
         <version>${version.properties-maven-plugin}</version>
         <executions>
           <execution>
+            <id>initialize-system-properties</id>
+            <phase>initialize</phase>
             <goals>
               <goal>set-system-properties</goal>
             </goals>
             <configuration>
               <properties>
                 <property>
-                  <name>dekorate.properties-profile</name>
+                  <name>dekorate.options.properties-profile</name>
                   <value>foo</value>
+                </property>
+              </properties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>clear-system-properties</id>
+            <phase>install</phase>
+            <goals>
+              <goal>set-system-properties</goal>
+            </goals>
+            <configuration>
+              <properties>
+                <property>
+                  <name>dekorate.options.properties-profile</name>
+                  <value></value>
                 </property>
               </properties>
             </configuration>

--- a/examples/spring-boot-on-openshift-with-dekorate-profile-example/src/test/java/io/dekorate/example/SpringBootOnOpenshiftTest.java
+++ b/examples/spring-boot-on-openshift-with-dekorate-profile-example/src/test/java/io/dekorate/example/SpringBootOnOpenshiftTest.java
@@ -18,29 +18,23 @@
 package io.dekorate.example;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
 
+import io.dekorate.utils.Serialization;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
-import io.fabric8.openshift.api.model.BuildConfig;
-import io.fabric8.openshift.api.model.DeploymentConfig;
-import io.dekorate.utils.Serialization;
+import io.fabric8.openshift.api.model.Route;
 
 class SpringBootOnOpenshiftTest {
 
   @Test
-  public void shouldHaveMatchingOutputImageAndTrigger() {
+  public void shouldHaveRouteExposeBecauseCustomPropertiesFileIsUsed() {
     KubernetesList list = Serialization.unmarshalAsList(getClass().getClassLoader().getResourceAsStream("META-INF/dekorate/openshift.yml"));
     assertNotNull(list);
-    DeploymentConfig d = findFirst(list, DeploymentConfig.class).orElseThrow(() -> new IllegalStateException());
-    BuildConfig b = findFirst(list, BuildConfig.class).orElseThrow(() -> new IllegalStateException());
-    assertNotNull(d);
-    assertNotNull(b);
-    assertTrue(d.getSpec().getTriggers().stream().filter(t -> t.getImageChangeParams().getFrom().getName().equals(b.getSpec().getOutput().getTo().getName())).findFirst().isPresent());
+    findFirst(list, Route.class).orElseThrow(() -> new IllegalStateException("Route was not generated!"));
   }
 
   <T extends HasMetadata> Optional<T> findFirst(KubernetesList list, Class<T> t) {

--- a/readme.md
+++ b/readme.md
@@ -1136,10 +1136,10 @@ Then, for Spring Boot applications, it will also take into account the Spring pr
 2. `application-${spring.profiles.active}.yaml`
 3. `application-${spring.profiles.active}.yml`
 
-Finally, if the Dekorate profile property `dekorate.properties-profile` is set:
-1. if property `dekorate.properties-profile` is set, then `application-${dekorate.properties-profile}.properties`
-2. if property `dekorate.properties-profile` is set, then `application-${dekorate.properties-profile}.yaml`
-3. if property `dekorate.properties-profile` is set, then `application-${dekorate.properties-profile}.yml`
+Finally, if the Dekorate profile property `dekorate.options.properties-profile` is set:
+1. if property `dekorate.options.properties-profile` is set, then `application-${dekorate.options.properties-profile}.properties`
+2. if property `dekorate.options.properties-profile` is set, then `application-${dekorate.options.properties-profile}.yaml`
+3. if property `dekorate.options.properties-profile` is set, then `application-${dekorate.options.properties-profile}.yml`
 
 It's important to repeat that the override that occurs by *fully* replacing any lower-priority configuration and not via any kind
 of merge between the existing and higher-priority values. This means that if you choose to override the annotation-specified


### PR DESCRIPTION
The correct property is `dekorate.options.properties-profile`, not `dekorate.properties-profile`.  This changed recently when introducing the wrap config Options.  I've also fixed the example using this property to correctly cover this functionality.