### PR TITLE
Remove the deprecated library of fusesource jansi jline

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,9 +66,16 @@ limitations under the License.
     </dependency>
 
     <!-- Misc -->
+    <!-- This project is deprecated : https://github.com/fusesource/jansi
+     <dependency>
+       <groupId>org.fusesource.jansi</groupId>
+       <artifactId>jansi</artifactId>
+       <version>${version.jansi}</version>
+     </dependency>
+     -->
     <dependency>
-      <groupId>org.fusesource.jansi</groupId>
-      <artifactId>jansi</artifactId>
+      <groupId>org.jline</groupId>
+      <artifactId>jline</artifactId>
     </dependency>
 
     <dependency>

--- a/core/src/main/java/io/dekorate/logger/AnsiLogger.java
+++ b/core/src/main/java/io/dekorate/logger/AnsiLogger.java
@@ -17,14 +17,14 @@
 
 package io.dekorate.logger;
 
-import static org.fusesource.jansi.Ansi.*;
-import static org.fusesource.jansi.Ansi.Color.*;
+import static org.jline.jansi.Ansi.*;
+import static org.jline.jansi.Ansi.Color.*;
 
 import java.io.FileDescriptor;
 import java.io.FileOutputStream;
 import java.io.PrintStream;
 
-import org.fusesource.jansi.*;
+import org.jline.jansi.*;
 
 import io.dekorate.Logger;
 import io.dekorate.LoggerFactory;
@@ -39,12 +39,12 @@ public class AnsiLogger extends LoggerFactory<PrintStream> implements Logger {
 
   //Should not be used by user code. Only needed for Java SPI.
   public AnsiLogger() {
-    this.stream = AnsiConsole.out;
+    this.stream = AnsiConsole.out();
   }
 
   public AnsiLogger(PrintStream stream) {
     check();
-    this.stream = stream != null ? AnsiConsole.wrapPrintStream(stream, 0) : AnsiConsole.out;
+    this.stream = stream != null ? stream : AnsiConsole.out();
   }
 
   @Override

--- a/examples/frameworkless-on-kubernetes-example/Dockerfile
+++ b/examples/frameworkless-on-kubernetes-example/Dockerfile
@@ -1,5 +1,12 @@
 FROM adoptopenjdk/openjdk8
+
 ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} frameworkless-on-kubernetes-example.jar
+RUN groupadd -r appgroup && useradd -r -g appgroup -s /sbin/nologin appuser
+WORKDIR /app
+COPY ${JAR_FILE} /app/frameworkless-on-kubernetes-example.jar
+
+RUN chown -R appuser:appgroup /app
+USER appuser
+
 EXPOSE 8080
-ENTRYPOINT ["java","-jar","/frameworkless-on-kubernetes-example.jar"]
+ENTRYPOINT ["java","-jar","frameworkless-on-kubernetes-example.jar"]

--- a/examples/frameworkless-on-kubernetes-example/Dockerfile
+++ b/examples/frameworkless-on-kubernetes-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM adoptopenjdk/openjdk8
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} frameworkless-on-kubernetes-example.jar
 EXPOSE 8080

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <version.application-crd-client>1.1.1</version.application-crd-client>
     <version.commons-codec>1.10</version.commons-codec>
     <version.commons-compress>1.21</version.commons-compress>
-    <version.jansi>1.18</version.jansi>
+    <version.jline>4.0.0</version.jline>
     <version.jackson>2.14.1</version.jackson>
     <version.kubernetes-client>6.13.0</version.kubernetes-client>
     <version.sundrio>0.101.3</version.sundrio>
@@ -180,10 +180,17 @@
       </dependency>
 
       <!-- Misc -->
+      <!-- This project is deprecated : https://github.com/fusesource/jansi
       <dependency>
         <groupId>org.fusesource.jansi</groupId>
         <artifactId>jansi</artifactId>
         <version>${version.jansi}</version>
+      </dependency>
+      -->
+      <dependency>
+        <groupId>org.jline</groupId>
+        <artifactId>jline</artifactId>
+        <version>${version.jline}</version>
       </dependency>
 
       <!-- Testing -->


### PR DESCRIPTION
- Remove the deprecated library of fusesource jansi jline in favor of org.jline
- Fix CVE issue https://cert.pl/en/posts/2026/06/CVE-2026-8484/ reported: 
See: #1319

@jmartisk @aureamunoz 