### PR TITLE
[2.11.x] Bump Jackson from 2.12.3 to 2.14.1

### DIFF
--- a/examples/frameworkless-on-kubernetes-example/pom.xml
+++ b/examples/frameworkless-on-kubernetes-example/pom.xml
@@ -15,9 +15,7 @@
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-failsafe-plugin>3.0.0-M3</version.maven-failsafe-plugin>
     <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
-    <version.jackson>2.12.3</version.jackson>
   </properties>
-
 
   <dependencies>
     <dependency>

--- a/examples/frameworkless-on-openshift-example/pom.xml
+++ b/examples/frameworkless-on-openshift-example/pom.xml
@@ -15,9 +15,7 @@
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-failsafe-plugin>3.0.0-M3</version.maven-failsafe-plugin>
     <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
-    <version.jackson-databind>2.12.3</version.jackson-databind>
   </properties>
-
 
   <dependencies>
     <dependency>

--- a/examples/minikube-example-with-properties/pom.xml
+++ b/examples/minikube-example-with-properties/pom.xml
@@ -16,9 +16,7 @@
     <version.maven-failsafe-plugin>3.0.0-M3</version.maven-failsafe-plugin>
     <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
     <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
-    <version.jackson>2.12.3</version.jackson>
   </properties>
-
 
   <dependencies>
     <dependency>

--- a/examples/minikube-example/pom.xml
+++ b/examples/minikube-example/pom.xml
@@ -16,7 +16,6 @@
     <version.maven-failsafe-plugin>3.0.0-M3</version.maven-failsafe-plugin>
     <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
     <version.maven-jar-plugin>3.2.0</version.maven-jar-plugin>
-    <version.jackson>2.12.3</version.jackson>
   </properties>
 
 

--- a/examples/thorntail-on-kubernetes-example/pom.xml
+++ b/examples/thorntail-on-kubernetes-example/pom.xml
@@ -14,7 +14,7 @@
     <java.version>1.8</java.version>
 
     <version.thorntail>2.5.0.Final</version.thorntail>
-    <version.jackson>2.12.3</version.jackson>
+    <version.maven-war-plugin>3.3.1</version.maven-war-plugin>
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-failsafe-plugin>3.0.0-M3</version.maven-failsafe-plugin>
     <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
@@ -24,14 +24,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>${version.jackson}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-
       <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>bom</artifactId>
@@ -54,6 +46,16 @@
       <groupId>io.thorntail</groupId>
       <artifactId>jaxrs</artifactId>
       <version>${version.thorntail}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.thorntail</groupId>
@@ -72,6 +74,10 @@
 
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>${version.maven-war-plugin}</version>
+      </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${version.maven-compiler-plugin}</version>

--- a/examples/thorntail-on-openshift-example/pom.xml
+++ b/examples/thorntail-on-openshift-example/pom.xml
@@ -14,7 +14,7 @@
     <java.version>1.8</java.version>
 
     <version.thorntail>2.5.0.Final</version.thorntail>
-    <version.jackson>2.12.3</version.jackson>
+    <version.maven-war-plugin>3.3.1</version.maven-war-plugin>
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-failsafe-plugin>3.0.0-M3</version.maven-failsafe-plugin>
     <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
@@ -24,13 +24,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>${version.jackson}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
       <dependency>
         <groupId>io.thorntail</groupId>
         <artifactId>bom</artifactId>
@@ -53,6 +46,16 @@
       <groupId>io.thorntail</groupId>
       <artifactId>jaxrs</artifactId>
       <version>${version.thorntail}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.jaxrs</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>io.thorntail</groupId>
@@ -71,6 +74,10 @@
 
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>${version.maven-war-plugin}</version>
+      </plugin>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${version.maven-compiler-plugin}</version>

--- a/examples/vertx-on-kubernetes-example/pom.xml
+++ b/examples/vertx-on-kubernetes-example/pom.xml
@@ -28,24 +28,10 @@ limitations under the License.
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
 
-    <version.vertx>3.8.2</version.vertx>
-    <version.jackson>2.12.3</version.jackson>
+    <version.vertx>4.3.7</version.vertx>
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>${version.jackson}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
 
   <dependencies>
     <dependency>

--- a/examples/vertx-on-kubernetes-example/src/main/java/io/dekorate/example/Main.java
+++ b/examples/vertx-on-kubernetes-example/src/main/java/io/dekorate/example/Main.java
@@ -18,15 +18,14 @@
 package io.dekorate.example;
 
 import io.dekorate.annotation.Dekorate;
-
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 @Dekorate
 public class Main extends AbstractVerticle {
 
   @Override
-  public void start(Future<Void> future) {
+  public void start(Promise future) {
     vertx
         .createHttpServer()
         .requestHandler(r -> {

--- a/examples/vertx-on-openshift-example/pom.xml
+++ b/examples/vertx-on-openshift-example/pom.xml
@@ -28,23 +28,10 @@ limitations under the License.
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>1.8</java.version>
 
-    <version.jackson>2.12.3</version.jackson>
-    <version.vertx>3.8.2</version.vertx>
+    <version.vertx>4.3.7</version.vertx>
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>
     <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>${version.jackson}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>

--- a/examples/vertx-on-openshift-example/src/main/java/io/dekorate/example/Main.java
+++ b/examples/vertx-on-openshift-example/src/main/java/io/dekorate/example/Main.java
@@ -18,15 +18,14 @@
 package io.dekorate.example;
 
 import io.dekorate.annotation.Dekorate;
-
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 @Dekorate
 public class Main extends AbstractVerticle {
 
   @Override
-  public void start(Future<Void> future) {
+  public void start(Promise future) {
     vertx
         .createHttpServer()
         .requestHandler(r -> {

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
     <version.commons-codec>1.10</version.commons-codec>
     <version.commons-compress>1.21</version.commons-compress>
     <version.jansi>1.18</version.jansi>
-    <version.jackson>2.12.3</version.jackson>
+    <version.jackson>2.14.1</version.jackson>
     <version.kubernetes-client>5.12.1</version.kubernetes-client>
     <version.sundrio>0.90.4</version.sundrio>
     <version.jayway.jsonpath>2.6.0</version.jayway.jsonpath>
@@ -69,7 +69,8 @@
     <version.assertj>3.11.1</version.assertj>
     <!-- Other Testing Dependencies (frameworks, tools, etc) -->
     <!-- Note: Dekorate DOES NOT depend on these, just some integration tests -->
-    <version.spring-boot>2.5.12</version.spring-boot>    <version.thorntail>2.5.0.Final</version.thorntail>
+    <version.spring-boot>2.5.12</version.spring-boot>
+    <version.thorntail>2.5.0.Final</version.thorntail>
 
     <!-- Plugins -->
     <version.maven-compiler-plugin>3.8.0</version.maven-compiler-plugin>

--- a/tests/feat-347-thorntail-annotationless/pom.xml
+++ b/tests/feat-347-thorntail-annotationless/pom.xml
@@ -19,6 +19,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <failOnMissingWebXml>false</failOnMissingWebXml>
+
+    <version.maven-war-plugin>3.3.1</version.maven-war-plugin>
   </properties>
 
   <dependencyManagement>
@@ -34,7 +36,6 @@
   </dependencyManagement>
 
   <dependencies>
-
     <dependency>
       <groupId>io.dekorate</groupId>
       <artifactId>dekorate-thorntail</artifactId>
@@ -78,7 +79,6 @@
       <version>${version.junit-jupiter}</version>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <build>
@@ -94,6 +94,10 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-war-plugin</artifactId>
+        <version>${version.maven-war-plugin}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/tests/feat-openshift-probes/pom.xml
+++ b/tests/feat-openshift-probes/pom.xml
@@ -31,7 +31,7 @@ limitations under the License.
   <name>Dekorate :: Tests :: Probes :: OpenShift</name>
 
   <properties>
-    <version.vertx>3.8.2</version.vertx>
+    <version.vertx>4.3.7</version.vertx>
   </properties>
 
   <dependencies>

--- a/tests/feat-openshift-probes/src/main/java/io/dekorate/example/Main.java
+++ b/tests/feat-openshift-probes/src/main/java/io/dekorate/example/Main.java
@@ -19,13 +19,13 @@ package io.dekorate.example;
 
 import io.dekorate.annotation.Dekorate;
 import io.vertx.core.AbstractVerticle;
-import io.vertx.core.Future;
+import io.vertx.core.Promise;
 
 @Dekorate
 public class Main extends AbstractVerticle {
 
   @Override
-  public void start(Future<Void> future) {
+  public void start(Promise future) {
     vertx
         .createHttpServer()
         .requestHandler(r -> {


### PR DESCRIPTION
Necessary to fix CVE-2022-1471

Plus:
- Bump vertx version that is used in tests to not bring the Jackson dependencies as well
- Fix throntail examples to configure the war plugin and exclude the jackson dependecies (which are quite old)