### PR TITLE
fix: tekton should create consistent names for persistent volumes

### DIFF
--- a/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/decorator/AddWorkspaceToPipelineTaskDecorator.java
+++ b/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/decorator/AddWorkspaceToPipelineTaskDecorator.java
@@ -27,13 +27,11 @@ public class AddWorkspaceToPipelineTaskDecorator extends NamedPipelineDecorator 
 
   private final String taskName;
   private final String id;
-  private final String workspace;
 
-  public AddWorkspaceToPipelineTaskDecorator(String pipelineName, String taskName, String id, String workspace) {
+  public AddWorkspaceToPipelineTaskDecorator(String pipelineName, String taskName, String id) {
     super(pipelineName);
     this.taskName = taskName;
     this.id = id;
-    this.workspace = workspace;
   }
 
   @Override
@@ -47,7 +45,7 @@ public class AddWorkspaceToPipelineTaskDecorator extends NamedPipelineDecorator 
 
     //If no task name is specified we need to add the workspace to all pipeline tasks.
     if (spec.hasMatchingTask(predicate)) {
-      spec.editMatchingTask(predicate).addNewWorkspace().withName(id).withWorkspace(workspace).endWorkspace().endTask();
+      spec.editMatchingTask(predicate).addNewWorkspace().withName(id).withWorkspace(id).endWorkspace().endTask();
     }
   }
 }

--- a/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/manifest/TektonManifestGenerator.java
+++ b/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/manifest/TektonManifestGenerator.java
@@ -126,10 +126,6 @@ public class TektonManifestGenerator implements ManifestGenerator<TektonConfig>,
   private static final String RUN = "run";
   private static final String NOW = "now";
 
-  private static final String PIPELINE_SOURCE_WS = "pipeline-source-ws";
-
-  private static final String PIPELINE_M2_WS = "pipeline-m2-ws";
-
   private static final String PROJECT = "project";
   private static final String DASH = "-";
 
@@ -407,11 +403,11 @@ public class TektonManifestGenerator implements ManifestGenerator<TektonConfig>,
 
     if (isNotNullOrEmpty(m2WorkspaceClaimName)) {
       resourceRegistry.decorate(TEKTON_PIPELINE,
-          new AddWorkspaceToPipelineTaskDecorator(null, PROJECT + DASH + BUILD, config.getM2Workspace(), PIPELINE_M2_WS));
+          new AddWorkspaceToPipelineTaskDecorator(null, PROJECT + DASH + BUILD, config.getM2Workspace()));
       resourceRegistry.decorate(TEKTON_PIPELINE,
-          new AddWorkspaceToPipelineDecorator(null, PIPELINE_M2_WS, "Local maven repository workspace"));
+          new AddWorkspaceToPipelineDecorator(null, config.getM2Workspace(), "Local maven repository workspace"));
       resourceRegistry.decorate(TEKTON_PIPELINE_RUN,
-          new AddPvcToPipelineRunDecorator(null, PIPELINE_M2_WS, m2WorkspaceClaimName, false));
+          new AddPvcToPipelineRunDecorator(null, config.getM2Workspace(), m2WorkspaceClaimName, false));
     }
   }
 
@@ -438,7 +434,7 @@ public class TektonManifestGenerator implements ManifestGenerator<TektonConfig>,
         .withNewTaskRef()
         .withName(gitCloneTaskName(config))
         .endTaskRef()
-        .addNewWorkspace().withName(config.getSourceWorkspace()).withWorkspace(PIPELINE_SOURCE_WS).endWorkspace()
+        .addNewWorkspace().withName(config.getSourceWorkspace()).withWorkspace(config.getSourceWorkspace()).endWorkspace()
         .build();
   }
 
@@ -448,7 +444,7 @@ public class TektonManifestGenerator implements ManifestGenerator<TektonConfig>,
         .withNewTaskRef()
         .withName(projectBuildTaskName(config))
         .endTaskRef()
-        .addNewWorkspace().withName(config.getSourceWorkspace()).withWorkspace(PIPELINE_SOURCE_WS).endWorkspace()
+        .addNewWorkspace().withName(config.getSourceWorkspace()).withWorkspace(config.getSourceWorkspace()).endWorkspace()
         .addNewParam().withName(ProjectBuildStep.PATH_TO_CONTEXT_PARAM_NAME).withNewValue(getContextPath(getProject()))
         .endParam();
 
@@ -465,7 +461,7 @@ public class TektonManifestGenerator implements ManifestGenerator<TektonConfig>,
         .withNewTaskRef()
         .withName(imageBuildTaskName(config))
         .endTaskRef()
-        .addNewWorkspace().withName(config.getSourceWorkspace()).withWorkspace(PIPELINE_SOURCE_WS).endWorkspace()
+        .addNewWorkspace().withName(config.getSourceWorkspace()).withWorkspace(config.getSourceWorkspace()).endWorkspace()
         .withRunAfter(PROJECT + DASH + BUILD)
         .build();
   }
@@ -476,7 +472,7 @@ public class TektonManifestGenerator implements ManifestGenerator<TektonConfig>,
         .withNewTaskRef()
         .withName(deployTaskName(config))
         .endTaskRef()
-        .addNewWorkspace().withName(config.getSourceWorkspace()).withWorkspace(PIPELINE_SOURCE_WS).endWorkspace()
+        .addNewWorkspace().withName(config.getSourceWorkspace()).withWorkspace(config.getSourceWorkspace()).endWorkspace()
         .addNewParam().withName(DeployStep.PATH_TO_YML_PARAM_NAME).withNewValue(getYamlPath(getProject())).endParam()
         .addNewParam().withName(DeployStep.PATH_TO_CONTEXT_PARAM_NAME).withNewValue(getContextPath(getProject())).endParam()
         .withRunAfter(PROJECT + DASH + BUILD, IMAGE + DASH + BUILD)
@@ -498,7 +494,7 @@ public class TektonManifestGenerator implements ManifestGenerator<TektonConfig>,
         .withName(config.getName())
         .endMetadata()
         .withNewSpec()
-        .addNewWorkspace().withName(PIPELINE_SOURCE_WS).endWorkspace()
+        .addNewWorkspace().withName(config.getSourceWorkspace()).endWorkspace()
         .addAllToTasks(tasks)
         .endSpec()
         .build();
@@ -526,7 +522,7 @@ public class TektonManifestGenerator implements ManifestGenerator<TektonConfig>,
           .endMetadata()
           .withNewSpec()
           .withServiceAccountName(config.getName())
-          .addNewWorkspace().withName(PIPELINE_SOURCE_WS)
+          .addNewWorkspace().withName(config.getSourceWorkspace())
           .withNewPersistentVolumeClaim(sourceWorkspaceClaimName(config), false)
           .endWorkspace()
           .withNewPipelineRef().withName(config.getName()).endPipelineRef()

--- a/examples/spring-boot-with-tekton-and-m2-pvc-example/src/main/resources/application.properties
+++ b/examples/spring-boot-with-tekton-and-m2-pvc-example/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 dekorate.tekton.m2-workspace-claim.name=m2-pvc
 dekorate.tekton.m2-workspace-claim.size=1
 dekorate.tekton.m2-workspace-claim.unit=Gi
-dekorate.tekton.m2-workspace-claim.matchLables[0].key=volume-type
-dekorate.tekton.m2-workspace-claim.matchLables[0].value=m2
+dekorate.tekton.m2-workspace-claim.matchLabels[0].key=volume-type
+dekorate.tekton.m2-workspace-claim.matchLabels[0].value=m2


### PR DESCRIPTION
At the moment, the pipeline vs tasks resources generate the same persistent volumes but using different names.

With this fix, this is addressed to generate always the same volume persistent volume name.