### PR TITLE
Helm: Fix value property generated by OpenShift S2i

### DIFF
--- a/core/src/main/java/io/dekorate/ConfigReference.java
+++ b/core/src/main/java/io/dekorate/ConfigReference.java
@@ -133,7 +133,9 @@ public class ConfigReference {
       return null;
     }
 
-    return Stream.of(properties).filter(p -> !Strings.equals(ANY, p)).collect(Collectors.joining("."));
+    return Strings.kebabToCamelCase(Stream.of(properties)
+        .filter(p -> !Strings.equals(ANY, p))
+        .collect(Collectors.joining(".")));
   }
 
   public static class Builder {

--- a/examples/helm-on-openshift-example/src/test/java/io/dekorate/example/HelmOpenshiftExampleTest.java
+++ b/examples/helm-on-openshift-example/src/test/java/io/dekorate/example/HelmOpenshiftExampleTest.java
@@ -67,8 +67,8 @@ class HelmOpenshiftExampleTest {
     Map<String, Object> helmExampleValues = (Map<String, Object>) values.get(ROOT_CONFIG_NAME);
 
     // Should contain s2i configuration
-    assertNotNull(helmExampleValues.get("s2i-java"));
-    assertEquals("fabric8/s2i-java", ((Map<String, Object>) helmExampleValues.get("s2i-java")).get("builder-image"));
+    assertNotNull(helmExampleValues.get("s2iJava"));
+    assertEquals("fabric8/s2i-java", ((Map<String, Object>) helmExampleValues.get("s2iJava")).get("builderImage"));
     // Should contain replicas
     assertEquals(3, helmExampleValues.get("replicas"));
     // Should NOT contain notFound: as this property is ignored
@@ -87,8 +87,8 @@ class HelmOpenshiftExampleTest {
     Map<String, Object> helmExampleValues = (Map<String, Object>) values.get(ROOT_CONFIG_NAME);
 
     // Should contain s2i configuration
-    assertNotNull(helmExampleValues.get("s2i-java"));
-    assertEquals("fabric8/s2i-java", ((Map<String, Object>) helmExampleValues.get("s2i-java")).get("builder-image"));
+    assertNotNull(helmExampleValues.get("s2iJava"));
+    assertEquals("fabric8/s2i-java", ((Map<String, Object>) helmExampleValues.get("s2iJava")).get("builderImage"));
     // Should contain replicas
     assertEquals(3, helmExampleValues.get("replicas"));
     // Should NOT contain notFound: as this property is ignored


### PR DESCRIPTION
The property `s2i-java.builder-image` is invalid in the context of Helm. 

After these changes, this property will be changed to `s2iJava.builderImage`.