### PR TITLE
chore: delete tmp files that back streams when stream is closed

### DIFF
--- a/core/src/main/java/io/dekorate/utils/Streams.java
+++ b/core/src/main/java/io/dekorate/utils/Streams.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2018 The original authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
 **/
 
 package io.dekorate.utils;
@@ -57,7 +57,14 @@ public final class Streams {
 
   public static FileInputStream crateTempFileInputStream(InputStream is) {
     try {
-      return new FileInputStream(createTemporaryFile(is));
+      final File tmpFile = createTemporaryFile(is);
+      return new FileInputStream(tmpFile) {
+        @Override
+        public void close() throws IOException {
+          super.close();
+          tmpFile.delete();
+        }
+      };
     } catch (FileNotFoundException e) {
       throw DekorateException.launderThrowable(e);
     }


### PR DESCRIPTION
The pull request cleans up temporary files that are used to support Streams.
Closing happens when stream closes which render the File no longer accessible.