### PR TITLE
chore: centralize handling of container decorator order

### DIFF
--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddAnnotationDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddAnnotationDecorator.java
@@ -64,12 +64,6 @@ public class AddAnnotationDecorator extends NamedResourceDecorator<ObjectMetaBui
   }
 
   @Override
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class,
-        AddSidecarDecorator.class };
-  }
-
-  @Override
   public boolean equals(Object o) {
     if (this == o)
       return true;

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddEnvVarDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddEnvVarDecorator.java
@@ -148,11 +148,6 @@ public class AddEnvVarDecorator extends ApplicationContainerDecorator<ContainerB
     return Objects.hash(env);
   }
 
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class,
-        AddSidecarDecorator.class };
-  }
-
   @Override
   public List<ConfigReference> getConfigReferences() {
     if (env.getValue() != null) {

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddLabelDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddLabelDecorator.java
@@ -65,12 +65,6 @@ public class AddLabelDecorator extends NamedResourceDecorator<ObjectMetaFluent> 
   }
 
   @Override
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class,
-        AddSidecarDecorator.class };
-  }
-
-  @Override
   public int hashCode() {
     final int prime = 31;
     int result = 1 + getClass().hashCode();

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddMountDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddMountDecorator.java
@@ -44,10 +44,4 @@ public class AddMountDecorator extends ApplicationContainerDecorator<ContainerBu
         .withReadOnly(mount.isReadOnly())
         .endVolumeMount();
   }
-
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class,
-        AddSidecarDecorator.class, AddInitContainerDecorator.class };
-  }
-
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddPortDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddPortDecorator.java
@@ -74,9 +74,4 @@ public class AddPortDecorator extends ApplicationContainerDecorator<ContainerBui
 
     return Objects.hash(port);
   }
-
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class,
-        AddSidecarDecorator.class };
-  }
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplicationContainerDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplicationContainerDecorator.java
@@ -80,7 +80,8 @@ public abstract class ApplicationContainerDecorator<T> extends Decorator<Visitab
   public abstract void andThenVisit(T item);
 
   public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class };
+    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class, AddSidecarDecorator.class,
+        AddInitContainerDecorator.class };
   }
 
   private class DeploymentVisitor extends TypedVisitor<ContainerBuilder> {

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyArgsDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyArgsDecorator.java
@@ -39,9 +39,4 @@ public class ApplyArgsDecorator extends ApplicationContainerDecorator<ContainerF
       container.withArgs(argument);
     }
   }
-
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class,
-        AddSidecarDecorator.class };
-  }
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyCommandDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyCommandDecorator.java
@@ -39,10 +39,4 @@ public class ApplyCommandDecorator extends ApplicationContainerDecorator<Contain
       container.withCommand(command);
     }
   }
-
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class,
-        AddSidecarDecorator.class };
-  }
-
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyImageDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyImageDecorator.java
@@ -42,11 +42,6 @@ public class ApplyImageDecorator extends ApplicationContainerDecorator<Container
     container.withImage(image);
   }
 
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class,
-        AddSidecarDecorator.class };
-  }
-
   @Override
   public List<ConfigReference> getConfigReferences() {
     return Arrays.asList(buildConfigReferenceForImage());

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyImagePullPolicyDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyImagePullPolicyDecorator.java
@@ -51,10 +51,4 @@ public class ApplyImagePullPolicyDecorator extends ApplicationContainerDecorator
   public void andThenVisit(ContainerFluent<?> container) {
     container.withImagePullPolicy(imagePullPolicy != null ? imagePullPolicy.name() : "IfNotPresent");
   }
-
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class, AddSidecarDecorator.class,
-        AddInitContainerDecorator.class };
-  }
-
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyLimitsCpuDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyLimitsCpuDecorator.java
@@ -40,9 +40,4 @@ public class ApplyLimitsCpuDecorator extends ApplicationContainerDecorator<Conta
   public void andThenVisit(ContainerFluent<?> container) {
     container.editOrNewResources().addToLimits(CPU, new Quantity(amount)).endResources();
   }
-
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class,
-        AddSidecarDecorator.class, AddInitContainerDecorator.class };
-  }
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyLimitsMemoryDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyLimitsMemoryDecorator.java
@@ -39,9 +39,4 @@ public class ApplyLimitsMemoryDecorator extends ApplicationContainerDecorator<Co
   public void andThenVisit(ContainerFluent<?> container) {
     container.editOrNewResources().addToLimits(MEM, new Quantity(amount)).endResources();
   }
-
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class,
-        AddSidecarDecorator.class, AddInitContainerDecorator.class };
-  }
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyPortNameDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyPortNameDecorator.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import io.dekorate.utils.Decorators;
 import io.fabric8.kubernetes.api.model.ContainerPortFluent;
 
 public class ApplyPortNameDecorator extends ApplicationContainerDecorator<ContainerPortFluent<?>> {
@@ -43,7 +44,6 @@ public class ApplyPortNameDecorator extends ApplicationContainerDecorator<Contai
 
   @Override
   public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class, AddSidecarDecorator.class,
-        AddPortDecorator.class };
+    return Decorators.append(super.after(), AddPortDecorator.class);
   }
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyRequestsCpuDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyRequestsCpuDecorator.java
@@ -40,9 +40,4 @@ public class ApplyRequestsCpuDecorator extends ApplicationContainerDecorator<Con
     System.out.println("Apply requests cpu to:" + container.getName());
     container.editOrNewResources().addToRequests(CPU, new Quantity(amount)).endResources();
   }
-
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class,
-        AddSidecarDecorator.class, AddInitContainerDecorator.class };
-  }
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyRequestsMemoryDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ApplyRequestsMemoryDecorator.java
@@ -39,9 +39,4 @@ public class ApplyRequestsMemoryDecorator extends ApplicationContainerDecorator<
   public void andThenVisit(ContainerFluent<?> container) {
     container.editOrNewResources().addToRequests(MEM, new Quantity(amount)).endResources();
   }
-
-  public Class<? extends Decorator>[] after() {
-    return new Class[] { ResourceProvidingDecorator.class, ApplyApplicationContainerDecorator.class,
-        AddSidecarDecorator.class, AddInitContainerDecorator.class };
-  }
 }

--- a/core/src/main/java/io/dekorate/utils/Decorators.java
+++ b/core/src/main/java/io/dekorate/utils/Decorators.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2018 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.dekorate.utils;
+
+import io.dekorate.kubernetes.decorator.Decorator;
+
+public final class Decorators {
+
+  private Decorators() {
+    //Utility classs
+  }
+
+  public static Class<? extends Decorator>[] append(Class<? extends Decorator>[] original,
+      Class<? extends Decorator>... additional) {
+    Class<? extends Decorator>[] result = new Class[original.length + additional.length];
+    System.arraycopy(original, 0, result, 0, original.length);
+    for (int i = 0; i < additional.length; i++) {
+      result[original.length + i] = additional[i];
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
The pull request move containers dekorator order handling (before / after) methods to the `ApplicationContainerDecorator` class. Also, adds ApplicatonContainerDecorators to run after `AddInitContainerDecorator`.