### PR TITLE
Fix template metadata is not generated in Deployment resources

### DIFF
--- a/core/src/main/java/io/dekorate/kubernetes/decorator/DeploymentResourceFactory.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/DeploymentResourceFactory.java
@@ -20,6 +20,7 @@ import io.dekorate.ResourceFactory;
 import io.dekorate.kubernetes.config.BaseConfig;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
+import io.fabric8.kubernetes.api.model.PodTemplateSpecBuilder;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 
 public class DeploymentResourceFactory implements ResourceFactory {
@@ -39,9 +40,10 @@ public class DeploymentResourceFactory implements ResourceFactory {
         .endMetadata()
         .withNewSpec()
         .withReplicas(1)
-        .withNewTemplate()
-        .withSpec(new PodSpecBuilder().build())
-        .endTemplate()
+        .withTemplate(new PodTemplateSpecBuilder()
+            .withSpec(new PodSpecBuilder().build())
+            .withNewMetadata().endMetadata()
+            .build())
         .endSpec().build();
   }
 }


### PR DESCRIPTION
Relates to CI failures: https://github.com/quarkusio/quarkus/runs/12159739217#user-content-test-failure-io.quarkus.it.kubernetes.kuberneteswithmetricscustomabsolutetest-1