### PR TITLE
chore: prepare for release 4.1.11

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: Dekorate
 release:
-  current-version: 4.1.10
+  current-version: 4.1.11
   next-version: 999-SNAPSHOT


### PR DESCRIPTION
## Summary
- Bump release version to 4.1.11 in `.github/project.yml`
- Retriggers the release workflow after 4.1.10 failed due to GPG signing and javadoc plugin issues (now fixed on main)

## Test plan
- [x] Merging this PR triggers the release workflow
- [ ] Verify GPG signing succeeds with the updated plugin versions
- [ ] Verify javadoc generation succeeds with maven-javadoc-plugin 3.11.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)