### PR TITLE
Helm: Do not add the serviceType properties

### DIFF
--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddServiceResourceDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddServiceResourceDecorator.java
@@ -17,7 +17,6 @@
 package io.dekorate.kubernetes.decorator;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -25,10 +24,8 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-import io.dekorate.ConfigReference;
 import io.dekorate.Logger;
 import io.dekorate.LoggerFactory;
-import io.dekorate.WithConfigReferences;
 import io.dekorate.doc.Description;
 import io.dekorate.kubernetes.annotation.Protocol;
 import io.dekorate.kubernetes.annotation.ServiceType;
@@ -41,8 +38,7 @@ import io.fabric8.kubernetes.api.model.ServicePort;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 
 @Description("Add a service to the list.")
-public class AddServiceResourceDecorator extends ResourceProvidingDecorator<KubernetesListBuilder>
-    implements WithConfigReferences {
+public class AddServiceResourceDecorator extends ResourceProvidingDecorator<KubernetesListBuilder> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger();
   public static final int MIN_PORT_NUMBER = 1;
@@ -115,20 +111,5 @@ public class AddServiceResourceDecorator extends ResourceProvidingDecorator<Kube
         return map.putIfAbsent(keyExtractor.apply(t), Boolean.TRUE) == null;
       }
     };
-  }
-
-  @Override
-  public List<ConfigReference> getConfigReferences() {
-    return Arrays.asList(buildConfigReferenceServiceType());
-  }
-
-  private ConfigReference buildConfigReferenceServiceType() {
-    String property = "serviceType";
-    String path = "(kind == Service && metadata.name == " + config.getName() + ").spec.type";
-    return new ConfigReference.Builder(property, path)
-        .withDescription("The service type to use.")
-        .withValue(config.getServiceType() != null ? config.getServiceType().name() : "ClusterIP")
-        .withEnum(ServiceType.class)
-        .build();
   }
 }

--- a/docs/documentation/helm.md
+++ b/docs/documentation/helm.md
@@ -67,7 +67,6 @@ By default, Dekorate will generate the Helm values file (`values.yaml`) by mappi
 - The Kubernetes/OpenShift image
 - The Kubernetes/OpenShift Env Var values (only for plain values - secrets or configmaps are not supported yet)
 - The Kubernetes/OpenShift health checks for Readiness, Liveness and Startup probes
-- The Kubernetes/OpenShift service type
 - The Kubernetes ingress host
 - The Kubernetes/OpenShift port numbers
 - The OpenShift S2i builder image

--- a/examples/helm-on-kubernetes-example/src/test/java/io/dekorate/example/HelmKubernetesExampleTest.java
+++ b/examples/helm-on-kubernetes-example/src/test/java/io/dekorate/example/HelmKubernetesExampleTest.java
@@ -109,8 +109,6 @@ class HelmKubernetesExampleTest {
     assertNotNull(app.get("image"));
     // Should contain replicas
     assertEquals(3, app.get("replicas"));
-    // Should contain service type
-    assertEquals("NodePort", app.get("serviceType"));
     // Should NOT contain notFound: as this property is ignored
     assertNull(app.get("notFound"));
     // Should contain vcsUrl with the overridden value from properties
@@ -185,17 +183,11 @@ class HelmKubernetesExampleTest {
     // From config references
     ValuesSchemaProperty app = schema.getProperties().get("app");
     assertNotNull(app);
-    assertEquals(1, app.getRequired().size());
-    assertEquals("serviceType", app.getRequired().iterator().next());
     ValuesSchemaProperty replicas = app.getProperties().get("replicas");
     assertNotNull(replicas);
     assertEquals(3, replicas.getMinimum());
     assertEquals(5, replicas.getMaximum());
     assertEquals("Overwrite default description!", replicas.getDescription());
-    ValuesSchemaProperty serviceType = app.getProperties().get("serviceType");
-    assertNotNull(serviceType);
-    assertEquals("The service type to use.", serviceType.getDescription());
-    assertEquals(ServiceType.values().length, serviceType.getEnumValues().size());
   }
 
   @Test


### PR DESCRIPTION
Because changing this property would imply also changing other Service configuration that is not mapped, it does not make sense to add this mapping.
