### PR TITLE
fix: resolution of git remotes

### DIFF
--- a/core/src/main/java/io/dekorate/utils/Git.java
+++ b/core/src/main/java/io/dekorate/utils/Git.java
@@ -92,6 +92,7 @@ public class Git {
             String remoteLine = linesIter.next();
             if (remoteLine.startsWith(URL) && remoteLine.contains(EQUALS)) {
               result.put(remote, remoteLine.split(EQUALS)[1].trim());
+              break;
             }
           }
         });


### PR DESCRIPTION
Once the first git remote is found, we iterate over all the values and overwrite the values.

For example, having:

```
[remote "origin"]
	url = git@github.com:Sgitario/dekorate.git
	fetch = +refs/heads/*:refs/remotes/origin/*
[remote "upstream"]
	url = git@github.com:dekorateio/dekorate.git
	fetch = +refs/heads/*:refs/remotes/upstream/*
[remote "auri"]
	url = https://github.com/aureamunoz/dekorate
	fetch = +refs/heads/*:refs/remotes/auri/*
```

Will produce a map of only an entry with:

```
'remote "origin"': https://github.com/aureamunoz/dekorate
```

Because https://github.com/aureamunoz/dekorate, it's the last value.

Also, the logic about remotes need to be aligned with this in the TektonManifestGenerator.