### PR TITLE
Release 4.0.0 ?

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Dekorate
 release:
-  current-version: 3.7.1
-  next-version: 3.7-SNAPSHOT
+  current-version: 4.0.0
+  next-version: 999-SNAPSHOT


### PR DESCRIPTION
While I am on PTO I am creating this pull request mostly to lay out my thoughts on how we should proceed regarding the next release....

Since we upgraded main to the kubernetes-client model to 6.8.0 that brings massive changes to the API, the next release from main *needs* to bump the major version to 4. 

Fixes for 3.x version should happen from 3.x branch.

We may hold this around for a while if we are planning for other breaking changes that should be included in 4.0.0.
