### PR TITLE
Fix openshift annotation for link to version control source

### DIFF
--- a/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/OpenshiftAnnotations.java
+++ b/annotations/openshift-annotations/src/main/java/io/dekorate/openshift/OpenshiftAnnotations.java
@@ -17,5 +17,5 @@
 package io.dekorate.openshift;
 
 public class OpenshiftAnnotations {
-  public static final String VCS_URL = "app.openshift.io/vcs-url";
+  public static final String VCS_URL = "app.openshift.io/vcs-uri";
 }


### PR DESCRIPTION
Fix openshift annotation for link to version control source

As per https://docs.openshift.com/container-platform/4.13/applications/odc-viewing-application-composition-using-topology-view.html#odc-labels-and-annotations-used-for-topology-view_viewing-application-composition-using-topology-view should be vcs-uri not vcs-url