### PR TITLE
Bump Kubernetes Client to 6.8.0

### DIFF
--- a/annotations/certmanager-annotations/src/main/java/io/dekorate/certmanager/annotation/Certificate.java
+++ b/annotations/certmanager-annotations/src/main/java/io/dekorate/certmanager/annotation/Certificate.java
@@ -22,10 +22,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.Configuration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "CertificateConfig", autobox = true, mutable = true, superClass = Configuration.class, relativePath = "../config", withStaticBuilderMethod = true, withStaticAdapterMethod = false)
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.SOURCE)
@@ -39,7 +45,7 @@ public @interface Certificate {
   /**
    * SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource.
    * It will be populated with a private key and certificate, signed by the denoted issuer.
-   * 
+   *
    * @return the name of the secret resource that will be automatically created and managed by this Certificate resource.
    */
   String secretName();
@@ -66,7 +72,7 @@ public @interface Certificate {
 
   /**
    * Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
-   * 
+   *
    * @return the full X509 name specification
    */
   Subject subject() default @Subject;
@@ -74,7 +80,7 @@ public @interface Certificate {
   /**
    * CommonName is a common name to be used on the Certificate. The CommonName should have a length of 64 characters or fewer
    * to avoid generating invalid CSRs.
-   * 
+   *
    * @return the common name.
    */
   String commonName() default "";

--- a/annotations/certmanager-annotations/src/main/java/io/dekorate/certmanager/decorator/AddCaIssuerResourceDecorator.java
+++ b/annotations/certmanager-annotations/src/main/java/io/dekorate/certmanager/decorator/AddCaIssuerResourceDecorator.java
@@ -17,7 +17,7 @@ public class AddCaIssuerResourceDecorator extends BaseAddIssuerResourceDecorator
   }
 
   @Override
-  protected void visitIssuerSpec(IssuerFluent.SpecNested<IssuerBuilder> spec) {
+  protected void visitIssuerSpec(IssuerFluent<?>.SpecNested<IssuerBuilder> spec) {
     CAIssuerBuilder builder = new CAIssuerBuilder()
         .withSecretName(config.getSecretName());
 

--- a/annotations/certmanager-annotations/src/main/java/io/dekorate/certmanager/decorator/AddCertificateResourceDecorator.java
+++ b/annotations/certmanager-annotations/src/main/java/io/dekorate/certmanager/decorator/AddCertificateResourceDecorator.java
@@ -47,7 +47,7 @@ public class AddCertificateResourceDecorator extends ResourceProvidingDecorator<
         .endMetadata();
 
     // mandatory configuration
-    CertificateFluent.SpecNested<CertificateBuilder> spec = builder.withNewSpec().withSecretName(config.getSecretName());
+    CertificateFluent<?>.SpecNested<CertificateBuilder> spec = builder.withNewSpec().withSecretName(config.getSecretName());
 
     // issuer ref: it can be set or be auto generated (when it's auto generated, the name is the same as the Certificate res
     if (config.getIssuerRef() != null) {

--- a/annotations/certmanager-annotations/src/main/java/io/dekorate/certmanager/decorator/AddSelfSignedIssuerResourceDecorator.java
+++ b/annotations/certmanager-annotations/src/main/java/io/dekorate/certmanager/decorator/AddSelfSignedIssuerResourceDecorator.java
@@ -17,7 +17,7 @@ public class AddSelfSignedIssuerResourceDecorator extends BaseAddIssuerResourceD
   }
 
   @Override
-  protected void visitIssuerSpec(IssuerFluent.SpecNested<IssuerBuilder> spec) {
+  protected void visitIssuerSpec(IssuerFluent<?>.SpecNested<IssuerBuilder> spec) {
     SelfSignedIssuerBuilder builder = new SelfSignedIssuerBuilder();
 
     Optional.ofNullable(config.getCrlDistributionPoints()).ifPresent(builder::withCrlDistributionPoints);

--- a/annotations/certmanager-annotations/src/main/java/io/dekorate/certmanager/decorator/AddVaultIssuerResourceDecorator.java
+++ b/annotations/certmanager-annotations/src/main/java/io/dekorate/certmanager/decorator/AddVaultIssuerResourceDecorator.java
@@ -25,7 +25,7 @@ public class AddVaultIssuerResourceDecorator extends BaseAddIssuerResourceDecora
   }
 
   @Override
-  protected void visitIssuerSpec(IssuerFluent.SpecNested<IssuerBuilder> spec) {
+  protected void visitIssuerSpec(IssuerFluent<?>.SpecNested<IssuerBuilder> spec) {
     if (noneAuthIsSet(config.getAuthAppRole(), config.getAuthKubernetes(), config.getAuthTokenSecretRef())) {
       throw new IllegalArgumentException("No auth mechanism has been set in the Vault Issuer configuration");
     }

--- a/annotations/certmanager-annotations/src/main/java/io/dekorate/certmanager/decorator/BaseAddIssuerResourceDecorator.java
+++ b/annotations/certmanager-annotations/src/main/java/io/dekorate/certmanager/decorator/BaseAddIssuerResourceDecorator.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 
 public abstract class BaseAddIssuerResourceDecorator extends ResourceProvidingDecorator<KubernetesListBuilder> {
 
-  protected abstract void visitIssuerSpec(IssuerFluent.SpecNested<IssuerBuilder> spec);
+  protected abstract void visitIssuerSpec(IssuerFluent<?>.SpecNested<IssuerBuilder> spec);
 
   private final String name;
 
@@ -24,7 +24,7 @@ public abstract class BaseAddIssuerResourceDecorator extends ResourceProvidingDe
         .withName(name)
         .endMetadata();
 
-    IssuerFluent.SpecNested<IssuerBuilder> spec = builder.withNewSpec();
+    IssuerFluent<?>.SpecNested<IssuerBuilder> spec = builder.withNewSpec();
 
     visitIssuerSpec(spec);
 

--- a/annotations/docker-annotations/src/main/java/io/dekorate/docker/annotation/DockerBuild.java
+++ b/annotations/docker-annotations/src/main/java/io/dekorate/docker/annotation/DockerBuild.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2018 The original authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
 **/
 
 package io.dekorate.docker.annotation;
@@ -23,11 +23,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.ImageConfiguration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "DockerBuildConfig", autobox = true, mutable = true, superClass = ImageConfiguration.class, relativePath = "../config", withStaticAdapterMethod = false, adapter = @Adapter(name = "DockerBuildConfigAdapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
@@ -37,28 +43,28 @@ public @interface DockerBuild {
 
   /**
    * The registry that holds the image.
-   * 
+   *
    * @return The registry or empty string if no registry has been specified.
    */
   String registry() default "";
 
   /**
    * The group of the application. This value will be use as image user.
-   * 
+   *
    * @return The specified group name.
    */
   String group() default "";
 
   /**
    * The name of the application. This value will be used as name.
-   * 
+   *
    * @return The specified application name.
    */
   String name() default "";
 
   /**
    * The version of the application. This value be used as image tag.
-   * 
+   *
    * @return The version.
    */
   String version() default "";
@@ -66,28 +72,28 @@ public @interface DockerBuild {
   /**
    * The name of the image to be generated.
    * This property overrides group, name and version.
-   * 
+   *
    * @return the image name.
    */
   String image() default "";
 
   /**
    * The relative path of the Dockerfile, from the module root.
-   * 
+   *
    * @return The relative path.
    */
   String dockerFile() default "Dockerfile";
 
   /**
    * Flag to automatically push the image, to the specified registry.
-   * 
+   *
    * @return True if hook is to be registered, false otherwise.
    */
   boolean autoPushEnabled() default false;
 
   /**
    * Flag to automatically register a build hook after compilation.
-   * 
+   *
    * @return True if hook is to be registered, false otherwise.
    */
   boolean autoBuildEnabled() default false;
@@ -95,7 +101,7 @@ public @interface DockerBuild {
   /**
    * Flag to trigger the registration of the deploy hook. It's generally
    * preferable to use `-Ddekorate.deploy=true` instead of hardcoding this here.
-   * 
+   *
    * @return True for automatic registration of the build hook.
    */
   boolean autoDeployEnabled() default false;

--- a/annotations/helm-annotations/src/main/java/io/dekorate/helm/annotation/HelmChart.java
+++ b/annotations/helm-annotations/src/main/java/io/dekorate/helm/annotation/HelmChart.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2018 The original authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
 **/
 
 package io.dekorate.helm.annotation;
@@ -23,11 +23,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.Configuration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "HelmChartConfig", autobox = true, mutable = true, superClass = Configuration.class, relativePath = "../config", withStaticBuilderMethod = true, withStaticAdapterMethod = false, adapter = @Adapter(name = "HelmChartConfigAdapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/annotations/jaeger-annotations/src/main/java/io/dekorate/jaeger/annotation/EnableJaegerAgent.java
+++ b/annotations/jaeger-annotations/src/main/java/io/dekorate/jaeger/annotation/EnableJaegerAgent.java
@@ -22,11 +22,17 @@ import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.annotation.Port;
 import io.dekorate.kubernetes.config.Configuration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "JaegerAgentConfig", autobox = true, mutable = true, superClass = Configuration.class, relativePath = "../config", withStaticAdapterMethod = false, adapter = @Adapter(name = "JaegerAgentConfigAdapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
@@ -34,14 +40,14 @@ public @interface EnableJaegerAgent {
 
   /**
    * Flag to specify if Jaeger operator is available / enabled.
-   * 
+   *
    * @return True, if operator is available / enabled.
    */
   boolean operatorEnabled() default false;
 
   /**
    * The jaeger agent version.
-   * 
+   *
    * @return The version, or default to 1.10
    */
   String version() default "1.10";

--- a/annotations/jib-annotations/src/main/java/io/dekorate/jib/annotation/JibBuild.java
+++ b/annotations/jib-annotations/src/main/java/io/dekorate/jib/annotation/JibBuild.java
@@ -21,12 +21,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.ImageConfiguration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
-
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "JibBuildConfig", autobox = true, mutable = true, superClass = ImageConfiguration.class, relativePath = "../config", withStaticAdapterMethod = false, adapter = @Adapter(name = "JibBuildConfigAdapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.SOURCE)
@@ -36,28 +41,28 @@ public @interface JibBuild {
 
   /**
    * The registry that holds the image.
-   * 
+   *
    * @return The registry or empty string if no registry has been specified.
    */
   String registry() default "";
 
   /**
    * The group of the application. This value will be use as image user.
-   * 
+   *
    * @return The specified group name.
    */
   String group() default "";
 
   /**
    * The name of the application. This value will be used as name .
-   * 
+   *
    * @return The specified application name.
    */
   String name() default "";
 
   /**
    * The version of the application. This value be used as image tag.
-   * 
+   *
    * @return The version.
    */
   String version() default "";
@@ -65,35 +70,35 @@ public @interface JibBuild {
   /**
    * The name of the image to be generated.
    * This property overrides group, name and version.
-   * 
+   *
    * @return the image name.
    */
   String image() default "";
 
   /**
    * Flag that indicates whether to perform a docker build (build using the docker daemon) or not.
-   * 
+   *
    * @return true, if docker build is desired, false otherwise.
    */
   boolean dockerBuild() default true;
 
   /**
    * The base image to use.
-   * 
+   *
    * @return The base image.
    */
   String from() default "openjdk:8-jdk";
 
   /**
    * Flag to automatically push the image, to the specified registry.
-   * 
+   *
    * @return True if hook is to be registered, false otherwise.
    */
   boolean autoPushEnabled() default false;
 
   /**
    * Flag to automatically register a build hook after compilation.
-   * 
+   *
    * @return True if hook is to be registered, false otherwise.
    */
   boolean autoBuildEnabled() default false;
@@ -101,7 +106,7 @@ public @interface JibBuild {
   /**
    * Flag to trigger the registration of the deploy hook. It's generally
    * preferable to use `-Ddekorate.deploy=true` instead of hardcoding this here.
-   * 
+   *
    * @return True for automatic registration of the build hook.
    */
   boolean autoDeployEnabled() default false;

--- a/annotations/kind-annotations/src/main/java/io/dekorate/kind/annotation/Kind.java
+++ b/annotations/kind-annotations/src/main/java/io/dekorate/kind/annotation/Kind.java
@@ -24,11 +24,34 @@ import io.dekorate.kubernetes.annotation.ImagePullPolicy;
 import io.dekorate.kubernetes.annotation.Port;
 import io.dekorate.kubernetes.annotation.ServiceType;
 import io.dekorate.kubernetes.config.BaseConfig;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class),
+    @BuildableReference(io.dekorate.kubernetes.config.Label.class),
+    @BuildableReference(io.dekorate.kubernetes.config.Annotation.class),
+    @BuildableReference(io.dekorate.kubernetes.config.Env.class),
+    @BuildableReference(io.dekorate.kubernetes.config.PersistentVolumeClaimVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.SecretVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.ConfigMapVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.EmptyDirVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.GitRepoVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.AwsElasticBlockStoreVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.AzureDiskVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.AzureFileVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.Mount.class),
+    @BuildableReference(io.dekorate.kubernetes.config.RollingUpdate.class),
+    @BuildableReference(io.dekorate.kubernetes.config.HostAlias.class),
+    @BuildableReference(io.dekorate.kubernetes.config.Container.class),
+    @BuildableReference(io.dekorate.kubernetes.config.Job.class),
+    @BuildableReference(io.dekorate.kubernetes.config.CronJob.class)
+})
 @Pojo(name = "KindConfig", relativePath = "../config", autobox = true, mutable = true, superClass = BaseConfig.class, withStaticBuilderMethod = true, withStaticAdapterMethod = false, adapter = @Adapter(name = "KindConfigAdapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/annotations/knative-annotations/src/main/java/io/dekorate/knative/annotation/KnativeApplication.java
+++ b/annotations/knative-annotations/src/main/java/io/dekorate/knative/annotation/KnativeApplication.java
@@ -44,11 +44,21 @@ import io.dekorate.kubernetes.annotation.ResourceRequirements;
 import io.dekorate.kubernetes.annotation.SecretVolume;
 import io.dekorate.kubernetes.annotation.ServiceType;
 import io.dekorate.kubernetes.config.BaseConfig;
+import io.dekorate.kubernetes.config.HostAlias;
+import io.dekorate.kubernetes.config.RollingUpdate;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class),
+    @BuildableReference(HostAlias.class),
+    @BuildableReference(RollingUpdate.class)
+})
 @Pojo(name = "KnativeConfig", autobox = true, mutable = true, superClass = BaseConfig.class, relativePath = "../config", withStaticAdapterMethod = false, adapter = @Adapter(relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
@@ -61,7 +71,7 @@ public @interface KnativeApplication {
    * The name of the collection of componnet this component belongs to.
    * This value will be use as:
    * - labeling resources
-   * 
+   *
    * @return The specified group name.
    */
   String partOf() default "";
@@ -78,7 +88,7 @@ public @interface KnativeApplication {
    * Else if the system property app.name is present it will be used.
    * Else find the project root folder and use its name (root folder detection is done by moving to the parent folder until
    * .git is found).
-   * 
+   *
    * @return The specified application name.
    */
   String name() default "";
@@ -88,14 +98,14 @@ public @interface KnativeApplication {
    * This value be used for things like:
    * - The docker image tag.
    * If no value specified it will attempt to determine the name using the following rules:
-   * 
+   *
    * @return The version.
    */
   String version() default "";
 
   /**
    * Custom labels to add to all resources.
-   * 
+   *
    * @return The labels.
    */
   Label[] labels() default {};
@@ -107,49 +117,49 @@ public @interface KnativeApplication {
 
   /**
    * Custom annotations to add to all resources.
-   * 
+   *
    * @return The annotations.
    */
   Annotation[] annotations() default {};
 
   /**
    * Environment variables to add to all containers.
-   * 
+   *
    * @return The environment variables.
    */
   Env[] envVars() default {};
 
   /**
    * Working directory.
-   * 
+   *
    * @return The working directory if specified, else empty string.
    */
   String workingDir() default "";
 
   /**
    * The commands
-   * 
+   *
    * @return The commands.
    */
   String[] command() default {};
 
   /**
    * The arguments
-   * 
+   *
    * @return The arguments.
    */
   String[] arguments() default {};
 
   /**
    * The service account.
-   * 
+   *
    * @return The service account or empty string if not specified.
    */
   String serviceAccount() default "";
 
   /**
    * The host under which the application is going to be exposed.
-   * 
+   *
    * @return The hostname.
    */
   String host() default "";
@@ -211,14 +221,14 @@ public @interface KnativeApplication {
 
   /**
    * Mounts to add to all containers.
-   * 
+   *
    * @return The mounts.
    */
   Mount[] mounts() default {};
 
   /**
    * Image pull policy.
-   * 
+   *
    * @return The image pull policy.
    */
   ImagePullPolicy imagePullPolicy() default ImagePullPolicy.IfNotPresent;
@@ -230,14 +240,14 @@ public @interface KnativeApplication {
 
   /**
    * The liveness probe.
-   * 
+   *
    * @return The probe.
    */
   Probe livenessProbe() default @Probe();
 
   /**
    * The readiness probe.
-   * 
+   *
    * @return The probe.
    */
   Probe readinessProbe() default @Probe();
@@ -261,7 +271,7 @@ public @interface KnativeApplication {
 
   /**
    * The sidecars.
-   * 
+   *
    * @return the sidecar containers.
    */
   Container[] sidecars() default {};
@@ -276,7 +286,7 @@ public @interface KnativeApplication {
   /**
    * Flag to trigger the registration of the deploy hook.
    * It's generally preferable to use `-Ddekorate.deploy=true` instead of hardcoding this here.
-   * 
+   *
    * @return True for automatic registration of the build hook.
    */
   boolean autoDeployEnabled() default false;

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/annotation/KubernetesApplication.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/annotation/KubernetesApplication.java
@@ -22,12 +22,18 @@ import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.BaseConfig;
 import io.dekorate.kubernetes.config.DeploymentStrategy;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.fabric8.kubernetes.api.model.Service;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "KubernetesConfig", relativePath = "../config", autobox = true, mutable = true, superClass = BaseConfig.class, withStaticBuilderMethod = true, withStaticAdapterMethod = false, adapter = @Adapter(suffix = "Adapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
@@ -38,7 +44,7 @@ public @interface KubernetesApplication {
    * This value will be use as:
    * - docker image repo
    * - labeling resources
-   * 
+   *
    * @return The specified group name.
    */
   String partOf() default "";
@@ -51,7 +57,7 @@ public @interface KubernetesApplication {
    * name. Else if the system property app.name is present it will be used. Else
    * find the project root folder and use its name (root folder detection is done
    * by moving to the parent folder until .git is found).
-   * 
+   *
    * @return The specified application name.
    */
   String name() default "";
@@ -60,7 +66,7 @@ public @interface KubernetesApplication {
    * The version of the application. This value be used for things like: - The
    * docker image tag. If no value specified it will attempt to determine the name
    * using the following rules:
-   * 
+   *
    * @return The version.
    */
   String version() default "";
@@ -68,63 +74,63 @@ public @interface KubernetesApplication {
   /**
    * The kind of the deployment resource to use.
    * Supported values are 'Deployment', 'StatefulSet', 'Job' and 'CronJob' defaulting to the first.
-   * 
+   *
    * @return The deployment kind resource.
    */
   String deploymentKind() default "Deployment";
 
   /**
    * The init containers.
-   * 
+   *
    * @return the init containers.
    */
   Container[] initContainers() default {};
 
   /**
    * Custom labels to add to all resources.
-   * 
+   *
    * @return The labels.
    */
   Label[] labels() default {};
 
   /**
    * Custom annotations to add to all resources.
-   * 
+   *
    * @return The annotations.
    */
   Annotation[] annotations() default {};
 
   /**
    * Environment variables to add to all containers.
-   * 
+   *
    * @return The environment variables.
    */
   Env[] envVars() default {};
 
   /**
    * Working directory.
-   * 
+   *
    * @return The working directory if specified, else empty string.
    */
   String workingDir() default "";
 
   /**
    * The commands
-   * 
+   *
    * @return The commands.
    */
   String[] command() default {};
 
   /**
    * The arguments
-   * 
+   *
    * @return The arguments.
    */
   String[] arguments() default {};
 
   /**
    * The number of replicas to use.
-   * 
+   *
    * @return The number of replicas.
    */
   int replicas() default 1;
@@ -143,7 +149,7 @@ public @interface KubernetesApplication {
 
   /**
    * The service account.
-   * 
+   *
    * @return The service account or empty string if not specified.
    */
   String serviceAccount() default "";
@@ -200,14 +206,14 @@ public @interface KubernetesApplication {
 
   /**
    * Mounts to add to all containers.
-   * 
+   *
    * @return The mounts.
    */
   Mount[] mounts() default {};
 
   /**
    * Image pull policy.
-   * 
+   *
    * @return The image pull policy.
    */
   ImagePullPolicy imagePullPolicy() default ImagePullPolicy.IfNotPresent;
@@ -224,14 +230,14 @@ public @interface KubernetesApplication {
 
   /**
    * The liveness probe.
-   * 
+   *
    * @return The probe.
    */
   Probe livenessProbe() default @Probe();
 
   /**
    * The readiness probe.
-   * 
+   *
    * @return The probe.
    */
   Probe readinessProbe() default @Probe();
@@ -255,7 +261,7 @@ public @interface KubernetesApplication {
 
   /**
    * The sidecars.
-   * 
+   *
    * @return the sidecar containers.
    */
   Container[] sidecars() default {};
@@ -267,7 +273,7 @@ public @interface KubernetesApplication {
 
   /**
    * Controls whether the generated {@link Service} will be headless.
-   * 
+   *
    * @return true if headless.
    */
   boolean headless() default false;
@@ -275,7 +281,7 @@ public @interface KubernetesApplication {
   /**
    * Flag to trigger the registration of the deploy hook. It's generally
    * preferable to use `-Ddekorate.deploy=true` instead of hardcoding this here.
-   * 
+   *
    * @return True for automatic registration of the build hook.
    */
   boolean autoDeployEnabled() default false;

--- a/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/decorator/AddIngressRuleDecorator.java
+++ b/annotations/kubernetes-annotations/src/main/java/io/dekorate/kubernetes/decorator/AddIngressRuleDecorator.java
@@ -126,7 +126,7 @@ public class AddIngressRuleDecorator extends NamedResourceDecorator<IngressSpecB
               .endService()
               .endBackend()
               .endPath().endHttp();
-        } else if (existingRule.getHttp().getPaths().stream()
+        } else if (existingRule.buildHttp().getPaths().stream()
             .noneMatch(p -> Strings.equals(p.getPath(), path()) && Strings.equals(p.getPathType(), pathType()))) {
           existingRule.editHttp()
               .addNewPath()

--- a/annotations/minikube-annotations/src/main/java/io/dekorate/minikube/annotation/Minikube.java
+++ b/annotations/minikube-annotations/src/main/java/io/dekorate/minikube/annotation/Minikube.java
@@ -22,11 +22,34 @@ import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.annotation.*;
 import io.dekorate.kubernetes.config.BaseConfig;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class),
+    @BuildableReference(io.dekorate.kubernetes.config.Label.class),
+    @BuildableReference(io.dekorate.kubernetes.config.Annotation.class),
+    @BuildableReference(io.dekorate.kubernetes.config.Env.class),
+    @BuildableReference(io.dekorate.kubernetes.config.PersistentVolumeClaimVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.SecretVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.ConfigMapVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.EmptyDirVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.GitRepoVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.AwsElasticBlockStoreVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.AzureDiskVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.AzureFileVolume.class),
+    @BuildableReference(io.dekorate.kubernetes.config.Mount.class),
+    @BuildableReference(io.dekorate.kubernetes.config.RollingUpdate.class),
+    @BuildableReference(io.dekorate.kubernetes.config.HostAlias.class),
+    @BuildableReference(io.dekorate.kubernetes.config.Container.class),
+    @BuildableReference(io.dekorate.kubernetes.config.Job.class),
+    @BuildableReference(io.dekorate.kubernetes.config.CronJob.class)
+})
 @Pojo(name = "MinikubeConfig", relativePath = "../config", autobox = true, mutable = true, superClass = BaseConfig.class, withStaticBuilderMethod = true, withStaticAdapterMethod = false, adapter = @Adapter(suffix = "Adapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/annotation/OpenshiftApplication.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/annotation/OpenshiftApplication.java
@@ -43,11 +43,19 @@ import io.dekorate.kubernetes.annotation.SecretVolume;
 import io.dekorate.kubernetes.annotation.ServiceType;
 import io.dekorate.kubernetes.config.BaseConfig;
 import io.dekorate.kubernetes.config.DeploymentStrategy;
+import io.dekorate.kubernetes.config.HostAlias;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class),
+    @BuildableReference(HostAlias.class)
+})
 @Pojo(name = "OpenshiftConfig", autobox = true, mutable = true, superClass = BaseConfig.class, relativePath = "../config", withStaticAdapterMethod = false, adapter = @Adapter(relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
@@ -57,7 +65,7 @@ public @interface OpenshiftApplication {
    * The name of the collection of componnet this component belongs to.
    * This value will be use as:
    * - labeling resources
-   * 
+   *
    * @return The specified group name.
    */
   String partOf() default "";
@@ -74,7 +82,7 @@ public @interface OpenshiftApplication {
    * Else if the system property app.name is present it will be used.
    * Else find the project root folder and use its name (root folder detection is done by moving to the parent folder until
    * .git is found).
-   * 
+   *
    * @return The specified application name.
    */
   String name() default "";
@@ -84,7 +92,7 @@ public @interface OpenshiftApplication {
    * This value be used for things like:
    * - The docker image tag.
    * If no value specified it will attempt to determine the name using the following rules:
-   * 
+   *
    * @return The version.
    */
   String version() default "";
@@ -99,56 +107,56 @@ public @interface OpenshiftApplication {
 
   /**
    * The init containers.
-   * 
+   *
    * @return the init containers.
    */
   Container[] initContainers() default {};
 
   /**
    * Custom labels to add to all resources.
-   * 
+   *
    * @return The labels.
    */
   Label[] labels() default {};
 
   /**
    * Custom annotations to add to all resources.
-   * 
+   *
    * @return The annotations.
    */
   Annotation[] annotations() default {};
 
   /**
    * Environment variables to add to all containers.
-   * 
+   *
    * @return The environment variables.
    */
   Env[] envVars() default {};
 
   /**
    * Working directory.
-   * 
+   *
    * @return The working directory if specified, else empty string.
    */
   String workingDir() default "";
 
   /**
    * The commands
-   * 
+   *
    * @return The commands.
    */
   String[] command() default {};
 
   /**
    * The arguments
-   * 
+   *
    * @return The arguments.
    */
   String[] arguments() default {};
 
   /**
    * The number of replicas to use.
-   * 
+   *
    * @return The number of replicas.
    */
   int replicas() default 1;
@@ -167,7 +175,7 @@ public @interface OpenshiftApplication {
 
   /**
    * The service account.
-   * 
+   *
    * @return The service account or empty string if not specified.
    */
   String serviceAccount() default "";
@@ -224,14 +232,14 @@ public @interface OpenshiftApplication {
 
   /**
    * Mounts to add to all containers.
-   * 
+   *
    * @return The mounts.
    */
   Mount[] mounts() default {};
 
   /**
    * Image pull policy.
-   * 
+   *
    * @return The image pull policy.
    */
   ImagePullPolicy imagePullPolicy() default ImagePullPolicy.IfNotPresent;
@@ -243,14 +251,14 @@ public @interface OpenshiftApplication {
 
   /**
    * The liveness probe.
-   * 
+   *
    * @return The probe.
    */
   Probe livenessProbe() default @Probe();
 
   /**
    * The readiness probe.
-   * 
+   *
    * @return The probe.
    */
   Probe readinessProbe() default @Probe();
@@ -274,7 +282,7 @@ public @interface OpenshiftApplication {
 
   /**
    * The sidecars.
-   * 
+   *
    * @return the sidecar containers.
    */
   Container[] sidecars() default {};
@@ -286,7 +294,7 @@ public @interface OpenshiftApplication {
 
   /**
    * Controls whether the generated {@link Service} will be headless.
-   * 
+   *
    * @return true if headless.
    */
   boolean headless() default false;
@@ -294,7 +302,7 @@ public @interface OpenshiftApplication {
   /**
    * Flag to trigger the registration of the deploy hook.
    * It's generally preferable to use `-Ddekorate.deploy=true` instead of hardcoding this here.
-   * 
+   *
    * @return True for automatic registration of the build hook.
    */
   boolean autoDeployEnabled() default false;

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/AddTlsConfigToRouteDecorator.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/AddTlsConfigToRouteDecorator.java
@@ -45,7 +45,7 @@ public class AddTlsConfigToRouteDecorator extends NamedResourceDecorator<RouteSp
       return;
     }
 
-    RouteSpecFluent.TlsNested<?> tlsSpec = spec.editOrNewTls();
+    RouteSpecFluent<?>.TlsNested<?> tlsSpec = spec.editOrNewTls();
     TLSConfig tls = config.getRoute().getTls();
     if (Strings.isNotNullOrEmpty(tls.getCaCertificate())) {
       tlsSpec.withCaCertificate(tls.getCaCertificate());

--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/ApplyDeploymentTriggerDecorator.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/decorator/ApplyDeploymentTriggerDecorator.java
@@ -58,7 +58,7 @@ public class ApplyDeploymentTriggerDecorator extends NamedResourceDecorator<Depl
 
   @Override
   public void andThenVisit(DeploymentConfigSpecFluent<?> deploymentConfigSpec, ObjectMeta resourceMeta) {
-    DeploymentConfigSpecFluent.TriggersNested<?> target;
+    DeploymentConfigSpecFluent<?>.TriggersNested<?> target;
 
     if (deploymentConfigSpec.buildMatchingTrigger(predicate) != null) {
       target = deploymentConfigSpec.editMatchingTrigger(predicate);

--- a/annotations/option-annotations/src/main/java/io/dekorate/option/annotation/JvmOptions.java
+++ b/annotations/option-annotations/src/main/java/io/dekorate/option/annotation/JvmOptions.java
@@ -21,15 +21,21 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.Configuration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
 /**
  * References:
  * - https://www.baeldung.com/jvm-parameters (awesome resource).
  */
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "JvmConfig", relativePath = "../config", autobox = true, mutable = true, superClass = Configuration.class, withStaticBuilderMethod = false, withStaticAdapterMethod = false, adapter = @Adapter(suffix = "Adapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.SOURCE)
@@ -37,56 +43,56 @@ public @interface JvmOptions {
 
   /**
    * Starting heap size in megabytes.
-   * 
+   *
    * @return The starting heap size in megabytes, or 0 if undefined.
    */
   int xms() default 0;
 
   /**
    * Maxium heap size in megabytes.
-   * 
+   *
    * @return The maximum heap size in megabytes, or 0 if undefined.
    */
   int xmx() default 0;
 
   /**
    * Server Flag.
-   * 
+   *
    * @return True if server flag is used.
    */
   boolean server() default false;
 
   /**
    * String deduplication flag.
-   * 
+   *
    * @return True if string deduplication is enabled.
    */
   boolean useStringDeduplication() default false;
 
   /**
    * Prefer IPv4 stack.
-   * 
+   *
    * @return True if preferred.
    */
   boolean preferIPv4Stack() default false;
 
   /**
    * Instructs the JVM to dump heap into physical file in case of OutOfMemoryError
-   * 
+   *
    * @return True, if enabled.
    */
   boolean heapDumpOnOutOfMemoryError() default false;
 
   /**
    * Is a policy that limits the proportion of the VM’s time that is spent in GC before an OutOfMemory error is thrown.
-   * 
+   *
    * @return True if enabled.
    */
   boolean useGCOverheadLimit() default false;
 
   /**
    * Garbage Collector implementation.
-   * 
+   *
    * @return The gc impl or Undefined if none is selected.
    */
   GarbageCollector gc() default GarbageCollector.Undefined;
@@ -94,7 +100,7 @@ public @interface JvmOptions {
   /**
    * The Secure random source to use.
    * This will determine -Djava.security.egd option.
-   * 
+   *
    * @return The source to use. Defaults to undefined.
    */
   SecureRandomSource secureRandom() default SecureRandomSource.Undefined;

--- a/annotations/option-annotations/src/main/java/io/dekorate/option/annotation/VcsOptions.java
+++ b/annotations/option-annotations/src/main/java/io/dekorate/option/annotation/VcsOptions.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2018 The original authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
 **/
 
 package io.dekorate.option.annotation;
@@ -23,11 +23,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.Configuration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "VcsConfig", relativePath = "../config", autobox = true, mutable = true, superClass = Configuration.class, withStaticBuilderMethod = false, withStaticAdapterMethod = false, adapter = @Adapter(suffix = "Adapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.SOURCE)
@@ -35,7 +41,7 @@ public @interface VcsOptions {
 
   /**
    * The remote to use.
-   * 
+   *
    * @return the name of the remote, defaults to 'origin'.
    */
   String remote() default "origin";
@@ -43,7 +49,7 @@ public @interface VcsOptions {
   /**
    * Flag that specifies that https is preferred.
    * When use vcs url that use 'git+ssh' will be converted to https.
-   * 
+   *
    * @return true, if https is prefered.
    */
   boolean httpsPreferred() default false;

--- a/annotations/option-annotations/src/main/java/io/dekorate/option/configurator/ApplyJvmOptsConfigurator.java
+++ b/annotations/option-annotations/src/main/java/io/dekorate/option/configurator/ApplyJvmOptsConfigurator.java
@@ -79,7 +79,7 @@ public class ApplyJvmOptsConfigurator extends Configurator<BaseConfigFluent<?>> 
   }
 
   private void setJavaOptsEnvVar(String envVar, BaseConfigFluent<?> kubernetesConfig, JvmConfig jvmConfig) {
-    Optional<String> existing = Arrays.stream(kubernetesConfig.getEnvVars())
+    Optional<String> existing = Arrays.stream(kubernetesConfig.buildEnvVars())
         .filter(e -> e.getName().equals(envVar))
         .map(Env::getValue)
         .findFirst();

--- a/annotations/prometheus-annotations/src/main/java/io/dekorate/prometheus/annotation/EnableServiceMonitor.java
+++ b/annotations/prometheus-annotations/src/main/java/io/dekorate/prometheus/annotation/EnableServiceMonitor.java
@@ -21,11 +21,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.Configuration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "ServiceMonitorConfig", autobox = true, mutable = true, superClass = Configuration.class, relativePath = "../config", withStaticAdapterMethod = false, adapter = @Adapter(name = "ServiceMonitorConfigAdapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)

--- a/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/annotation/S2iBuild.java
+++ b/annotations/s2i-annotations/src/main/java/io/dekorate/s2i/annotation/S2iBuild.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2018 The original authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
 **/
 
 package io.dekorate.s2i.annotation;
@@ -24,14 +24,19 @@ import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.annotation.Env;
 import io.dekorate.kubernetes.config.ImageConfiguration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "S2iBuildConfig", autobox = true, mutable = true, superClass = ImageConfiguration.class, relativePath = "../config", withStaticBuilderMethod = true, withStaticAdapterMethod = false, adapter = @Adapter(name = "S2iBuildConfigAdapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
-
 @Retention(RetentionPolicy.RUNTIME)
 public @interface S2iBuild {
 
@@ -39,28 +44,28 @@ public @interface S2iBuild {
 
   /**
    * The registry that holds the image.
-   * 
+   *
    * @return The registry or empty string if no registry has been specified.
    */
   String registry() default "";
 
   /**
    * The group of the application. This value will be use as image user.
-   * 
+   *
    * @return The specified group name.
    */
   String group() default "";
 
   /**
    * The name of the application. This value will be used as name.
-   * 
+   *
    * @return The specified application name.
    */
   String name() default "";
 
   /**
    * The version of the application. This value be used as image tag.
-   * 
+   *
    * @return The version.
    */
   String version() default "";
@@ -68,42 +73,42 @@ public @interface S2iBuild {
   /**
    * The name of the image to be generated.
    * This property overrides group, name and version.
-   * 
+   *
    * @return the image name.
    */
   String image() default "";
 
   /**
    * The relative path of the Dockerfile, from the module root.
-   * 
+   *
    * @return The relative path.
    */
   String dockerFile() default "Dockerfile";
 
   /**
    * The S2i builder image to use.
-   * 
+   *
    * @return The builder image.
    */
   String builderImage() default "fabric8/s2i-java:2.3";
 
   /**
    * Environment variables to use for the s2i build.
-   * 
+   *
    * @return The environment variables.
    */
   Env[] buildEnvVars() default {};
 
   /**
    * Flag to automatically push the image, to the specified registry.
-   * 
+   *
    * @return True if hook is to be registered, false otherwise.
    */
   boolean autoPushEnabled() default false;
 
   /**
    * Flag to automatically register a build hook after compilation.
-   * 
+   *
    * @return True if hook is to be registered, false otherwise.
    */
   boolean autoBuildEnabled() default false;
@@ -111,7 +116,7 @@ public @interface S2iBuild {
   /**
    * Flag to trigger the registration of the deploy hook. It's generally
    * preferable to use `-Ddekorate.deploy=true` instead of hardcoding this here.
-   * 
+   *
    * @return True for automatic registration of the build hook.
    */
   boolean autoDeployEnabled() default false;

--- a/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/annotation/Application.java
+++ b/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/annotation/Application.java
@@ -22,10 +22,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.Configuration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "ApplicationConfig", autobox = true, mutable = true, superClass = Configuration.class, relativePath = "../config", withStaticAdapterMethod = false)
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.SOURCE)

--- a/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/annotation/BindingPath.java
+++ b/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/annotation/BindingPath.java
@@ -6,10 +6,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.Configuration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "BindingPathConfig", autobox = true, mutable = true, superClass = Configuration.class, relativePath = "../config", withStaticAdapterMethod = false)
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.SOURCE)

--- a/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/annotation/Service.java
+++ b/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/annotation/Service.java
@@ -22,10 +22,16 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.Configuration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "ServiceConfig", autobox = true, mutable = true, superClass = Configuration.class, relativePath = "../config", withStaticAdapterMethod = false)
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.SOURCE)

--- a/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/annotation/ServiceBinding.java
+++ b/annotations/servicebinding-annotations/src/main/java/io/dekorate/servicebinding/annotation/ServiceBinding.java
@@ -23,10 +23,16 @@ import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.annotation.Env;
 import io.dekorate.kubernetes.config.ApplicationConfiguration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "ServiceBindingConfig", autobox = true, mutable = true, superClass = ApplicationConfiguration.class, relativePath = "../config", withStaticAdapterMethod = false)
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.SOURCE)

--- a/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/annotation/TektonApplication.java
+++ b/annotations/tekton-annotations/src/main/java/io/dekorate/tekton/annotation/TektonApplication.java
@@ -24,11 +24,17 @@ import io.dekorate.kubernetes.annotation.Annotation;
 import io.dekorate.kubernetes.annotation.Label;
 import io.dekorate.kubernetes.annotation.PersistentVolumeClaim;
 import io.dekorate.kubernetes.config.ApplicationConfiguration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "TektonConfig", autobox = true, mutable = true, superClass = ApplicationConfiguration.class, relativePath = "../config", withStaticAdapterMethod = false, adapter = @Adapter(relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
@@ -40,7 +46,7 @@ public @interface TektonApplication {
    * The name of the collection of componnet this component belongs to.
    * This value will be use as:
    * - labeling resources
-   * 
+   *
    * @return The specified group name.
    */
   String partOf() default "";
@@ -57,7 +63,7 @@ public @interface TektonApplication {
    * Else if the system property app.name is present it will be used.
    * Else find the project root folder and use its name (root folder detection is done by moving to the parent folder until
    * .git is found).
-   * 
+   *
    * @return The specified application name.
    */
   String name() default "";
@@ -67,35 +73,35 @@ public @interface TektonApplication {
    * This value be used for things like:
    * - The docker image tag.
    * If no value specified it will attempt to determine the name using the following rules:
-   * 
+   *
    * @return The version.
    */
   String version() default "";
 
   /**
    * Custom labels to add to all resources.
-   * 
+   *
    * @return The labels.
    */
   Label[] labels() default {};
 
   /**
    * Custom annotations to add to all resources.
-   * 
+   *
    * @return The annotations.
    */
   Annotation[] annotations() default {};
 
   /*
    * The name of an external git pipeline resource.
-   * 
+   *
    * @return The name of the resource, or empty if none is specified.
    */
   String externalGitPipelineResource() default "";
 
   /*
    * The name of the source workspace.
-   * 
+   *
    * @return the name, or 'source' if no name specified.
    */
   String sourceWorkspace() default "source";
@@ -103,14 +109,14 @@ public @interface TektonApplication {
   /*
    * The persistent volume claim configuration for the source workspace.
    * The option only makes sense when the PVC is going to be generated (no external pvc specified).
-   * 
+   *
    * @return The PVC configuration.
    */
   PersistentVolumeClaim sourceWorkspaceClaim() default @PersistentVolumeClaim();
 
   /**
    * The name of workspace to use as a maven artifact repository.
-   * 
+   *
    * @return the workspace name.
    */
   String m2Workspace() default "m2";
@@ -118,77 +124,77 @@ public @interface TektonApplication {
   /*
    * The persistent volume claim configuration for the artifact repository.
    * The option only makes sense when the PVC is going to be generated (no external pvc specified).
-   * 
+   *
    * @return The PVC configuration.
    */
   PersistentVolumeClaim m2WorkspaceClaim() default @PersistentVolumeClaim();
 
   /**
    * The builder image to use.
-   * 
+   *
    * @return The builder image, or empty if the image should be inferred.
    */
   String projectBuilderImage() default "";
 
   /*
    * The builder command to use.
-   * 
+   *
    * @return The builder command or empty if the command is to be inferred
    */
   String projectBuilderCommand() default "";
 
   /*
    * The builder command arguments to use.
-   * 
+   *
    * @return The builder command arguments or empty if the command is to be inferred
    */
   String[] projectBuilderArguments() default {};
 
   /**
    * The image builder strategy to use.
-   * 
+   *
    * @return the strategy.
    */
   TektonImageBuildStrategy imageBuildStrategy() default TektonImageBuildStrategy.kaniko;
 
   /**
    * The container image builder image to use.
-   * 
+   *
    * @return The container image builder image, or empty if the image should be inferred.
    */
   String imageBuildImage() default "";
 
   /*
    * The container image builder command to use.
-   * 
+   *
    * @return The container image builder command or empty if the command is to be inferred
    */
   String imageBuildCommand() default "";
 
   /*
    * The container image builder command arguments to use.
-   * 
+   *
    * @return The container image builder command arguments or empty if the command is to be inferred
    */
   String[] imageBuildArguments() default {};
 
   /**
    * The container image push image to use.
-   * 
+   *
    * @return The container image push image, or empty if the image should be inferred.
    */
   String imagePushImage() default "";
 
   /*
    * The container image push command to use.
-   * 
+   *
    * @return The container image push command or empty if the command is to be inferred
    */
   String imagePushCommand() default "";
 
   /*
    * The container image push command arguments to use.
-   * 
+   *
    * @return The container image push command arguments or empty if the command is to be inferred
    */
   String[] imagePushArguments() default {};
@@ -202,7 +208,7 @@ public @interface TektonApplication {
 
   /**
    * The relative path to the Dockerfile.
-   * 
+   *
    * @return the path to the Dockerfile.
    */
   String dockerfile() default "Dockerfile";
@@ -210,7 +216,7 @@ public @interface TektonApplication {
   /**
    * The docker image to be used for the deployment task.
    * Such image needs to have kubectl available.
-   * 
+   *
    * @return The image, if specified or fallback to the default otherwise.
    */
   String deployerImage() default DEFAULT_DEPLOYER_IMAGE;
@@ -219,7 +225,7 @@ public @interface TektonApplication {
    * The service account to use for the image pushing tasks.
    * An existing or a generated service account can be used.
    * If no existing service account is provided one will be generated based on the context.
-   * 
+   *
    * @return An existing service account, or empty if we just need to generate one.
    */
   String imagePushServiceAccount() default "";
@@ -228,35 +234,35 @@ public @interface TektonApplication {
    * The secret to use when generating an image push service account.
    * When no existing service account is provided, one will be generated.
    * The generated service account may or may not use an existing secret.
-   * 
+   *
    * @return The existing secret, or empty string if the secret needs to be generated.
    */
   String imagePushSecret() default "";
 
   /*
    * Wether to upload the local `.docker/config.json` to automatically create the secret.
-   * 
+   *
    * @return
    */
   boolean useLocalDockerConfigJson() default false;
 
   /*
    * The username to use for generating image builder secrets.
-   * 
+   *
    * @return The username.
    */
   String registry() default "docker.io";
 
   /*
    * The username to use for generating image builder secrets.
-   * 
+   *
    * @return The username.
    */
   String registryUsername() default "";
 
   /*
    * The password to use for generating image builder secrets.
-   * 
+   *
    * @return The password.
    */
   String registryPassword() default "";

--- a/core/src/main/java/io/dekorate/ResourceRegistry.java
+++ b/core/src/main/java/io/dekorate/ResourceRegistry.java
@@ -48,7 +48,7 @@ public class ResourceRegistry {
 
   /**
    * Get all registered groups.
-   * 
+   *
    * @return The groups map.
    */
   public Map<String, KubernetesListBuilder> groups() {
@@ -57,7 +57,7 @@ public class ResourceRegistry {
 
   /**
    * Get the global builder
-   * 
+   *
    * @return The groups map.
    */
   public KubernetesListBuilder common() {
@@ -66,7 +66,7 @@ public class ResourceRegistry {
 
   /**
    * Add a {@link Decorator}.
-   * 
+   *
    * @param decorator The decorator.
    */
   public void decorate(Decorator decorator) {
@@ -75,7 +75,7 @@ public class ResourceRegistry {
 
   /**
    * Add a {@link Decorator} to the specified resource group.
-   * 
+   *
    * @param group The group.
    * @param decorator The decorator.
    */
@@ -88,7 +88,7 @@ public class ResourceRegistry {
 
   /**
    * Add a resource to all groups.
-   * 
+   *
    * @param metadata
    */
   public void add(HasMetadata metadata) {
@@ -97,7 +97,7 @@ public class ResourceRegistry {
 
   /**
    * Add a resource to the specified group.
-   * 
+   *
    * @param group The group.
    * @param metadata The resource.
    */
@@ -115,7 +115,7 @@ public class ResourceRegistry {
    * Add a {@link Decorator} to the specified custom group.
    * Custom groups hold custom resources and are not mixed and matched with Kubernetes/Openshift resources.
    * To add a custom decorator, you need to explicitly specify it using this method.
-   * 
+   *
    * @param group The group.
    * @param decorator The decorator.
    */
@@ -130,7 +130,7 @@ public class ResourceRegistry {
    * Add a resource to the specified custom group.
    * Custom groups hold custom resources and are not mixed and matched with Kubernetes/Openshift resources.
    * To add a custom resource, you need to explicitly specify it using this method.
-   * 
+   *
    * @param group The group.
    * @param metadata The resource.
    */
@@ -145,18 +145,18 @@ public class ResourceRegistry {
 
   /**
    * Generate all resources.
-   * 
+   *
    * @return A map of {@link KubernetesList} by group name.
    */
   protected Map<String, KubernetesList> generate() {
-    if (!this.common.getItems().isEmpty()) {
+    if (!this.common.buildItems().isEmpty()) {
       if (this.groups.isEmpty()) {
         KubernetesListBuilder builder = new KubernetesListBuilder();
-        builder.addToItems(common.buildItems().toArray(new HasMetadata[common.getItems().size()]));
+        builder.addToItems(common.buildItems().toArray(new HasMetadata[common.buildItems().size()]));
         this.groups.put(DEFAULT_GROUP, builder);
       } else {
         this.groups.forEach((group, builder) -> builder
-            .addToItems(common.buildItems().toArray(new HasMetadata[common.getItems().size()])));
+            .addToItems(common.buildItems().toArray(new HasMetadata[common.buildItems().size()])));
       }
     }
 

--- a/core/src/main/java/io/dekorate/kubernetes/annotation/Base.java
+++ b/core/src/main/java/io/dekorate/kubernetes/annotation/Base.java
@@ -22,7 +22,10 @@ import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.ApplicationConfiguration;
 import io.dekorate.kubernetes.config.DeploymentStrategy;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
 /**
@@ -31,7 +34,10 @@ import io.sundr.builder.annotations.Pojo;
  * {@link io.dekorate.kubernetes.config.KubernetesConfig} class that is used as
  * a base for the rest of the config classes.
  */
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "BaseConfig", relativePath = "../config", autobox = true, mutable = true, superClass = ApplicationConfiguration.class, withStaticBuilderMethod = true, withStaticAdapterMethod = false)
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.SOURCE)
@@ -42,7 +48,7 @@ import io.sundr.builder.annotations.Pojo;
    * This value will be use as:
    * - docker image repo
    * - labeling resources
-   * 
+   *
    * @return The specified group name.
    */
   String partOf() default "";
@@ -55,7 +61,7 @@ import io.sundr.builder.annotations.Pojo;
    * name. Else if the system property app.name is present it will be used. Else
    * find the project root folder and use its name (root folder detection is done
    * by moving to the parent folder until .git is found).
-   * 
+   *
    * @return The specified application name.
    */
   String name() default "";
@@ -64,63 +70,63 @@ import io.sundr.builder.annotations.Pojo;
    * The version of the application. This value be used for things like: - The
    * docker image tag. If no value specified it will attempt to determine the name
    * using the following rules:
-   * 
+   *
    * @return The version.
    */
   String version() default "";
 
   /**
    * The kind of the deployment resource to use.
-   * 
+   *
    * @return The deployment kind resource.
    */
   String deploymentKind() default "Deployment";
 
   /**
    * Custom labels to add to all resources.
-   * 
+   *
    * @return The labels.
    */
   Label[] labels() default {};
 
   /**
    * Custom annotations to add to all resources.
-   * 
+   *
    * @return The annotations.
    */
   Annotation[] annotations() default {};
 
   /**
    * Environment variables to add to all containers.
-   * 
+   *
    * @return The environment variables.
    */
   Env[] envVars() default {};
 
   /**
    * Working directory.
-   * 
+   *
    * @return The working directory if specified, else empty string.
    */
   String workingDir() default "";
 
   /**
    * The commands
-   * 
+   *
    * @return The commands.
    */
   String[] command() default {};
 
   /**
    * The arguments
-   * 
+   *
    * @return The arguments.
    */
   String[] arguments() default {};
 
   /**
    * The service account.
-   * 
+   *
    * @return The service account or empty string if not specified.
    */
   String serviceAccount() default "";
@@ -153,14 +159,14 @@ import io.sundr.builder.annotations.Pojo;
 
   /**
    * Mounts to add to all containers.
-   * 
+   *
    * @return The mounts.
    */
   Mount[] mounts() default {};
 
   /**
    * Image pull policy.
-   * 
+   *
    * @return The image pull policy.
    */
   ImagePullPolicy imagePullPolicy() default ImagePullPolicy.IfNotPresent;
@@ -191,14 +197,14 @@ import io.sundr.builder.annotations.Pojo;
 
   /**
    * The liveness probe.
-   * 
+   *
    * @return The probe.
    */
   Probe livenessProbe() default @Probe();
 
   /**
    * The readiness probe.
-   * 
+   *
    * @return The probe.
    */
   Probe readinessProbe() default @Probe();
@@ -222,7 +228,7 @@ import io.sundr.builder.annotations.Pojo;
 
   /**
    * The sidecars.
-   * 
+   *
    * @return the sidecar containers.
    */
   Container[] sidecars() default {};
@@ -230,7 +236,7 @@ import io.sundr.builder.annotations.Pojo;
   /**
    * Flag to trigger the registration of the deploy hook. It's generally
    * preferable to use `-Ddekorate.deploy=true` instead of hardcoding this here.
-   * 
+   *
    * @return True for automatic registration of the build hook.
    */
   boolean autoDeployEnabled() default false;

--- a/core/src/main/java/io/dekorate/kubernetes/config/ApplicationConfiguration.java
+++ b/core/src/main/java/io/dekorate/kubernetes/config/ApplicationConfiguration.java
@@ -18,10 +18,15 @@ package io.dekorate.kubernetes.config;
 import java.util.Map;
 
 import io.dekorate.Coordinates;
+import io.dekorate.project.BuildInfo;
 import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 public class ApplicationConfiguration extends Configuration implements Coordinates {
 
   private String partOf;

--- a/core/src/main/java/io/dekorate/kubernetes/config/Configuration.java
+++ b/core/src/main/java/io/dekorate/kubernetes/config/Configuration.java
@@ -22,10 +22,15 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import io.dekorate.project.BuildInfo;
 import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 public class Configuration {
 
   private Project project;

--- a/core/src/main/java/io/dekorate/kubernetes/config/ImageConfiguration.java
+++ b/core/src/main/java/io/dekorate/kubernetes/config/ImageConfiguration.java
@@ -21,11 +21,16 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import io.dekorate.project.BuildInfo;
 import io.dekorate.project.Project;
 import io.dekorate.utils.Strings;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "@class")
 public class ImageConfiguration extends ApplicationConfiguration {
 

--- a/core/src/main/java/io/dekorate/kubernetes/configurator/AddLivenessProbeConfigurator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/configurator/AddLivenessProbeConfigurator.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2018 The original authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
 **/
 
 package io.dekorate.kubernetes.configurator;
@@ -34,7 +34,7 @@ public class AddLivenessProbeConfigurator extends Configurator<BaseConfigFluent>
 
   @Override
   public void visit(BaseConfigFluent config) {
-    Probe existing = config.getLivenessProbe();
+    Probe existing = config.buildLivenessProbe();
     config.withLivenessProbe(overwrite ? Beans.combine(existing, probe) : Beans.combine(probe, existing));
   }
 }

--- a/core/src/main/java/io/dekorate/kubernetes/configurator/AddPort.java
+++ b/core/src/main/java/io/dekorate/kubernetes/configurator/AddPort.java
@@ -40,12 +40,12 @@ public class AddPort extends Configurator<BaseConfigFluent> {
 
   /**
    * Check if the {@link io.dekorate.kubernetes.config.BaseConfig} already has port.
-   * 
+   *
    * @param config The port.
    * @return True if port with same container port exists.
    */
   private boolean hasPort(BaseConfigFluent config) {
-    for (Port p : config.getPorts()) {
+    for (Port p : config.buildPorts()) {
       if (p.getContainerPort() == port.getContainerPort()) {
         return true;
       }

--- a/core/src/main/java/io/dekorate/kubernetes/configurator/AddReadinessProbeConfigurator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/configurator/AddReadinessProbeConfigurator.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2018 The original authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
 **/
 
 package io.dekorate.kubernetes.configurator;
@@ -34,7 +34,7 @@ public class AddReadinessProbeConfigurator extends Configurator<BaseConfigFluent
 
   @Override
   public void visit(BaseConfigFluent config) {
-    Probe existing = config.getReadinessProbe();
+    Probe existing = config.buildReadinessProbe();
     config.withReadinessProbe(overwrite ? Beans.combine(existing, probe) : Beans.combine(probe, existing));
   }
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddCronJobDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddCronJobDecorator.java
@@ -63,7 +63,7 @@ public class AddCronJobDecorator extends ResourceProvidingDecorator<KubernetesLi
       return;
     }
 
-    CronJobFluent.SpecNested<CronJobBuilder> cronJobBuilder = new CronJobBuilder()
+    CronJobFluent<CronJobBuilder>.SpecNested<CronJobBuilder> cronJobBuilder = new CronJobBuilder()
         .withApiVersion(API_VERSION)
         .withNewMetadata()
         .withName(name)
@@ -80,7 +80,7 @@ public class AddCronJobDecorator extends ResourceProvidingDecorator<KubernetesLi
       cronJobBuilder = cronJobBuilder.withStartingDeadlineSeconds(job.getStartingDeadlineSeconds());
     }
 
-    JobTemplateSpecFluent.SpecNested<CronJobSpecFluent.JobTemplateNested<CronJobFluent.SpecNested<CronJobBuilder>>> jobBuilder = cronJobBuilder
+    JobTemplateSpecFluent<CronJobSpecFluent<CronJobFluent<CronJobBuilder>.SpecNested<CronJobBuilder>>.JobTemplateNested<CronJobFluent<CronJobBuilder>.SpecNested<CronJobBuilder>>>.SpecNested<CronJobSpecFluent<CronJobFluent<CronJobBuilder>.SpecNested<CronJobBuilder>>.JobTemplateNested<CronJobFluent<CronJobBuilder>.SpecNested<CronJobBuilder>>> jobBuilder = cronJobBuilder
         .withNewJobTemplate()
         .withNewSpec()
         .withCompletionMode(job.getCompletionMode().name());

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddDockerConfigJsonSecretDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddDockerConfigJsonSecretDecorator.java
@@ -77,7 +77,7 @@ public class AddDockerConfigJsonSecretDecorator extends ResourceProvidingDecorat
         .addToData(DOT_DOCKER_CONFIG_JSON, this.content)
         .build();
 
-    list.addToSecretItems(secret);
+    list.addToItems(secret);
   }
 
 }

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddEnvVarDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddEnvVarDecorator.java
@@ -62,9 +62,9 @@ public class AddEnvVarDecorator extends ApplicationContainerDecorator<ContainerB
 
     Predicate<EnvFromSourceBuilder> matchingEnvFrom = new Predicate<EnvFromSourceBuilder>() {
       public boolean test(EnvFromSourceBuilder e) {
-        if (e.getSecretRef() != null && e.getSecretRef().getName() != null) {
-          return e.getSecretRef().getName().equals(env.getSecret());
-        } else if (e.getConfigMapRef() != null && e.editConfigMapRef().getName() != null) {
+        if (e.buildSecretRef() != null && e.buildSecretRef().getName() != null) {
+          return e.buildSecretRef().getName().equals(env.getSecret());
+        } else if (e.buildConfigMapRef() != null && e.editConfigMapRef().getName() != null) {
           return e.editConfigMapRef().getName().equals(env.getConfigmap());
         }
         return false;

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddInitContainerDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddInitContainerDecorator.java
@@ -51,7 +51,7 @@ public class AddInitContainerDecorator extends NamedResourceDecorator<PodSpecBui
   }
 
   private void update(PodSpecBuilder podSpec, io.fabric8.kubernetes.api.model.Container resource) {
-    PodSpecFluent.InitContainersNested<PodSpecBuilder> matching = podSpec
+    PodSpecFluent<PodSpecBuilder>.InitContainersNested<PodSpecBuilder> matching = podSpec
         .editMatchingInitContainer(this::existsContainerByName);
 
     if (resource.getImage() != null) {

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddJobDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddJobDecorator.java
@@ -57,7 +57,7 @@ public class AddJobDecorator extends ResourceProvidingDecorator<KubernetesListBu
       return;
     }
 
-    JobFluent.SpecNested<JobBuilder> jobBuilder = new JobBuilder()
+    JobFluent<JobBuilder>.SpecNested<JobBuilder> jobBuilder = new JobBuilder()
         .withApiVersion(API_VERSION)
         .withNewMetadata()
         .withName(name)

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/AddSidecarDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/AddSidecarDecorator.java
@@ -55,7 +55,8 @@ public class AddSidecarDecorator extends NamedResourceDecorator<PodSpecBuilder> 
   }
 
   private void update(PodSpecBuilder podSpec, io.fabric8.kubernetes.api.model.Container resource) {
-    PodSpecFluent.ContainersNested<PodSpecBuilder> matching = podSpec.editMatchingContainer(this::existsContainerByName);
+    PodSpecFluent<PodSpecBuilder>.ContainersNested<PodSpecBuilder> matching = podSpec
+        .editMatchingContainer(this::existsContainerByName);
 
     if (resource.getImage() != null) {
       matching.withImage(resource.getImage());

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/RemoveProbesFromInitContainerDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/RemoveProbesFromInitContainerDecorator.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2018 The original authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
 **/
 
 package io.dekorate.kubernetes.decorator;
@@ -25,7 +25,7 @@ public class RemoveProbesFromInitContainerDecorator extends NamedResourceDecorat
 
   @Override
   public void andThenVisit(PodSpecFluent<?> podSpec, ObjectMeta resourceMeta) {
-    podSpec.getContainers().forEach(container -> {
+    podSpec.buildContainers().forEach(container -> {
       podSpec.editMatchingContainer(Predicates.builderMatches(container))
           .withLivenessProbe(null)
           .withReadinessProbe(null)

--- a/core/src/main/java/io/dekorate/kubernetes/decorator/ResourceProvidingDecorator.java
+++ b/core/src/main/java/io/dekorate/kubernetes/decorator/ResourceProvidingDecorator.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2018 The original authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  **/
 
 package io.dekorate.kubernetes.decorator;
@@ -82,7 +82,7 @@ public abstract class ResourceProvidingDecorator<T> extends Decorator<T> {
   }
 
   public Optional<HasMetadata> getDeploymentHasMetadata(KubernetesListBuilder list, String name) {
-    return list.getItems().stream().filter(h -> DEPLOYMENT_KINDS.contains(h.getKind())).findFirst();
+    return list.buildItems().stream().filter(h -> DEPLOYMENT_KINDS.contains(h.getKind())).findFirst();
   }
 
   public ObjectMeta getMandatoryDeploymentMetadata(KubernetesListBuilder list) {

--- a/core/src/main/java/io/dekorate/option/annotation/GeneratorOptions.java
+++ b/core/src/main/java/io/dekorate/option/annotation/GeneratorOptions.java
@@ -21,11 +21,17 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.dekorate.kubernetes.config.Configuration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Adapter;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 import io.sundr.builder.annotations.Pojo;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 @Pojo(name = "GeneratorConfig", relativePath = "../config", autobox = true, mutable = true, superClass = Configuration.class, withStaticBuilderMethod = false, withStaticAdapterMethod = false, adapter = @Adapter(suffix = "Adapter", relativePath = "../adapter", withMapAdapterMethod = true))
 @Target({ ElementType.CONSTRUCTOR, ElementType.TYPE })
 @Retention(RetentionPolicy.SOURCE)
@@ -36,14 +42,14 @@ public @interface GeneratorOptions {
    * If the path is specified and the manifests are found, they will be used as input to the generator process.
    * In this case, the instead of generating resources from scratch, the existing will be used and will be decarated
    * according to the annotation configuration.
-   * 
+   *
    * @return The path, or empty string.
    */
   String inputPath() default "";
 
   /**
    * The output path where the generated/decorated manifests will be stored.
-   * 
+   *
    * @return The path, or empty string.
    */
   String outputPath() default "";
@@ -57,28 +63,28 @@ public @interface GeneratorOptions {
 
   /**
    * The properties profile to use.
-   * 
+   *
    * @reutrn the profile or empty string.
    */
   String propertiesProfile() default "";
 
   /**
    * Flag to enable build.
-   * 
+   *
    * @return true if build is enabled.
    */
   boolean build() default false;
 
   /**
    * Flag to enable push.
-   * 
+   *
    * @return true if push is enabled.
    */
   boolean push() default false;
 
   /**
    * Flag to enable deply.
-   * 
+   *
    * @return true if deply is enabled.
    */
   boolean deploy() default false;

--- a/core/src/main/java/io/dekorate/utils/Ports.java
+++ b/core/src/main/java/io/dekorate/utils/Ports.java
@@ -130,12 +130,12 @@ public class Ports {
 
   public static Optional<ContainerPort> getHttpPort(ContainerFluent<?> container) {
     //If we have a single port, return that no matter what.
-    if (container.getPorts().size() == 1) {
-      return Optional.of(container.getPorts().get(0));
+    if (container.buildPorts().size() == 1) {
+      return Optional.of(container.buildPorts().get(0));
     }
 
     for (String portName : HTTP_PORT_NAMES.keySet()) {
-      Optional<ContainerPort> port = container.getPorts().stream().filter(p -> portName.equals(p.getName()))
+      Optional<ContainerPort> port = container.buildPorts().stream().filter(p -> portName.equals(p.getName()))
           .findFirst();
       if (port.isPresent()) {
         return port;
@@ -143,7 +143,7 @@ public class Ports {
     }
 
     for (Integer portNumber : HTTP_PORT_NUMBERS.keySet()) {
-      Optional<ContainerPort> port = container.getPorts().stream().filter(p -> portNumber.equals(p.getHostPort()))
+      Optional<ContainerPort> port = container.buildPorts().stream().filter(p -> portNumber.equals(p.getHostPort()))
           .findFirst();
       if (port.isPresent()) {
         return port;

--- a/frameworks/jaxrs/src/main/java/io/dekorate/jaxrs/config/JaxrsConfig.java
+++ b/frameworks/jaxrs/src/main/java/io/dekorate/jaxrs/config/JaxrsConfig.java
@@ -16,9 +16,15 @@
 package io.dekorate.jaxrs.config;
 
 import io.dekorate.kubernetes.config.Configuration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder")
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 public class JaxrsConfig extends Configuration {
 
   private final String path;

--- a/frameworks/spring-boot/src/main/java/io/dekorate/spring/config/SpringApplicationConfig.java
+++ b/frameworks/spring-boot/src/main/java/io/dekorate/spring/config/SpringApplicationConfig.java
@@ -16,9 +16,14 @@
 package io.dekorate.spring.config;
 
 import io.dekorate.kubernetes.config.Configuration;
+import io.dekorate.project.BuildInfo;
+import io.dekorate.project.Project;
 import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 
-@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = @BuildableReference(Configuration.class))
+@Buildable(builderPackage = "io.fabric8.kubernetes.api.builder", refs = {
+    @BuildableReference(Project.class),
+    @BuildableReference(BuildInfo.class)
+})
 public class SpringApplicationConfig extends Configuration {
 }

--- a/frameworks/thorntail/src/main/java/io/dekorate/thorntail/configurator/ThorntailPrometheusAgentConfigurator.java
+++ b/frameworks/thorntail/src/main/java/io/dekorate/thorntail/configurator/ThorntailPrometheusAgentConfigurator.java
@@ -30,7 +30,7 @@ public class ThorntailPrometheusAgentConfigurator extends Configurator<BaseConfi
 
   @Override
   public void visit(BaseConfigFluent<?> openshiftConfig) {
-    boolean alreadyExists = Arrays.stream(openshiftConfig.getEnvVars())
+    boolean alreadyExists = Arrays.stream(openshiftConfig.buildEnvVars())
         .anyMatch(e -> AB_PROMETHEUS_OFF.equals(e.getName()));
 
     if (alreadyExists) {

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
     <version.commons-compress>1.21</version.commons-compress>
     <version.jansi>1.18</version.jansi>
     <version.jackson>2.14.1</version.jackson>
-    <version.kubernetes-client>6.7.2</version.kubernetes-client>
-    <version.sundrio>0.92.1</version.sundrio>
+    <version.kubernetes-client>6.8.0</version.kubernetes-client>
+    <version.sundrio>0.100.3</version.sundrio>
     <version.jayway.jsonpath>2.6.0</version.jayway.jsonpath>
 
     <!-- Testing Dependencies -->
@@ -342,7 +342,7 @@
       <url>https://repo.gradle.org/gradle/libs-releases-local/</url>
     </repository>
   </repositories>
-  
+
   <pluginRepositories>
     <pluginRepository>
       <id>gradle</id>

--- a/tests/issue-442-build-config-name/pom.xml
+++ b/tests/issue-442-build-config-name/pom.xml
@@ -103,6 +103,25 @@ limitations under the License.
           <target>${java.target}</target>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>${version.maven-shade-plugin}</version>
+        <executions>
+          <execution>
+            <goals><goal>shade</goal></goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Main-Class>io.dekorate.example.Main</Main-Class>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/tests/issue-442-build-config-name/src/main/java/io/dekorate/example/Main.java
+++ b/tests/issue-442-build-config-name/src/main/java/io/dekorate/example/Main.java
@@ -21,7 +21,8 @@ import io.dekorate.annotation.Dekorate;
 @Dekorate
 public class Main {
 
-  public static void main(String[] args) {
+  public static void main(String[] args) throws Exception {
+    Thread.sleep(3_600_000);
   }
 
 }


### PR DESCRIPTION
- deps: Bump Kubernetes Client to 6.8.0
- deps: Bump sundrio to 0.100.1

Prior to bumping the Kubernetes Client version in Quarkus, we need to align the Fabric8 Kubernetes Client in Dekorate.

I'm trying to update. However, I'm reaching two problems (for now):
- If keeping the Sundrio version intact, the prometheus-annotations module (and probably others) won't work/compile since its buildables rely on other Kubernetes Client buildables (such as ObjectMeta) that are not compatible accross sundrio versions.
- If updating the Sundrio version too, then there seeems to be a problem with the option-annotations which makes use of the `@Pojo` generator. I think that since it has a Buildable superClass (in this case Configuration) the template uses a `getXxx` method which is not OK. My impression is that the problem is in Sundrio and that this wasn't considered when removing the Fluent interfaces (the Pojo tests don't include this scenario)

I'm kind of blocked at the moment.

/cc @iocanel