### PR TITLE
Prioritize the user configuration over the decorate configuration

### DIFF
--- a/annotations/helm-annotations/src/main/java/io/dekorate/helm/listener/HelmWriterSessionListener.java
+++ b/annotations/helm-annotations/src/main/java/io/dekorate/helm/listener/HelmWriterSessionListener.java
@@ -242,13 +242,12 @@ public class HelmWriterSessionListener implements SessionListener, WithProject, 
   private List<ConfigReference> mergeValuesReferencesFromDecorators(List<ConfigReference> configReferencesFromConfig,
       Session session) {
     List<ConfigReference> configReferences = new LinkedList<>();
+    // From user
+    configReferences.addAll(configReferencesFromConfig);
     // From decorators
     for (WithConfigReferences decorator : session.getResourceRegistry().getConfigReferences()) {
       configReferences.addAll(decorator.getConfigReferences());
     }
-
-    // From user
-    configReferences.addAll(configReferencesFromConfig);
 
     return configReferences;
   }


### PR DESCRIPTION
Related to https://github.com/quarkiverse/quarkus-helm/issues/135