### PR TITLE
Bump Kubernetes Client to 6.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <version.commons-compress>1.21</version.commons-compress>
     <version.jansi>1.18</version.jansi>
     <version.jackson>2.14.1</version.jackson>
-    <version.kubernetes-client>6.4.0</version.kubernetes-client>
+    <version.kubernetes-client>6.5.0</version.kubernetes-client>
     <version.sundrio>0.92.1</version.sundrio>
     <version.jayway.jsonpath>2.6.0</version.jayway.jsonpath>
 


### PR DESCRIPTION
Changes: https://github.com/fabric8io/kubernetes-client/releases/tag/v6.5.0