### PR TITLE
doc: fix duplicated jib property and typo in k8s guide

### DIFF
--- a/docs/configuration-guide.md
+++ b/docs/configuration-guide.md
@@ -409,7 +409,6 @@ The section below describes all the available subtypes.
 | dekorate.jib.group               | String  | The group of the application. This value will be use as image user.                                                                             |               |
 | dekorate.jib.name                | String  | The name of the application. This value will be used as name.                                                                                   |               |
 | dekorate.jib.version             | String  | The version of the application. This value be used as image tag.                                                                                |               |
-| dekorate.jib.image               | String  |                                                                                                                                                 |               |
 | dekorate.jib.image               | String  | The name of the image to be generated. This property overrides group, name and version.                                                         |               |
 | dekorate.jib.docker-build        | boolean | Flag that indicates whether to perform a docker build (build using the docker daemon) or not.                                                   | true          |
 | dekorate.jib.from                | String  | The base image to use.                                                                                                                          | openjdk:8-jdk |

--- a/docs/documentation/kubernetes.md
+++ b/docs/documentation/kubernetes.md
@@ -26,7 +26,7 @@ When the project gets compiled, the annotation will trigger the generation of a 
 will end up under 'target/classes/META-INF/dekorate'.
 
 The annotation comes with a lot of parameters, which can be used in order to customize the `Deployment` and/or trigger
-the generations of addition resources, like `Service` and `Ingress`.
+the generations of additional resources, like `Service` and `Ingress`.
 
 
 #### Adding the kubernetes annotation processor to the classpath


### PR DESCRIPTION
Just a few fix that I detected during the dekorate demo x KCD preparation this week