### PR TITLE
Fix wrong image value when another decorator is overwritting it

### DIFF
--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/ApplyReplicasToDeploymentConfigDecorator.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/ApplyReplicasToDeploymentConfigDecorator.java
@@ -63,7 +63,6 @@ public class ApplyReplicasToDeploymentConfigDecorator extends NamedResourceDecor
 
     return new ConfigReference.Builder(property, path)
         .withDescription("The number of desired pods.")
-        .withValue(replicas)
         .withMinimum(0)
         .build();
   }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyImageDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyImageDecorator.java
@@ -64,7 +64,7 @@ public class ApplyImageDecorator extends ApplicationContainerDecorator<Container
       path = "spec.template.spec.containers.(name == " + getContainerName() + ").image";
     }
 
-    return new ConfigReference.Builder(property, path).withDescription("The container image to use.").withValue(image).build();
+    return new ConfigReference.Builder(property, path).withDescription("The container image to use.").build();
   }
 
 }


### PR DESCRIPTION
When Quarkus updates the image providing a different value, the default image is wrong.  

Unsetting the value will force the config reference to look up the image that has been used.