### PR TITLE
Find and register  Modules in the ObjectMappers

### DIFF
--- a/core/src/main/java/io/dekorate/utils/Serialization.java
+++ b/core/src/main/java/io/dekorate/utils/Serialization.java
@@ -92,7 +92,7 @@ public class Serialization {
   }
 
   public static ObjectMapper createJsonMapper(String[] enabledFeatures, String[] disabledFeatures) {
-    return new ObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper() {
       {
 
         for (String name : enabledFeatures) {
@@ -110,6 +110,8 @@ public class Serialization {
 
       }
     };
+    mapper.findAndRegisterModules();
+    return mapper;
   }
 
   private static final ObjectMapper JSON_MAPPER = createJsonMapper(new String[] { INDENT_OUTPUT },


### PR DESCRIPTION
Without this, I suddenly get errors like the following:

```
com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Java 8 date/time type `java.time.ZonedDateTime` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling
 at [Source: UNKNOWN; byte offset: #UNKNOWN] (through reference chain: io.fabric8.kubernetes.api.model.coordination.v1.Lease["spec"]->io.fabric8.kubernetes.api.model.coordination.v1.LeaseSpec["acquireTime"])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:67)
	at com.fasterxml.jackson.databind.DeserializationContext.reportBadDefinition(DeserializationContext.java:1909)
	at com.fasterxml.jackson.databind.deser.impl.UnsupportedTypeDeserializer.deserialize(UnsupportedTypeDeserializer.java:48)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:314)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:129)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:314)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323)
	at com.fasterxml.jackson.databind.ObjectMapper._readValue(ObjectMapper.java:4706)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2879)
	at com.fasterxml.jackson.databind.ObjectMapper.treeToValue(ObjectMapper.java:3343)
	at io.fabric8.kubernetes.internal.KubernetesDeserializer.fromObjectNode(KubernetesDeserializer.java:125)
	at io.fabric8.kubernetes.internal.KubernetesDeserializer.deserialize(KubernetesDeserializer.java:84)
	at io.fabric8.kubernetes.internal.KubernetesDeserializer.deserialize(KubernetesDeserializer.java:42)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:323)
	at com.fasterxml.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:2105)
	at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1481)
	at io.dekorate.utils.Serialization.unmarshal(Serialization.java:278)
	at io.dekorate.utils.Serialization.unmarshal(Serialization.java:249)
	at io.dekorate.utils.Serialization.unmarshal(Serialization.java:237)
	at io.dekorate.utils.Serialization.unmarshal(Serialization.java:294)
	at org.wildfly.test.cloud.common.WildFlySerialization.unmarshalAsList(WildFlySerialization.java:48)
```
The error message led me to https://howtodoinjava.com/jackson/java-8-date-time-type-not-supported-by-default/. I noticed the ObjectMapper.findAndRegisterModules() method not getting called, while it is called later on when Jackson instantiates and uses its own ObjectMapper instances.

I've worked around this locally on the WildFly side by doing what this PR does with reflection, but that is a temporary (and fragile!) workaround.



