### PR TITLE
Fix integration tests failures in Kubernetes and OpenShift

### DIFF
--- a/.github/workflows/integration-tests-with-dockerio.yml
+++ b/.github/workflows/integration-tests-with-dockerio.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.4.1
+        uses: manusa/actions-setup-minikube@v2.7.1
         with:
           minikube version: v1.23.2
           kubernetes version: ${{ matrix.kubernetes }}

--- a/.github/workflows/integration-tests-with-dockerio.yml
+++ b/.github/workflows/integration-tests-with-dockerio.yml
@@ -100,7 +100,8 @@ jobs:
   openshift:
     name: Openshift Build
     needs: cache
-    runs-on: ubuntu-latest
+    # the action "manusa/actions-setup-openshift@v1.1.4" only works in ubuntu-20.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration-tests-with-dockerio.yml
+++ b/.github/workflows/integration-tests-with-dockerio.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.3.4
       - name: Setup OpenShift
-        uses: manusa/actions-setup-openshift@v1.1.3
+        uses: manusa/actions-setup-openshift@v1.1.4
         with:
           oc version: ${{ matrix.openshift }}
           github token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -125,7 +125,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Setup OpenShift
-        uses: manusa/actions-setup-openshift@v1.1.3
+        uses: manusa/actions-setup-openshift@v1.1.4
         with:
           oc version: ${{ matrix.openshift }}
           github token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,7 +66,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}
           restore-keys: ${{ runner.os }}-maven-
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.4.1
+        uses: manusa/actions-setup-minikube@v2.7.1
         with:
           minikube version: v1.23.2
           kubernetes version: ${{ matrix.kubernetes }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -105,7 +105,8 @@ jobs:
   openshift:
     name: Openshift Build
     needs: cache
-    runs-on: ubuntu-latest
+    # the action "manusa/actions-setup-openshift@v1.1.4" only works in ubuntu-20.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The Kubernetes tests are fixed by using manusa/actions-setup-minikube@v2.7.1
However, the OpenShift tests are still failing :/. Any help here @manusa ?