### PR TITLE
Helm: Bind port numbers in Helm values file

### DIFF
--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddPortDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddPortDecorator.java
@@ -15,19 +15,26 @@
  */
 package io.dekorate.kubernetes.decorator;
 
+import static io.dekorate.ConfigReference.joinProperties;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 
+import io.dekorate.ConfigReference;
+import io.dekorate.WithConfigReferences;
 import io.dekorate.doc.Description;
 import io.dekorate.kubernetes.annotation.Protocol;
 import io.dekorate.kubernetes.config.Port;
 import io.dekorate.utils.Predicates;
+import io.dekorate.utils.Strings;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 
 /**
  * A decorator that adds a port to all containers.
  */
 @Description("Add port to to the specified container(s).")
-public class AddPortDecorator extends ApplicationContainerDecorator<ContainerBuilder> {
+public class AddPortDecorator extends ApplicationContainerDecorator<ContainerBuilder> implements WithConfigReferences {
 
   private final Port port;
 
@@ -71,7 +78,39 @@ public class AddPortDecorator extends ApplicationContainerDecorator<ContainerBui
 
   @Override
   public int hashCode() {
-
     return Objects.hash(port);
+  }
+
+  @Override
+  public List<ConfigReference> getConfigReferences() {
+    String property = joinProperties("ports." + port.getName());
+    return Arrays.asList(new ConfigReference.Builder(property, new String[] { pathForDeployment(), pathForService() })
+        .withValue(port.getContainerPort())
+        .withDescription("The port number to use for " + port.getName() + ".")
+        .build());
+  }
+
+  private String pathForDeployment() {
+    String portFilter = ".ports.(name == " + port.getName() + ").containerPort";
+    String path = "spec.template.spec.containers." + portFilter;
+    if (!Strings.equals(getDeploymentName(), ANY) && !Strings.equals(getContainerName(), ANY)) {
+      path = "(metadata.name == " + getDeploymentName() + ").spec.template.spec.containers.(name == "
+          + getContainerName() + ")" + portFilter;
+    } else if (!Strings.equals(getDeploymentName(), ANY)) {
+      path = "(metadata.name == " + getDeploymentName() + ").spec.template.spec.containers." + portFilter;
+    } else if (!Strings.equals(getContainerName(), ANY)) {
+      path = "spec.template.spec.containers.(name == " + getContainerName() + ")" + portFilter;
+    }
+
+    return path;
+  }
+
+  private String pathForService() {
+    String path = "spec.ports.(name == " + port.getName() + ").targetPort";
+    if (!Strings.equals(getDeploymentName(), ANY)) {
+      path = "(metadata.name == " + getDeploymentName() + ")." + path;
+    }
+
+    return path;
   }
 }

--- a/docs/documentation/helm.md
+++ b/docs/documentation/helm.md
@@ -69,6 +69,7 @@ By default, Dekorate will generate the Helm values file (`values.yaml`) by mappi
 - The Kubernetes/OpenShift health checks for Readiness, Liveness and Startup probes
 - The Kubernetes/OpenShift service type
 - The Kubernetes ingress host
+- The Kubernetes/OpenShift port numbers
 - The OpenShift S2i builder image
 - The OpenShift route host/path
 

--- a/examples/helm-on-kubernetes-example/src/test/java/io/dekorate/example/HelmKubernetesExampleTest.java
+++ b/examples/helm-on-kubernetes-example/src/test/java/io/dekorate/example/HelmKubernetesExampleTest.java
@@ -115,6 +115,10 @@ class HelmKubernetesExampleTest {
     assertNull(app.get("notFound"));
     // Should contain vcsUrl with the overridden value from properties
     assertEquals("Overridden", app.get("vcsUrl"));
+    // Should map ports:
+    Map<String, Object> ports = (Map<String, Object>) app.get("ports");
+    assertNotNull(ports);
+    assertEquals(8080, ports.get("http"));
     // Should include health check properties:
     // 1. tcp socket action
     Map<String, Object> livenessValues = (Map<String, Object>) app.get("livenessProbe");
@@ -127,7 +131,8 @@ class HelmKubernetesExampleTest {
     assertProbe(readinessValues, 10, 30);
     Map<String, Object> httpGetValues = (Map<String, Object>) readinessValues.get("httpGet");
     assertEquals("/readiness", httpGetValues.get("path"));
-    assertEquals(8080, httpGetValues.get("port"));
+    // It should be null because it's now mapped with app.ports.http;
+    assertNull(httpGetValues.get("port"));
     assertEquals("HTTP", httpGetValues.get("scheme"));
     // 3. exec action
     Map<String, Object> startupValues = (Map<String, Object>) app.get("startupProbe");

--- a/examples/helm-on-openshift-example/src/test/java/io/dekorate/example/HelmOpenshiftExampleTest.java
+++ b/examples/helm-on-openshift-example/src/test/java/io/dekorate/example/HelmOpenshiftExampleTest.java
@@ -64,17 +64,21 @@ class HelmOpenshiftExampleTest {
 
     assertNotNull(values.containsKey(ROOT_CONFIG_NAME), "Does not contain `" + ROOT_CONFIG_NAME + "`");
     assertNotNull(values.get(ROOT_CONFIG_NAME) instanceof Map, "Value `" + ROOT_CONFIG_NAME + "` is not a map!");
-    Map<String, Object> helmExampleValues = (Map<String, Object>) values.get(ROOT_CONFIG_NAME);
+    Map<String, Object> app = (Map<String, Object>) values.get(ROOT_CONFIG_NAME);
 
+    // Should map ports:
+    Map<String, Object> ports = (Map<String, Object>) app.get("ports");
+    assertNotNull(ports);
+    assertEquals(8080, ports.get("http"));
     // Should contain s2i configuration
-    assertNotNull(helmExampleValues.get("s2iJava"));
-    assertEquals("fabric8/s2i-java", ((Map<String, Object>) helmExampleValues.get("s2iJava")).get("builderImage"));
+    assertNotNull(app.get("s2iJava"));
+    assertEquals("fabric8/s2i-java", ((Map<String, Object>) app.get("s2iJava")).get("builderImage"));
     // Should contain replicas
-    assertEquals(3, helmExampleValues.get("replicas"));
+    assertEquals(3, app.get("replicas"));
     // Should NOT contain notFound: as this property is ignored
-    assertNull(helmExampleValues.get("notFound"));
+    assertNull(app.get("notFound"));
     // Should contain vcsUrl with the overridden value from properties
-    assertEquals("Overridden", helmExampleValues.get("vcsUrl"));
+    assertEquals("Overridden", app.get("vcsUrl"));
   }
 
   @Test

--- a/tests/issue-knative-probes-helm/src/test/java/io/dekorate/knative/helm/KnativeWithHelmTest.java
+++ b/tests/issue-knative-probes-helm/src/test/java/io/dekorate/knative/helm/KnativeWithHelmTest.java
@@ -17,6 +17,7 @@
 
 package io.dekorate.knative.helm;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
@@ -39,15 +40,19 @@ public class KnativeWithHelmTest {
         .readValue(getResource("/helm/knative/example/values.yaml"), Map.class);
     Map<String, Object> app = (Map<String, Object>) values.get("app");
     assertNotNull(app);
-    assertPortIsNotNullForProbe(app, "livenessProbe");
-    assertPortIsNotNullForProbe(app, "readinessProbe");
+    assertPathIsNotNullForProbe(app, "livenessProbe");
+    assertPathIsNotNullForProbe(app, "readinessProbe");
+
+    Map<String, Object> ports = (Map<String, Object>) app.get("ports");
+    assertNotNull(ports);
+    assertEquals(8080, ports.get("http1"));
   }
 
-  private static void assertPortIsNotNullForProbe(Map<String, Object> app, String probeName) {
+  private static void assertPathIsNotNullForProbe(Map<String, Object> app, String probeName) {
     Map<String, Object> probe = (Map<String, Object>) app.get(probeName);
     assertNotNull(probe);
     Map<String, Object> httpGet = (Map<String, Object>) probe.get("httpGet");
-    assertNotNull(httpGet.get("port"));
+    assertNotNull(httpGet.get("path"));
   }
 
   private static InputStream getResource(String resource) {


### PR DESCRIPTION
The port number should be inline in several locations: deployment resources, service and HTTP probes.